### PR TITLE
Prepare for extension publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Occasionally, we might also have logistical, commercial, or legal reasons why we
 Pre-requisites:
 
 - Node.js LTS (18.x)
+- [Git LFS](https://git-lfs.github.com/) easiest to install via package manager (e.g. `brew install git-lfs` on macOS)
 - [antlr4-tools](https://github.com/antlr/antlr4-tools) easiest to install with `pip install antlr4-tools` (python3 required)
 
 In the root folder of the project run:
@@ -26,4 +27,4 @@ From here you can start the `react-codemirror-playground` with:
 
 `npm run dev:codemirror`
 
-To run the VSCode extension, see the `vscode-extension` [README.md](./packages/vscode-extension/).
+To run the VSCode extension, choose `VSCode Playground` in the `Run & Debug` menu in VSCode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ From here you can start the `react-codemirror-playground` with:
 
 `npm run dev:codemirror`
 
-To run the VSCode extension, choose `VSCode Playground` in the `Run & Debug` menu in VS Code.
+To run the VS Code extension, choose `VSCode Playground` in the `Run & Debug` menu in VS Code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ From here you can start the `react-codemirror-playground` with:
 
 `npm run dev:codemirror`
 
-To run the VSCode extension, choose `VSCode Playground` in the `Run & Debug` menu in VSCode.
+To run the VSCode extension, choose `VSCode Playground` in the `Run & Debug` menu in VS Code.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This mono repo contains packages that together make up Neo4j's Cypher Language s
 
 The project is in an early stage. We are still missing important features and the project is not yet stable. We welcome feedback and contributions!
 
-Try it out in our [demo](https://neo4j.github.io/cypher-language-support/) or in our alpha releases in [Neo4j Workspace](https://workspace.neo4j.io) and soon also in our VSCode extension.
+Try it out in our [demo](https://neo4j.github.io/cypher-language-support/) or in our alpha releases in [Neo4j Workspace](https://workspace.neo4j.io) and soon also in our VS Code extension.
 
 ## Project Overview
 
@@ -16,7 +16,7 @@ The project comprises several packages:
 
 - [language-support](./packages/language-support/README.md) - The core library implementing the language support features.
 - [language-server](./packages/language-server/README.md) - The language server wrapper for the `language-support` package.
-- [vscode-extension](./packages/vscode-extension/README.md) - The Neo4j VSCode extension which bundles the `language-server`
+- [vscode-extension](./packages/vscode-extension/README.md) - The Neo4j VS Code extension which bundles the `language-server`
 - [react-codemirror](./packages/react-codemirror/README.md) - A set of [codemirror6](https://codemirror.net/) cypher language support plugins and a react wrapper.
 - [react-codemirror-playground](./packages/react-codemirror-playground/README.md) - A playground for the codemirror integration.
 - [schema-poller](./packages/schema-poller/README.md) - An internal package we use to manage the Neo4j connection and keep the schema (procedure names, labels, database names, etc.) up to date in the language server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14444,10 +14444,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/neo4j-cypher-vscode-extension": {
-      "resolved": "packages/vscode-extension",
-      "link": true
-    },
     "node_modules/neo4j-driver": {
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.13.0.tgz",
@@ -14472,6 +14468,10 @@
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.13.0.tgz",
       "integrity": "sha512-IOqCeKWMSeYmZ8YwgoUNMRm63bTeQsw1b0v4AtjV7u87N2Jj89m5o+LRbaSIE0M8ruCW8PGOQ9I0PsmYYkhywQ=="
+    },
+    "node_modules/neo4j-vscode": {
+      "resolved": "packages/vscode-extension",
+      "link": true
     },
     "node_modules/node-abi": {
       "version": "3.51.0",
@@ -19071,6 +19071,7 @@
       },
       "devDependencies": {
         "@types/lodash.debounce": "^4.0.9",
+        "@types/workerpool": "^6.4.7",
         "esbuild": "^0.19.4"
       },
       "engines": {
@@ -20207,7 +20208,7 @@
       }
     },
     "packages/vscode-extension": {
-      "name": "neo4j-cypher-vscode-extension",
+      "name": "neo4j-vscode",
       "version": "2.0.0-next.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14444,10 +14444,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/neo4j-cypher-vscode-extension": {
-      "resolved": "packages/vscode-extension",
-      "link": true
-    },
     "node_modules/neo4j-driver": {
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.13.0.tgz",
@@ -14472,6 +14468,10 @@
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.13.0.tgz",
       "integrity": "sha512-IOqCeKWMSeYmZ8YwgoUNMRm63bTeQsw1b0v4AtjV7u87N2Jj89m5o+LRbaSIE0M8ruCW8PGOQ9I0PsmYYkhywQ=="
+    },
+    "node_modules/neo4j-vscode": {
+      "resolved": "packages/vscode-extension",
+      "link": true
     },
     "node_modules/node-abi": {
       "version": "3.51.0",
@@ -20207,7 +20207,7 @@
       }
     },
     "packages/vscode-extension": {
-      "name": "neo4j-cypher-vscode-extension",
+      "name": "neo4j-vscode",
       "version": "2.0.0-next.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14444,6 +14444,10 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/neo4j-cypher-vscode-extension": {
+      "resolved": "packages/vscode-extension",
+      "link": true
+    },
     "node_modules/neo4j-driver": {
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.13.0.tgz",
@@ -14468,10 +14472,6 @@
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.13.0.tgz",
       "integrity": "sha512-IOqCeKWMSeYmZ8YwgoUNMRm63bTeQsw1b0v4AtjV7u87N2Jj89m5o+LRbaSIE0M8ruCW8PGOQ9I0PsmYYkhywQ=="
-    },
-    "node_modules/neo4j-vscode": {
-      "resolved": "packages/vscode-extension",
-      "link": true
     },
     "node_modules/node-abi": {
       "version": "3.51.0",
@@ -20207,7 +20207,7 @@
       }
     },
     "packages/vscode-extension": {
-      "name": "neo4j-vscode",
+      "name": "neo4j-cypher-vscode-extension",
       "version": "2.0.0-next.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19071,7 +19071,6 @@
       },
       "devDependencies": {
         "@types/lodash.debounce": "^4.0.9",
-        "@types/workerpool": "^6.4.7",
         "esbuild": "^0.19.4"
       },
       "engines": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -42,13 +42,15 @@
     "workerpool": "^9.0.4"
   },
   "scripts": {
-    "build": "tsc -b && npm run bundle && npm run make-executable",
+    "build": "tsc -b && npm run bundle && npm run make-executable && npm run bundle-worker",
     "bundle": "esbuild ./src/server.ts --bundle --format=cjs --platform=node --outfile=dist/cypher-language-server.js --minify",
+    "bundle-worker": "esbuild ./src/lintWorker.ts --bundle --format=cjs --platform=node --outfile=dist/lintWorker.js --minify",
     "make-executable": "cd dist && echo '#!/usr/bin/env node' > cypher-language-server && cat cypher-language-server.js >> cypher-language-server",
     "clean": "rm -rf dist",
     "watch": "tsc -b -w"
   },
   "devDependencies": {
+    "@types/workerpool": "^6.4.7",
     "@types/lodash.debounce": "^4.0.9",
     "esbuild": "^0.19.4"
   }

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -50,7 +50,6 @@
     "watch": "tsc -b -w"
   },
   "devDependencies": {
-    "@types/workerpool": "^6.4.7",
     "@types/lodash.debounce": "^4.0.9",
     "esbuild": "^0.19.4"
   }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -101,11 +101,11 @@ connection.onDidChangeConfiguration(
       neo4jSdk.connection === undefined &&
       neo4jConfig.connect &&
       neo4jConfig.password &&
-      neo4jConfig.URL &&
+      neo4jConfig.connectURL &&
       neo4jConfig.user
     ) {
       void neo4jSdk.persistentConnect(
-        neo4jConfig.URL,
+        neo4jConfig.connectURL,
         {
           username: neo4jConfig.user,
           password: neo4jConfig.password,

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -5,6 +5,6 @@ export type Neo4jSettings = {
   };
   connect?: boolean;
   password?: string;
-  URL?: string;
+  connectURL?: string;
   user?: string;
 };

--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -33,7 +33,7 @@ interface ParsedMethod {
 }
 
 function toSignatureHelp(
-  methodSignatures: Record<string, SignatureInformation>,
+  methodSignatures: Record<string, SignatureInformation> = {},
   parsedMethod: ParsedMethod,
 ) {
   const methodName = parsedMethod.methodName;

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -219,6 +219,11 @@ describe('Procedures signature help', () => {
       63,
     );
   });
+
+  test('Does not crash on missing schema', () => {
+    testSignatureHelp(`CALL apoc.do.when`, undefined, emptyResult);
+    testSignatureHelp(`CALL apoc.do.when`, {}, emptyResult);
+  });
 });
 
 describe('Functions signature help', () => {
@@ -390,5 +395,10 @@ describe('Functions signature help', () => {
       expectedArgIndex(1),
       89,
     );
+  });
+
+  test('Does not crash on missing schema', () => {
+    testSignatureHelp(`CALL apoc.do.when`, undefined, emptyResult);
+    testSignatureHelp(`CALL apoc.do.when`, {}, emptyResult);
   });
 });

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -10,3 +10,4 @@
 !dist/extension.js
 !dist/lintWorker.js
 !dist/cypher-language-server.js
+!cypher-language-configuration.json

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,13 +1,12 @@
-dist/
-!dist/extension.js
-!dist/cypher-language-server.js
+# Ignore everything, https://github.com/microsoft/vscode-vsce/issues/12
+**
+# Required for the ignore everything rule to work from testing
 ../../
 ../
-node_modules
-out/
-src/
-e2e_tests/
-tsconfig.json
-webpack.config.js
-.turbo
-.vscode
+
+# Unignore only required files, readme/package.json automatically included
+!LICENSE.md
+!images/
+!dist/extension.js
+!dist/lintWorker.js
+!dist/cypher-language-server.js

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -2,43 +2,43 @@
 
 ## Getting started
 
-Open a file with `.cypher` extension after installing the extension from the VSCode marketplace. To enable database aware features (such as completing labels/functions), set up a connection to a neo4j instance using the settings described in the settings section below.
+After installing the extension from the VS Code Marketplace, open a file with a `.cypher` to start using the extension. To enable database aware features (such as completing labels/functions), set up a connection to a Neo4j instance using the settings described in the settings section below.
 
-### Feature Highlights
+## Feature Highlights
 
-Our extension preview provides a rich set of features for working with Cypher, including:
+Our extension preview provides a rich set of features for working with Cypher, the query language for Neo4j databases, including:
 
 - Syntax highlighting
-- Syntax checking - both syntax and semantic errors (e.g. type errors, unknown labels etc.)
+- Syntax checking - both simple and semantic errors (e.g. type errors, unknown labels, etc)
 - Autocompletion for Cypher keywords, functions, labels, properties, database names and more
 - Signature help for functions - shows the signature of the function while typing
 
-![whirlwind-tour](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/images/demo.gif?raw=true)
+![demo-gif](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/images/demo.gif?raw=true)
 
-### Upcoming features
+## Upcoming features
 
 We're working on adding more features to the extension, such as:
 
 - Easier database connection management
 - Embedded cypher support in other file types
 - REPL-like scratchpad for debugging queries
-- Automated formatting
+- Automatic query formatting
 
 ## Extension settings
 
-The following settings are available in VSCode once the plugin is installed, which can be set either through the `Settings` menu on VSCode or by editing your `.vscode/settings.json` file.
+The following settings are available in VS Code once the plugin is installed, which can be set either through the `Settings` menu on VS Code or by editing your `.vscode/settings.json` file.
 
-- `cypherLSP.neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`.
-- `cypherLSP.neo4j.user`: Defaults to `"neo4j"`
-- `cypherLSP.neo4j.password`: Defaults to `"password"`
-- `cypherLSP.neo4j.URL`: Defaults to `"neo4j://localhost:7687"`
+- `cypherLSP.neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
+- `cypherLSP.neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
+- `cypherLSP.neo4j.password`: Replace this with the password for the user above
+- `cypherLSP.neo4j.URL`: Defaults to `"neo4j://localhost:7687"`, the default URL for a local Neo4j instance
 
 ### Debug
 
-- `cypherLSP.trace.server`: Traces the communication between VS Code and the language server for debugging purposes.
+- `cypherLSP.trace.server`: Traces the communication between VS Code and the language server for debugging purposes
 
-### Contributing
+## Contributing
 
-We welcome your suggestions, ideas, bug reports and contributions on the project on our [github](https://github.com/neo4j/cypher-language-support).
+We welcome your suggestions, ideas, bug reports and contributions on our [github](https://github.com/neo4j/cypher-language-support).
 
-To build the project locally, see the [CONTRIBUTING.md](CONTRIBUTING.md) file at the root of the repository.
+To build the project locally, see the [CONTRIBUTING.md](https://github.com/neo4j/cypher-language-support/blob/main/CONTRIBUTING.md) file at the root of the git repository.

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -31,7 +31,7 @@ The following settings are available in VS Code once the plugin is installed, wh
 - `neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
 - `neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
 - `neo4j.password`: Replace this with the password for the user above
-- `neo4j.boltUrl`: Defaults to `"neo4j://localhost:7687"`, the default url for connecting a local Neo4j instance over websocket via the `bolt` protocol
+- `neo4j.connectURL`: Defaults to `"neo4j://localhost:7687"`, the default url for connecting a local Neo4j instance over websocket via the `bolt` protocol
 
 ### Debug
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,37 +1,44 @@
-# VSCode Extension
+# Neo4j for VS Code Preview
 
-This is a VScode extension playground for testing the Cypher language server.
+## Getting started
 
-It's not yet published on the VSCode Marketplace, so to test it you need to run it locally.
+Open a file with `.cypher` extension after installing the extension from the VSCode marketplace. To enable database aware features (such as completing labels/functions), set up a connection to a neo4j instance using the settings described in the settings section below.
 
-For running it, compile the code first:
+### Feature Highlights
 
-```
-npm install
-npm run build
-```
+Our extension preview provides a rich set of features for working with Cypher, including:
 
-To launch a new VSCode window with the extension installed go to the `Run & Debug` tab (normally in the left pannel), select and run `VSCode Playground` clicking on the play ▷ button.
+- Syntax highlighting
+- Syntax checking - both syntax and semantic errors (e.g. type errors, unknown labels etc.)
+- Autocompletion for Cypher keywords, functions, labels, properties, database names and more
+- Signature help for functions - shows the signature of the function while typing
 
-This will open a new window where we can open our folder of choice, create a file with `.cypher` extension and start typing cypher helped by the language support.
+![whirlwind-tour](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/images/demo.gif?raw=true)
 
-## Plugin settings
+### Upcoming features
 
-For database aware features (such as autocompleting labels, procedure names, etc), you can connect to a running database (Aura, neo4j docker, etc) by tweaking the playground settings, in the opened window.
+We're working on adding more features to the extension, such as:
 
-The following settings are available in VSCode once the plugin is installed, which can be set either through the `Settings` menu on VSCode or by creating a `.vscode/settings.json` file in the window opened by the play button.
+- Easier database connection management
+- Embedded cypher support in other file types
+- REPL-like scratchpad for debugging queries
+- Automated formatting
 
-### Settings for database connection
+## Extension settings
 
-The following settings refer to the database connection used for signature loading, this will allow for autocomplete on Labels and Types.
+The following settings are available in VSCode once the plugin is installed, which can be set either through the `Settings` menu on VSCode or by editing your `.vscode/settings.json` file.
 
-- `cypherLSP.neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve signature information. Defaults to `true`.
+- `cypherLSP.neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`.
 - `cypherLSP.neo4j.user`: Defaults to `"neo4j"`
 - `cypherLSP.neo4j.password`: Defaults to `"password"`
-- `cypherLSP.neo4j.URL`: Defaults to `"bolt://localhost:7687"`
-
-![](../../imgs/vscode-playground.png)
+- `cypherLSP.neo4j.URL`: Defaults to `"neo4j://localhost:7687"`
 
 ### Debug
 
 - `cypherLSP.trace.server`: Traces the communication between VS Code and the language server for debugging purposes.
+
+### Contributing
+
+We welcome your suggestions, ideas, bug reports and contributions on the project on our [github](https://github.com/neo4j/cypher-language-support).
+
+To build the project locally, see the [CONTRIBUTING.md](CONTRIBUTING.md) file at the root of the repository.

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -29,9 +29,9 @@ We're working on adding more features to the extension, such as:
 The following settings are available in VS Code once the plugin is installed, which can be set either through the `Settings` menu on VS Code or by editing your `.vscode/settings.json` file.
 
 - `neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
+- `neo4j.connectURL`: Defaults to `"neo4j://localhost:7687"`, the default url for connecting a local Neo4j instance over websocket via the `bolt` protocol
 - `neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
 - `neo4j.password`: Replace this with the password for the user above
-- `neo4j.connectURL`: Defaults to `"neo4j://localhost:7687"`, the default url for connecting a local Neo4j instance over websocket via the `bolt` protocol
 
 ### Debug
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -21,21 +21,21 @@ We're working on adding more features to the extension, such as:
 
 - Easier database connection management
 - Embedded cypher support in other file types
-- REPL-like scratchpad for debugging queries
+- Query exectution and result visualization
 - Automatic query formatting
 
 ## Extension settings
 
 The following settings are available in VS Code once the plugin is installed, which can be set either through the `Settings` menu on VS Code or by editing your `.vscode/settings.json` file.
 
-- `cypherLSP.neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
-- `cypherLSP.neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
-- `cypherLSP.neo4j.password`: Replace this with the password for the user above
-- `cypherLSP.neo4j.URL`: Defaults to `"neo4j://localhost:7687"`, the default URL for a local Neo4j instance
+- `neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
+- `neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
+- `neo4j.password`: Replace this with the password for the user above
+- `neo4j.boltUrl`: Defaults to `"neo4j://localhost:7687"`, the default url for a local Neo4j instance
 
 ### Debug
 
-- `cypherLSP.trace.server`: Traces the communication between VS Code and the language server for debugging purposes
+- `neo4j.trace.server`: Traces the communication between VS Code and the language server for debugging purposes
 
 ## Contributing
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -31,7 +31,7 @@ The following settings are available in VS Code once the plugin is installed, wh
 - `neo4j.connect`: If true it will attempt to connect to a Neo4j database to retrieve data used for completions. Defaults to `true`
 - `neo4j.user`: Defaults to `"neo4j"`, the default user for a local Neo4j instance
 - `neo4j.password`: Replace this with the password for the user above
-- `neo4j.boltUrl`: Defaults to `"neo4j://localhost:7687"`, the default url for a local Neo4j instance
+- `neo4j.boltUrl`: Defaults to `"neo4j://localhost:7687"`, the default url for connecting a local Neo4j instance over websocket via the `bolt` protocol
 
 ### Debug
 

--- a/packages/vscode-extension/e2e_tests/fixtures/.vscode/settings-template.json
+++ b/packages/vscode-extension/e2e_tests/fixtures/.vscode/settings-template.json
@@ -1,7 +1,7 @@
 {
   "neo4j.connect": true,
   "neo4j.password": "{PASSWORD}",
-  "neo4j.URL": "neo4j://localhost:{PORT}",
+  "neo4j.connectURL": "neo4j://localhost:{PORT}",
   "neo4j.user": "neo4j",
   "neo4j.trace.server": "off"
 }

--- a/packages/vscode-extension/images/demo.gif
+++ b/packages/vscode-extension/images/demo.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0256a57a610f842cca24742dbd3864b45e752c0b4fb270050742f65f3ff36f76
+size 3924718

--- a/packages/vscode-extension/images/logo.png
+++ b/packages/vscode-extension/images/logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:372e7b261b3a815f8a863c69cff88df809417cf82484bf798be8f1d68cdb0fdc
+size 3536

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -49,7 +49,7 @@
       }
     ],
     "configuration": {
-      "title": "Cypher LSP",
+      "title": "Neo4j for VS Code",
       "properties": {
         "neo4j.trace.server": {
           "scope": "window",
@@ -66,25 +66,25 @@
           "order": 1,
           "type": "boolean",
           "default": true,
-          "description": "Shall connect to Neo4j to gather data about labels and types."
+          "description": "Connect to Neo4j for database aware completions."
         },
         "neo4j.URL": {
           "order": 2,
           "type": "string",
-          "default": "bolt://localhost:7687",
+          "default": "neo4j://localhost:7687",
           "description": "Url of the database to connect."
         },
         "neo4j.user": {
           "order": 3,
           "type": "string",
           "default": "neo4j",
-          "description": "Username of the database to connect."
+          "description": "Username for database connection."
         },
         "neo4j.password": {
           "order": 4,
           "type": "string",
           "default": "password",
-          "description": "Password of the database to connect."
+          "description": "Password for database connection."
         }
       }
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -93,7 +93,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run build",
-    "bundle-language-server": "cd ../language-server && npm run bundle && cp dist/cypher-language-server.js ../vscode-extension/dist/ && cp dist/lintWorker.js ../vscode-extension/dist/",
+    "bundle-language-server": "cd ../language-server && npm run bundle && cp dist/cypher-language-server.js ../vscode-extension/dist/ && npm run bundle-worker && cp dist/lintWorker.js ../vscode-extension/dist/",
     "bundle-extension": "esbuild ./src/extension.ts --bundle --external:vscode --format=cjs --platform=node --minify --outfile=dist/extension.js",
     "build": "tsc -b && npm run bundle-extension && npm run bundle-language-server",
     "clean": "rm -rf dist",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -65,11 +65,11 @@
           "default": true,
           "description": "Whether to connect to Neo4j for database aware completions."
         },
-        "neo4j.URL": {
+        "neo4j.connectURL": {
           "order": 2,
           "type": "string",
           "default": "neo4j://localhost:7687",
-          "description": "Url of the databases bolt connector."
+          "description": "URL of the Neo4j instance to poll data from, `bolt` & `neo4j` protocols supported."
         },
         "neo4j.user": {
           "order": 3,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -78,13 +78,13 @@
           "order": 3,
           "type": "string",
           "default": "neo4j",
-          "description": "Username for database connection."
+          "description": "Username for the database connection."
         },
         "neo4j.password": {
           "order": 4,
           "type": "string",
           "default": "password",
-          "description": "Password for database connection."
+          "description": "Password for the database connection."
         }
       }
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neo4j-cypher-vscode-extension",
+  "name": "neo4j-vscode",
   "displayName": "Neo4j for VS Code",
   "description": "Highlighting, completions and more for Neo4j Cypher in VS Code",
   "publisher": "neo4j-extensions",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neo4j-vscode",
+  "name": "neo4j-cypher-vscode-extension",
   "displayName": "Neo4j for VS Code",
   "description": "Highlighting, completions and more for Neo4j Cypher in VS Code",
   "publisher": "neo4j-extensions",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -66,13 +66,13 @@
           "order": 1,
           "type": "boolean",
           "default": true,
-          "description": "Connect to Neo4j for database aware completions."
+          "description": "Whether to connect to Neo4j for database aware completions."
         },
         "neo4j.URL": {
           "order": 2,
           "type": "string",
           "default": "neo4j://localhost:7687",
-          "description": "Url of the database to connect."
+          "description": "Url of the databases bolt connector."
         },
         "neo4j.user": {
           "order": 3,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,11 +1,24 @@
 {
-  "name": "neo4j-cypher-vscode-extension",
-  "private": true,
-  "description": "Enables support for Neo4j and its query language Cypher",
+  "name": "neo4j-vscode",
+  "displayName": "Neo4j for VS Code",
+  "description": "Highlighting, completions and more for Neo4j Cypher in VS Code",
+  "publisher": "neo4j-extensions",
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
   "version": "2.0.0-next.4",
-  "publisher": "Neo4j Inc.",
+  "preview": true,
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
+  "keywords": [
+    "cypher",
+    "neo4j",
+    "graph",
+    "database",
+    "completions"
+  ],
+  "icon": "images/logo.png",
   "activationEvents": [
     "onLanguage:cypher"
   ],

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -19,9 +19,6 @@
     "completions"
   ],
   "icon": "images/logo.png",
-  "activationEvents": [
-    "onLanguage:cypher"
-  ],
   "main": "./dist/extension.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the crash when dbschema isn't passed to the signature help and prepares our package for publishing.

Updates to our package.json based on the guidelines in the docs here:
https://code.visualstudio.com/api/references/extension-manifest

I've updated some "VSCode" to "VS Code", since that's how it's usually written in docs from microsoft.

Minimized the extension bundle, now it only includes the relevant files:
![CleanShot 2024-02-29 at 11 12 59](https://github.com/neo4j/cypher-language-support/assets/10564538/3fe099c1-7d76-499c-8dbb-72d5059f5c44)

The gif needs to be referenced via https to render in the marketplace, as noted [here](https://stackoverflow.com/questions/52686381/why-image-cant-show-up-in-the-vs-code-extension-gallery-when-i-used-html-tag-in) and [here](https://stackoverflow.com/questions/42988322/insert-video-in-readme-md-for-an-extension-of-vscode). Let me know if you prefer one of the older gifs, a static image or something completely different 😄 

I've also updated some wordings & descriptions, let me know what you think.