### PR TITLE
Makes VSCode tests debugging work again with several projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ generated
 .turbo
 build/
 dist/
+*.antlr
+*.jar

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "jest.autoRun": "off",
-  "jest.jestCommandLine": "npm test -- --",
+  "jest.jestCommandLine": "npm test -- -- --passWithNoTests",
   "jest.rootPath": "./"
 }

--- a/packages/antlr4-c3/package.json
+++ b/packages/antlr4-c3/package.json
@@ -24,7 +24,8 @@
     "test-ci": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest --no-coverage --watchAll=false --silent",
     "test-coverage": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest --coverage --silent",
     "generate": "tests/generate.sh",
-    "eslint": "eslint ."
+    "eslint": "eslint .",
+    "clean": "rm -rf out"
   },
   "dependencies": {
     "antlr4": "4.13"

--- a/packages/antlr4-c3/tests/generate.sh
+++ b/packages/antlr4-c3/tests/generate.sh
@@ -1,7 +1,6 @@
-ANTLR_JAR_FILE=/usr/local/lib/antlr4-tool.jar
 GRAMMAR_DIR=${PWD}/tests
-DOCKER_IMG=any0ne22/antlr4:4.13.0
-JAVA_ARGS="-Xmx500M -cp ${ANTLR_JAR_FILE} org.antlr.v4.Tool -Dlanguage=TypeScript"
-DOCKER_ARGS="run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v ${GRAMMAR_DIR}:/work ${DOCKER_IMG} java ${JAVA_ARGS} "
 
-docker ${DOCKER_ARGS} -no-listener -no-visitor CPP14.g4 Expr.g4 Whitebox.g4 -o /work/generated -Xexact-output-dir
+antlr4 -Dlanguage=TypeScript \
+  -no-listener -no-visitor \
+  ${GRAMMAR_DIR}/*.g4 \
+  -o ${GRAMMAR_DIR}/generated -Xexact-output-dir


### PR DESCRIPTION
## Why
Because it seemed to be broken since we created several sub-packages, because tests would not be found in some of them when debugging and the terminal would exit the debugging session.