### PR TITLE
Solves a problem with the trace.server

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: ExtensionContext) {
 
   // Create the language client and start the client.
   client = new LanguageClient(
-    'cypherLSP',
+    'neo4j',
     'Cypher Language Client',
     serverOptions,
     clientOptions,


### PR DESCRIPTION
The `neo4j.trace.server` setting wasn't working to debug the messages in the language server when set to other value rather than `verbose`. 

That's cause it's provided by VSCode for language servers and lives under the namespace we pass when setting up the client. We were passing `cypherLSP` still.