### PR TITLE
Add information about neovim support.

### DIFF
--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -173,3 +173,22 @@ As of Emacs 29, `eglot` is built in. In `eglot`, a language server needs to be a
 ```elisp
 (add-to-list 'Eglot-server-programs '((cypher-mode) "cypher-language-server" "--stdio")))
 ```
+
+#### Neovim
+
+##### With `nvim-lspconfig`
+
+There is built-in support for the `cypher-language-server` in the plugin ([cypher_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cypher_ls)).
+
+Activate the language server support in your config file.
+```lua
+require('lspconfig').cypher_ls.setup{}
+```
+
+The language server is registered for _cypher_ files.
+To make neovim aware of this type, add a file to your _neovim-configuration-path/ftdetect_ (if it does not exist, create one) folder, e.g. _cypher.vim_, defining the file suffix and file type.
+
+```vim
+au BufRead,BufNewFile *.cypher                set filetype=cypher
+```
+


### PR DESCRIPTION
After the nvim-lspconfig project has now merged the support for the `cypher-language-server` (https://github.com/neovim/nvim-lspconfig/commit/cedc13473c7ff65bfc85cf3a9cfa65f7876a03b8), it might be a good idea to add also the information here.