### PR TITLE
Differentiate procedures and functions

### DIFF
--- a/packages/language-support/src/autocompletion/helpers.ts
+++ b/packages/language-support/src/autocompletion/helpers.ts
@@ -23,7 +23,7 @@ const reltypeCompletions = (dbInfo: DbInfo) =>
 const proceduresCompletions = (dbInfo: DbInfo) =>
   Object.keys(dbInfo.procedureSignatures).map((procedureName) => ({
     label: procedureName,
-    kind: CompletionItemKind.Function,
+    kind: CompletionItemKind.Method,
   }));
 const functionCompletions = (dbInfo: DbInfo) =>
   Object.keys(dbInfo.functionSignatures).map((fnName) => ({

--- a/packages/language-support/src/tests/autocompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion.test.ts
@@ -468,8 +468,8 @@ describe('Procedures auto-completion', () => {
         'db.info': SignatureInformation.create(''),
       }),
       expected: [
-        { label: 'dbms.info', kind: CompletionItemKind.Function },
-        { label: 'db.info', kind: CompletionItemKind.Function },
+        { label: 'dbms.info', kind: CompletionItemKind.Method },
+        { label: 'db.info', kind: CompletionItemKind.Method },
       ],
     });
   });


### PR DESCRIPTION
When testing, greg was confused why some apoc methods showed up some times but not others until he realized it was because some were functions and other procedures. I suggested we give them separate icons, the closest I found was `Method`. Do you think this separation makes sense? 