### PR TITLE
Uses antlr4 directly in the CI

### DIFF
--- a/.github/actions/setup-antlr4/action.yaml
+++ b/.github/actions/setup-antlr4/action.yaml
@@ -1,0 +1,11 @@
+name: 'Setups antlr4 manually'
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: |
+        curl https://www.antlr.org/download/antlr-4.13.0-complete.jar --output antlr4.jar
+        mkdir -p $HOME/.local/bin
+        echo -e "#bin/bash\njava -jar $PWD/antlr4.jar \$@" > $HOME/.local/bin/antlr4
+        chmod a+x $HOME/.local/bin/antlr4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install antlr4 tool
-        run: pip install antlr4-tools
+      - name: Setup antlr4
+        uses: ./.github/actions/setup-antlr4
 
-      - name: Install dependencies with frozen lock file
+      - name: Install dependencies with frozen lock file and generate parser
         run: npm ci
 
       - name: Build project
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install antlr4 tool
-        run: pip install antlr4-tools
+      - name: Setup antlr4
+        uses: ./.github/actions/setup-antlr4
 
-      - name: Install dependencies and generate parser
+      - name: Install dependencies with frozen lock file and generate parser
         run: npm ci
 
       - name: Build project

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -29,18 +29,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Install antlr4 tool
-        run: pip install antlr4-tools
-      - name: Install dependencies with frozen lock file
+
+      - name: Setup antlr4
+        uses: ./.github/actions/setup-antlr4
+
+      - name: Install dependencies with frozen lock file and generate parser
         run: npm ci
+
       - name: Build project
         run: npm run build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: './packages/codemirror-playground/dist/'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ generated
 .turbo
 build/
 dist/
+*.antlr
+*.jar


### PR DESCRIPTION
## What
Wires antlr4 manually in the CI instead of using the python package that sets it up automatically.

## Why
Because the CI is failing due to https://search.maven.org/solrsearch/select?q=a:antlr4-master+g:org.antlr being not reachable at the moment

<img width="1515"  src="https://github.com/neo4j/cypher-language-support/assets/5649971/9cacc6da-5400-4db4-94c0-172b8cf9da28">
