### PR TITLE
Make codemirror autocompletion less trigger happy

### DIFF
--- a/packages/react-codemirror-experimental/src/lang-cypher/autocomplete.ts
+++ b/packages/react-codemirror-experimental/src/lang-cypher/autocomplete.ts
@@ -46,7 +46,7 @@ export const cypherAutocomplete: (schema?: DbInfo) => CompletionSource =
   (schema) => (context) => {
     const textUntilCursor = context.state.doc.toString().slice(0, context.pos);
 
-    const triggerCharacters = ['.', ':', '[', '(', '{', '$', ' ', '\n'];
+    const triggerCharacters = ['.', ':', '{', '$'];
     const lastCharacter = textUntilCursor.slice(-1);
 
     const lastWord = context.matchBefore(/\w*/);


### PR DESCRIPTION
Limit the characters that trigger the auto-completion panel to only the cases with labels, reltypes, properties, functions & parameters