### PR TITLE
improve history prop change detection

### DIFF
--- a/.changeset/purple-buckets-applaud.md
+++ b/.changeset/purple-buckets-applaud.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/react-codemirror': patch
+---
+
+Improved history prop change detection

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -302,7 +302,13 @@ export class CypherEditor extends Component<CypherEditorProps> {
       });
     }
 
-    if (prevProps.history?.length !== this.props.history?.length) {
+    // This component rerenders on every keystroke and comparing the
+    // full lists of editor strings on every render could be expensive.
+    const didChangeHistoryEstimate =
+      prevProps.history?.length !== this.props.history?.length ||
+      prevProps.history?.[0] !== this.props.history?.[0];
+
+    if (didChangeHistoryEstimate) {
       this.editorView.current.dispatch({
         effects: replaceHistory.of(this.props.history ?? []),
       });


### PR DESCRIPTION
The shortcut of comparing lengths works fine until you hit the maximum history length in workspace -> every new entry pushes an old one out, meaning the length of history entries is constant. I now also compare the newest history entry