### PR TITLE
Make editor history controlled and `onExecute` reactive

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,6 +14,7 @@
   "changesets": [
     "brown-ravens-obey",
     "fuzzy-rice-train",
-    "nervous-rabbits-greet"
+    "nervous-rabbits-greet",
+    "quick-berries-report"
   ]
 }

--- a/.changeset/quick-berries-report.md
+++ b/.changeset/quick-berries-report.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/react-codemirror': patch
+---
+
+Editor history is now a controlled prop

--- a/package-lock.json
+++ b/package-lock.json
@@ -18330,7 +18330,7 @@
     },
     "packages/language-server": {
       "name": "@neo4j-cypher/language-server",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@neo4j-cypher/language-support": "2.0.0-next.0",
@@ -18338,8 +18338,14 @@
         "vscode-languageserver": "^8.1.0",
         "vscode-languageserver-textdocument": "^1.0.8"
       },
+      "bin": {
+        "cypher-language-server": "dist/cypher-language-server"
+      },
       "devDependencies": {
         "esbuild": "^0.19.4"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/language-support": {
@@ -18354,11 +18360,14 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.5"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/react-codemirror": {
       "name": "@neo4j-cypher/react-codemirror",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
@@ -18388,13 +18397,16 @@
         "react": "^18.2.0",
         "typescript": "^4.9.5"
       },
+      "engines": {
+        "node": ">=18.18.2"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "packages/react-codemirror-playground": {
       "name": "@neo4j-cypher/react-codemirror-playground",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
         "@codemirror/commands": "^6.2.2",
@@ -18402,7 +18414,7 @@
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
         "@neo4j-cypher/language-support": "2.0.0-next.0",
-        "@neo4j-cypher/react-codemirror": "2.0.0-next.0",
+        "@neo4j-cypher/react-codemirror": "2.0.0-next.1",
         "react": "^18.2.0",
         "react-d3-tree": "^3.6.1",
         "react-dom": "^18.2.0",
@@ -18418,6 +18430,9 @@
         "tailwindcss": "^3.3.1",
         "typescript": "^4.9.5",
         "vite": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/react-codemirror-playground/node_modules/@esbuild/android-arm": {
@@ -19439,14 +19454,17 @@
       "dependencies": {
         "@neo4j-cypher/language-support": "2.0.0-next.0",
         "neo4j-driver": "^5.12.0"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/vscode-extension": {
       "name": "neo4j-cypher-vscode-extension",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-server": "2.0.0-next.0",
+        "@neo4j-cypher/language-server": "2.0.0-next.1",
         "vscode-languageclient": "^8.1.0"
       },
       "devDependencies": {
@@ -19459,6 +19477,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
+        "node": ">=18.18.2",
         "vscode": "^1.75.0"
       }
     },

--- a/packages/react-codemirror-playground/CHANGELOG.md
+++ b/packages/react-codemirror-playground/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neo4j-cypher/react-codemirror-playground
 
+## 2.0.0-next.2
+
+### Patch Changes
+
+- Updated dependencies [3866e43]
+  - @neo4j-cypher/react-codemirror@2.0.0-next.2
+
 ## 2.0.0-next.1
 
 ### Patch Changes

--- a/packages/react-codemirror-playground/package.json
+++ b/packages/react-codemirror-playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neo4j-cypher/react-codemirror-playground",
   "private": true,
-  "version": "2.0.0-next.1",
+  "version": "2.0.0-next.2",
   "type": "module",
   "scripts": {
     "dev": "vite --open",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@neo4j-cypher/language-support": "2.0.0-next.0",
-    "@neo4j-cypher/react-codemirror": "2.0.0-next.1",
+    "@neo4j-cypher/react-codemirror": "2.0.0-next.2",
     "@codemirror/autocomplete": "^6.5.1",
     "@codemirror/commands": "^6.2.2",
     "@codemirror/language": "^6.6.0",

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -108,7 +108,7 @@ export function App() {
               prompt="neo4j$"
               onExecute={() => setCommandRanCount((c) => c + 1)}
               theme={darkMode ? 'dark' : 'light'}
-              initialHistory={Object.values(demos)}
+              history={Object.values(demos)}
               schema={schema}
             />
 

--- a/packages/react-codemirror/CHANGELOG.md
+++ b/packages/react-codemirror/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neo4j-cypher/react-codemirror
 
+## 2.0.0-next.2
+
+### Patch Changes
+
+- 3866e43: Editor history is now a controlled prop
+
 ## 2.0.0-next.1
 
 ### Patch Changes

--- a/packages/react-codemirror/package.json
+++ b/packages/react-codemirror/package.json
@@ -17,7 +17,7 @@
     "codemirror",
     "codemirror 6"
   ],
-  "version": "2.0.0-next.1",
+  "version": "2.0.0-next.2",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -40,7 +40,8 @@ export interface CypherEditorProps {
    */
   onExecute?: (cmd: string) => void;
   /**
-   * The editor history navigateable via up/down arrow keys. Ordered newest to oldest.
+   * The editor history navigateable via up/down arrow keys. Order newest to oldest.
+   * Add to this list with the `onExecute` callback for REPL style history.
    */
   history?: string[];
   /**

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -13,9 +13,12 @@ import {
 } from '@codemirror/view';
 import type { DbSchema } from '@neo4j-cypher/language-support';
 import { Component, createRef } from 'react';
+import {
+  replaceHistory,
+  replMode as historyNavigation,
+} from './history-navigation';
 import { cypher, CypherConfig } from './lang-cypher/lang-cypher';
 import { basicNeo4jSetup } from './neo4j-setup';
-import { replMode } from './repl-mode';
 import { getThemeExtension } from './themes';
 
 export interface CypherEditorProps {
@@ -37,15 +40,9 @@ export interface CypherEditorProps {
    */
   onExecute?: (cmd: string) => void;
   /**
-   * Seed the editor history with some initial history entries
-   * Navigateable via up/down arrow keys
+   * The editor history navigateable via up/down arrow keys. Ordered newest to oldest.
    */
-  initialHistory?: string[];
-  /**
-   * Callback when a new history entry is added, useful for keeping track of history
-   * outside of the editor.
-   */
-  onNewHistoryEntry?: (historyEntry: string) => void;
+  history?: string[];
   /**
    * When set to `true` the editor will use the background color of the parent element.
    *
@@ -99,6 +96,25 @@ export interface CypherEditorProps {
    */
   onChange?(value: string, viewUpdate: ViewUpdate): void;
 }
+
+const executeKeybinding = (onExecute?: (cmd: string) => void) =>
+  onExecute
+    ? [
+        {
+          key: 'Ctrl-Enter',
+          mac: 'Mod-Enter',
+          preventDefault: true,
+          run: (view: EditorView) => {
+            const doc = view.state.doc.toString();
+            if (doc.trim() !== '') {
+              onExecute(doc);
+            }
+
+            return true;
+          },
+        },
+      ]
+    : [];
 
 const themeCompartment = new Compartment();
 const keyBindingCompartment = new Compartment();
@@ -158,33 +174,23 @@ export class CypherEditor extends Component<CypherEditorProps> {
     overrideThemeBackgroundColor: false,
     lineWrap: false,
     extraKeybindings: [],
-    initialHistory: [],
+    history: [],
     theme: 'light',
   };
 
   componentDidMount(): void {
     const {
       theme,
-      onExecute,
-      initialHistory,
-      onNewHistoryEntry,
       extraKeybindings,
       lineWrap,
       overrideThemeBackgroundColor,
       schema,
       lint,
       onChange,
+      onExecute,
     } = this.props;
 
     this.schemaRef.current = { schema, lint };
-
-    const maybeReplMode = onExecute
-      ? replMode({
-          onExecute,
-          initialHistory,
-          onNewHistoryEntry,
-        })
-      : [];
 
     const themeExtension = getThemeExtension(
       theme,
@@ -209,12 +215,14 @@ export class CypherEditor extends Component<CypherEditorProps> {
 
     this.editorState.current = EditorState.create({
       extensions: [
-        maybeReplMode,
+        keyBindingCompartment.of(
+          keymap.of([...executeKeybinding(onExecute), ...extraKeybindings]),
+        ),
+        historyNavigation(this.props),
         basicNeo4jSetup(),
         themeCompartment.of(themeExtension),
         changeListener,
         cypher(this.schemaRef.current),
-        keyBindingCompartment.of(keymap.of(extraKeybindings)),
         lineWrap ? EditorView.lineWrapping : [],
 
         lineNumbers({
@@ -279,11 +287,23 @@ export class CypherEditor extends Component<CypherEditorProps> {
       });
     }
 
-    if (prevProps.extraKeybindings !== this.props.extraKeybindings) {
+    if (
+      prevProps.extraKeybindings !== this.props.extraKeybindings ||
+      prevProps.onExecute !== this.props.onExecute
+    ) {
       this.editorView.current.dispatch({
         effects: keyBindingCompartment.reconfigure(
-          keymap.of(this.props.extraKeybindings),
+          keymap.of([
+            ...executeKeybinding(this.props.onExecute),
+            ...this.props.extraKeybindings,
+          ]),
         ),
+      });
+    }
+
+    if (prevProps.history?.length !== this.props.history?.length) {
+      this.editorView.current.dispatch({
+        effects: replaceHistory.of(this.props.history ?? []),
       });
     }
 

--- a/packages/react-codemirror/src/e2e_tests/syntax-validation.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/syntax-validation.spec.tsx
@@ -16,7 +16,6 @@ test('Prop lint set to false disables syntax validation', async ({
   });
 });
 
-// TODO
 test.skip('Can turn linting back on', async ({ page, mount }) => {
   const editorPage = new CypherEditorPage(page);
   const query = 'METCH (n) RETURN n';


### PR DESCRIPTION
We need more control of what is in the editor history in query, so I've moved it to be externally controlled. If we see the need for uncontrolled history, we can add an `uncontrolledHistory` prop to make `onExecute` push to history again.