### PR TITLE
fix second half of grafan push

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -24,6 +24,9 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: npm run build
 
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
       - name: Benchmark
         run: npm run benchmark --concurrency=1
         env:


### PR DESCRIPTION
The first grafana job published metrics properly, the e2e benchmark failed since playwright didn't have it's browser installed 