### PR TITLE
Avoid splitting multiline tokens

### DIFF
--- a/packages/language-support/src/highlighting/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/highlighting/syntaxColouring/syntaxColouring.ts
@@ -34,7 +34,9 @@ import CypherParserListener from '../../generated-parser/CypherParserListener';
 import { CypherTokenType } from '../../lexerSymbols';
 import { parserWrapper } from '../../parserWrapper';
 import {
+  BracketInfo,
   BracketType,
+  computeBracketInfo,
   getCypherTokenType,
   getTokenPosition,
   ParsedCypherToken,
@@ -42,7 +44,6 @@ import {
   shouldAssignTokenType,
   sortTokens,
   tokenPositionToString,
-  toParsedTokens,
 } from './syntaxColouringHelpers';
 
 export const syntaxColouringLegend: SemanticTokensLegend = {
@@ -94,15 +95,18 @@ class SyntaxHighlighter extends CypherParserListener {
   }
 
   private addToken(token: Token, tokenType: CypherTokenType, tokenStr: string) {
-    if (token.start >= 0) {
+    if (token.start >= 0 && tokenStr !== '') {
       const tokenPosition = getTokenPosition(token);
 
-      toParsedTokens(tokenPosition, tokenType, tokenStr, token).forEach(
-        (token) => {
-          const tokenPos = tokenPositionToString(token.position);
-          this.colouredTokens.set(tokenPos, token);
-        },
-      );
+      const stringiyed = tokenPositionToString(tokenPosition);
+
+      this.colouredTokens.set(stringiyed, {
+        tokenType,
+        position: tokenPosition,
+        length: tokenStr.length,
+        token: tokenStr,
+        bracketInfo: undefined,
+      });
     }
   }
 
@@ -245,16 +249,20 @@ function colourLexerTokens(tokens: Token[]) {
       const tokenPosition = getTokenPosition(token);
       const tokenStr = token.text ?? '';
 
-      toParsedTokens(
-        tokenPosition,
-        tokenType,
-        tokenStr,
+      const stringiyed = tokenPositionToString(tokenPosition);
+
+      const bracketInfo: BracketInfo | undefined = computeBracketInfo(
         token,
         bracketsLevel,
-      ).forEach((token) => {
-        const tokenPos = tokenPositionToString(token.position);
+      );
 
-        result.set(tokenPos, token);
+      // if(tokenStr !== ''){ }
+      result.set(stringiyed, {
+        tokenType,
+        position: tokenPosition,
+        length: tokenStr.length,
+        token: tokenStr,
+        bracketInfo,
       });
     }
   });

--- a/packages/language-support/src/tests/highlighting/syntaxColouring/comments.test.ts
+++ b/packages/language-support/src/tests/highlighting/syntaxColouring/comments.test.ts
@@ -11,24 +11,26 @@ describe('Comments syntax colouring', () => {
     expect(applySyntaxColouring(query)).toEqual([
       {
         bracketInfo: undefined,
-        length: 15,
+        length: 16,
         position: {
           line: 1,
           startCharacter: 4,
           startOffset: 5,
         },
-        token: '// Some comment',
+        token: `// Some comment
+`,
         tokenType: 'comment',
       },
       {
         bracketInfo: undefined,
-        length: 18,
+        length: 19,
         position: {
           line: 2,
           startCharacter: 4,
           startOffset: 25,
         },
-        token: '// Another comment',
+        token: `// Another comment
+`,
         tokenType: 'comment',
       },
       {
@@ -117,35 +119,15 @@ describe('Comments syntax colouring', () => {
     expect(applySyntaxColouring(query)).toEqual([
       {
         bracketInfo: undefined,
-        length: 17,
+        length: 36,
         position: {
           line: 1,
           startCharacter: 4,
           startOffset: 5,
         },
-        token: '/* Some multiline',
-        tokenType: 'comment',
-      },
-      {
-        bracketInfo: undefined,
-        length: 11,
-        position: {
-          line: 2,
-          startCharacter: 0,
-          startOffset: 23,
-        },
-        token: '    comment',
-        tokenType: 'comment',
-      },
-      {
-        bracketInfo: undefined,
-        length: 6,
-        position: {
-          line: 3,
-          startCharacter: 0,
-          startOffset: 35,
-        },
-        token: '    */',
+        token: `/* Some multiline
+    comment
+    */`,
         tokenType: 'comment',
       },
       {

--- a/packages/language-support/src/tests/highlighting/syntaxColouring/misc.test.ts
+++ b/packages/language-support/src/tests/highlighting/syntaxColouring/misc.test.ts
@@ -78,35 +78,15 @@ describe('Unfinished tokens', () => {
       },
       {
         bracketInfo: undefined,
-        length: 10,
+        length: 34,
         position: {
           line: 0,
           startCharacter: 7,
           startOffset: 7,
         },
-        token: '"something',
-        tokenType: 'stringLiteral',
-      },
-      {
-        bracketInfo: undefined,
-        length: 11,
-        position: {
-          line: 1,
-          startCharacter: 0,
-          startOffset: 18,
-        },
-        token: '        foo',
-        tokenType: 'stringLiteral',
-      },
-      {
-        bracketInfo: undefined,
-        length: 11,
-        position: {
-          line: 2,
-          startCharacter: 0,
-          startOffset: 30,
-        },
-        token: '        bar',
+        token: `"something
+        foo
+        bar`,
         tokenType: 'stringLiteral',
       },
     ]);
@@ -120,35 +100,15 @@ describe('Unfinished tokens', () => {
     expect(applySyntaxColouring(query)).toEqual([
       {
         bracketInfo: undefined,
-        length: 12,
+        length: 42,
         position: {
           line: 0,
           startCharacter: 0,
           startOffset: 0,
         },
-        token: '/* something',
-        tokenType: 'comment',
-      },
-      {
-        bracketInfo: undefined,
-        length: 11,
-        position: {
-          line: 1,
-          startCharacter: 0,
-          startOffset: 13,
-        },
-        token: '        foo',
-        tokenType: 'comment',
-      },
-      {
-        bracketInfo: undefined,
-        length: 17,
-        position: {
-          line: 2,
-          startCharacter: 0,
-          startOffset: 25,
-        },
-        token: '        MATCH (n)',
+        token: `/* something
+        foo
+        MATCH (n)`,
         tokenType: 'comment',
       },
     ]);
@@ -157,7 +117,7 @@ describe('Unfinished tokens', () => {
   test('Correctly colours unfinished property keys', () => {
     const query = `RETURN {\`something
     foo
-    
+ 
     bar: "hello"}`;
 
     expect(applySyntaxColouring(query)).toEqual([
@@ -188,46 +148,16 @@ describe('Unfinished tokens', () => {
       },
       {
         bracketInfo: undefined,
-        length: 10,
+        length: 38,
         position: {
           line: 0,
           startCharacter: 8,
           startOffset: 8,
         },
-        token: '`something',
-        tokenType: 'symbolicName',
-      },
-      {
-        bracketInfo: undefined,
-        length: 7,
-        position: {
-          line: 1,
-          startCharacter: 0,
-          startOffset: 19,
-        },
-        token: '    foo',
-        tokenType: 'symbolicName',
-      },
-      {
-        bracketInfo: undefined,
-        length: 4,
-        position: {
-          line: 2,
-          startCharacter: 0,
-          startOffset: 27,
-        },
-        token: '    ',
-        tokenType: 'symbolicName',
-      },
-      {
-        bracketInfo: undefined,
-        length: 17,
-        position: {
-          line: 3,
-          startCharacter: 0,
-          startOffset: 32,
-        },
-        token: '    bar: "hello"}',
+        token: `\`something
+    foo
+ 
+    bar: "hello"}`,
         tokenType: 'symbolicName',
       },
     ]);

--- a/packages/language-support/src/tests/highlighting/syntaxColouring/multilline.test.ts
+++ b/packages/language-support/src/tests/highlighting/syntaxColouring/multilline.test.ts
@@ -680,24 +680,13 @@ Other\`)
       },
       {
         bracketInfo: undefined,
-        length: 6,
+        length: 13,
         position: {
           line: 0,
           startCharacter: 9,
           startOffset: 9,
         },
-        token: '`Label',
-        tokenType: 'label',
-      },
-      {
-        bracketInfo: undefined,
-        length: 6,
-        position: {
-          line: 1,
-          startCharacter: 0,
-          startOffset: 16,
-        },
-        token: 'Other`',
+        token: '`Label\nOther`',
         tokenType: 'label',
       },
       {


### PR DESCRIPTION
We thought we had to split multi-line tokens for syntax highlighting to work, but that turned out not to be the case. This PR simplifies the code and slightly improves highlight performance

Highlighting benchmarks (ops/sec):
```
simple
5,147 -> 5,525 

movies 
32.02 -> 34.98

tictactoe 
163 -> 167

pokemon
2.67 -> 2.90
```