### PR TITLE
Removes console logs when executing ANTLR

### DIFF
--- a/packages/language-support/src/autocompletion.ts
+++ b/packages/language-support/src/autocompletion.ts
@@ -37,6 +37,7 @@ export function autocomplete(
   const lexer = new CypherLexer(inputStream);
   const tokenStream = new CommonTokenStream(lexer);
   const wholeFileParser = new CypherParser(tokenStream);
+  wholeFileParser.removeErrorListeners();
   const tree = wholeFileParser.statements();
   const tokens = getTokens(tokenStream);
   const lastToken = tokens[tokens.length - 2];

--- a/packages/language-support/src/highlighting/syntaxColouring.ts
+++ b/packages/language-support/src/highlighting/syntaxColouring.ts
@@ -251,6 +251,7 @@ export function applySyntaxColouring(
     colourLexerTokens(tokenStream);
 
   const parser = new CypherParser(tokenStream);
+  parser.removeErrorListeners();
   const treeSyntaxHighlighter = new SyntaxHighlighter(lexerTokens);
 
   /* Get a second pass at the colouring correcting the colours

--- a/packages/language-support/src/highlighting/syntaxValidation.ts
+++ b/packages/language-support/src/highlighting/syntaxValidation.ts
@@ -53,6 +53,7 @@ export function validateSyntax(wholeFileText: string): Diagnostic[] {
   const tokenStream = new CommonTokenStream(lexer);
 
   const parser = new CypherParser(tokenStream);
+  parser.removeErrorListeners();
   const errorListener = new ErrorListener();
   parser.addErrorListener(errorListener);
   parser.statements();

--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -95,6 +95,7 @@ export function signatureHelp(
   const lexer = new CypherLexer(inputStream);
   const tokenStream = new CommonTokenStream(lexer);
   const wholeFileParser = new CypherParser(tokenStream);
+  wholeFileParser.removeErrorListeners();
   const root = wholeFileParser.statements();
 
   const stopNode = findStopNode(root);


### PR DESCRIPTION
## What

Adds a `removeErrorListener` call to all instantiations of the parser

## Why

To avoid logging debugging errors to console like this one:

```
PASS src/tests/highlighting/syntaxColouring/readQuery.test.ts (15.306 s)
language-support:test:   ● Console
language-support:test: 
language-support:test:     console.error
language-support:test:       line 1:32 mismatched input '<EOF>' expecting {'-', ARROW_LINE}
language-support:test: 
language-support:test:       4413 |                     if (re instanceof RecognitionException) {
language-support:test:       4414 |                             localctx.exception = re;
language-support:test:     > 4415 |                             this._errHandler.reportError(this, re);
language-support:test:            |                                              ^
language-support:test:       4416 |                             this._errHandler.recover(this, re);
language-support:test:       4417 |                     } else {
language-support:test:       4418 |                             throw re;
language-support:test: 
language-support:test:       at u.column (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/error/ConsoleErrorListener.js:26:46)
language-support:test:       at msg (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/error/ProxyErrorListener.js:18:90)
language-support:test:           at Array.map (<anonymous>)
language-support:test:       at u.value (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/error/ProxyErrorListener.js:18:29)
language-support:test:       at CypherParser.line (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/Parser.js:318:52)
language-support:test:       at c.notifyErrorListeners (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/error/DefaultErrorStrategy.js:282:20)
language-support:test:       at c.recognizer (../../node_modules/antlr4/dist/webpack:/antlr4/src/antlr4/error/DefaultErrorStrategy.js:113:38)
language-support:test:       at CypherParser.arrowLine (src/generated-parser/CypherParser.ts:4415:22)
language-support:test:       at CypherParser.relationshipPattern (src/generated-parser/CypherParser.ts:4333:9)
language-support:test:       at CypherParser.maybeQuantifiedRelationshipPattern (src/generated-parser/CypherParser.ts:3718:9)
language-support:test:       at CypherParser.everyPathPattern (src/generated-parser/CypherParser.ts:3772:12)
language-support:test:       at CypherParser.anonymousPattern (src/generated-parser/CypherParser.ts:3634:10)
language-support:test:       at CypherParser.pattern (src/generated-parser/CypherParser.ts:3514:10)
language-support:test:       at CypherParser.patternList (src/generated-parser/CypherParser.ts:3458:9)
language-support:test:       at CypherParser.matchClause (src/generated-parser/CypherParser.ts:2435:9)
language-support:test:       at CypherParser.clause (src/generated-parser/CypherParser.ts:1373:10)
language-support:test:       at CypherParser.singleQuery (src/generated-parser/CypherParser.ts:1257:11)
language-support:test:       at CypherParser.singleQueryOrCommand (src/generated-parser/CypherParser.ts:1028:10)
language-support:test:       at CypherParser.statement (src/generated-parser/CypherParser.ts:972:10)
language-support:test:       at CypherParser.statements (src/generated-parser/CypherParser.ts:915:10)
language-support:test:       at applySyntaxColouring (src/highlighting/syntaxColouring.ts:264:62)
language-support:test:       at testSyntaxColouring (src/tests/highlighting/syntaxColouring/helpers.ts:8:44)
language-support:test:       at Object.<anonymous> (src/tests/highlighting/syntaxColouring/readQuery.test.ts:410:24)
language-support:test: 
language-support:test: 
language-support:test: Test Suites: 9 passed, 9 total
language-support:test: Tests:       14 skipped, 66 passed, 80 total
language-support:test: Snapshots:   0 total
language-support:test: Time:        16.105 s
language-support:test: Ran all test suites.
```