### PR TITLE
Fixes warnings on non declared labels

### DIFF
--- a/packages/language-support/src/highlighting/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/highlighting/syntaxValidation/syntaxValidation.ts
@@ -63,8 +63,9 @@ function warnOnUndeclaredLabels(
   if (dbSchema.labels && dbSchema.relationshipTypes) {
     const dbLabels = new Set(dbSchema.labels);
     const dbRelationshipTypes = new Set(dbSchema.relationshipTypes);
+    const labelsAndRelTypes = parsingResult.collectedLabelOrRelTypes;
 
-    parsingResult.collectedLabelOrRelTypes.forEach((labelOrRelType) => {
+    labelsAndRelTypes.forEach((labelOrRelType) => {
       const warning = detectNonDeclaredLabel(
         labelOrRelType,
         dbLabels,

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -10,12 +10,9 @@ import CypherLexer from './generated-parser/CypherLexer';
 
 import CypherParser, {
   ClauseContext,
-  CreateClauseContext,
-  ExpressionContext,
   LabelNameContext,
   LabelNameIsContext,
   LabelOrRelTypeContext,
-  MergeClauseContext,
   StatementsContext,
   VariableContext,
 } from './generated-parser/CypherParser';
@@ -53,15 +50,14 @@ function getLabelType(ctx: ParserRuleContext): LabelType {
 }
 
 function couldCreateNewLabel(ctx: ParserRuleContext): boolean {
-  const parent = findParent(
-    ctx,
-    (ctx) => ctx instanceof ClauseContext || ctx instanceof ExpressionContext,
-  );
+  const parent = findParent(ctx, (ctx) => ctx instanceof ClauseContext);
 
-  return (
-    parent instanceof CreateClauseContext ||
-    parent instanceof MergeClauseContext
-  );
+  if (parent instanceof ClauseContext) {
+    const clause = parent;
+    return isDefined(clause.mergeClause()) || isDefined(clause.createClause());
+  } else {
+    return false;
+  }
 }
 
 export type LabelOrRelType = {


### PR DESCRIPTION
## What
Stops warnings on queries like:

```
CREATE (n:Person)
```

when `Person` does not exists in the database.

## Why
Becase we should only be warning for read queries