### PR TITLE
Fixes memory leak in the React editor

### DIFF
--- a/packages/react-codemirror-experimental/src/CypherEditor.tsx
+++ b/packages/react-codemirror-experimental/src/CypherEditor.tsx
@@ -39,7 +39,7 @@ export const CypherEditor: CypherEditor = React.forwardRef((props, ref) => {
     overrideThemeBackgroundColor = false,
     schema = {},
     lint = true,
-    ...rest
+    value,
   } = props;
 
   const maybeReplMode = onExecute
@@ -65,7 +65,7 @@ export const CypherEditor: CypherEditor = React.forwardRef((props, ref) => {
       basicSetup={false}
       // reset to codemirror default and handle via completionKeymap extension
       indentWithTab={false}
-      {...rest}
+      value={value}
     />
   );
 });


### PR DESCRIPTION
This was reproducible when making the web repl grow gradually. For example by copy pasting the same example query back to back:

```
MATCH (n:Person)
WHERE n.name = "Steve" 
RETURN n 
LIMIT 12;
```

The memory consumption in Firefox jumped from 25 MiB to 400 MiB, I have even seen GiB if you keep on writing queries.

<img width="960"  src="https://github.com/neo4j/cypher-language-support/assets/5649971/a18a213d-75fb-4601-a77a-82b0a93a0c18">

After the change:

<img width="1916" src="https://github.com/neo4j/cypher-language-support/assets/5649971/9fc53ab0-f6da-4bc2-9fb3-aee2b10ab7a2">


## Why
I don't have a clear idea yet why this was happening, but I suspect we are holding the old string in the `onChange`, so we are just preventing the GC from cleaning old values of the editor?