### PR TITLE
Fix crash on `(` when not connected

### DIFF
--- a/packages/server/src/signatureHelp.ts
+++ b/packages/server/src/signatureHelp.ts
@@ -33,7 +33,7 @@ export function doSignatureHelp(
 
     return signatureHelp(
       textDocument.getText(range),
-      neo4j.metadata.dbSchema ?? {},
+      neo4j.metadata?.dbSchema ?? {},
     );
   };
 }


### PR DESCRIPTION
Errors like these we'll catch automatically when we update the ts-config to be more strict, I think we can do that when we no longer inline the two antlr packages