### PR TITLE
Fixes out of memory errors in GitHub actions deploy jobs

### DIFF
--- a/.github/workflows/deploy-cypher-editor.yaml
+++ b/.github/workflows/deploy-cypher-editor.yaml
@@ -8,6 +8,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  NODE_OPTIONS: '--max_old_space_size=4096'
+
 jobs:
   deploy:
     environment: publish-npm

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -20,6 +20,9 @@ concurrency:
   group: 'pages'
   cancel-in-progress: false
 
+env:
+  NODE_OPTIONS: '--max_old_space_size=4096'
+
 jobs:
   deploy:
     environment:


### PR DESCRIPTION
## Why
Because in #85 I found the same, but only fixed them in `ci.yaml`, not in the other jobs