### PR TITLE
Tries to ignore .js file from GH language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
+
+
+semanticAnalysis.js linguist-vendored


### PR DESCRIPTION
## What
Ignores `semanticAnalysis.js` file from GH stats.

## Why
To get the stats about the languages used in the repo better:

<img width="371" alt="gh-stats" src="https://github.com/neo4j/cypher-language-support/assets/5649971/f409ed22-c796-4692-86c1-f4a3035829a2">
