### PR TITLE
Fixes signature help edge case

### DIFF
--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -159,11 +159,6 @@ describe('Functions signature help', () => {
     };
   }
 
-  // TODO Fix this test.
-  // It stopped working because apoc.do.when( can be parsed ambiguously as
-  //   variable, property, property, spurious (
-  // or
-  //   functionName (
   test('Provides signature help for functions first argument when argument non started', () => {
     testSignatureHelp(
       `MATCH (n)

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -164,7 +164,7 @@ describe('Functions signature help', () => {
   //   variable, property, property, spurious (
   // or
   //   functionName (
-  test.skip('Provides signature help for functions first argument when argument non started', () => {
+  test('Provides signature help for functions first argument when argument non started', () => {
     testSignatureHelp(
       `MATCH (n)
          RETURN apoc.do.when(`,


### PR DESCRIPTION
## What
Fixes the case of getting the overlay with the information about the first argument for functions.

## How

`RETURN apoc.do.when(` gets parsed as:

```
      statements
     /    |    \     
statement (    EOF
    /  \
RETURN  expression
```

rather than:

```
      statements
     /    |    \     
statement (    EOF
    /  \
RETURN  functionInvocation
```
so we need to treat that case differently because we cannot modify the relative priority of functionInvocation vs expression

`RETURN apoc.do.when(x` gets parsed correctly in contrast (when we've started the first argument), because the parser has enough information to recognize it is a function invocation.

When our final character is `(`, just go to the preceeding statement and traverse it to find whether it ends on a expression. If it does, that's our function name.