### PR TITLE
fix pages demo & add missing image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This mono repo contains packages that together make up Neo4j's Cypher Language s
 
 The project is in an early stage. We are still missing important features and the project is not yet stable. We welcome feedback and contributions!
 
-Try it out in our demo or in our alpha releases in [Neo4j Workspace](https://workspace.neo4j.io) and soon also in our VSCode extension.
+Try it out in our [demo](https://neo4j.github.io/cypher-language-support/) or in our alpha releases in [Neo4j Workspace](https://workspace.neo4j.io) and soon also in our VSCode extension.
 
 ## Project Overview
 

--- a/imgs/repo-overview.png
+++ b/imgs/repo-overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ade0251274c661106b7e9fd63af2de76aff59ff8623117872c5e75b7d52a159
+size 603724

--- a/packages/react-codemirror-playground/vite.config.ts
+++ b/packages/react-codemirror-playground/vite.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/cypher-language-support',
 });


### PR DESCRIPTION
The demo is no longer served on the root of it's domain, so we need to update the vite config for the demo build as per [vite docs on github pages](https://vitejs.dev/guide/static-deploy.html#github-pages). 