### PR TITLE
Restricts vscode debugging to only language-support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "jest.autoRun": "off",
-  "jest.jestCommandLine": "npm test -- -- --passWithNoTests",
+  "jest.jestCommandLine": "npm test -- --filter=language-support -- --passWithNoTests",
   "jest.rootPath": "./"
 }


### PR DESCRIPTION
This affects only the debugging and executing tests from inside VSCode

# Why
Because with so many projects already debugging tests every time we need to change branches implies re-executing all of them from the VSCode extension, whilst the language-support ones take a very small time and we mainly work on those.