### PR TITLE
Solves bug with signature help and empty schema

### DIFF
--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -143,7 +143,7 @@ export function signatureHelp(
   const parserResult = parserWrapper.parse(fullQuery);
   const caret = findCaret(parserResult, caretPosition);
 
-  if (caret) {
+  if (caret && dbSchema.functionSignatures && dbSchema.procedureSignatures) {
     const statement = caret.statement;
 
     const signatureHelper = new SignatureHelper(statement.tokens, caret.token);

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -219,6 +219,18 @@ describe('Procedures signature help', () => {
       63,
     );
   });
+
+  test('Signature help does not crash on empty schema', () => {
+    testSignatureHelp(
+      `CALL apoc.do.when(`,
+      {},
+      {
+        signatures: [],
+        activeSignature: undefined,
+        activeParameter: undefined,
+      },
+    );
+  });
 });
 
 describe('Functions signature help', () => {
@@ -389,6 +401,18 @@ describe('Functions signature help', () => {
       dbSchema,
       expectedArgIndex(1),
       89,
+    );
+  });
+
+  test('Signature help does not crash on empty schema', () => {
+    testSignatureHelp(
+      `RETURN apoc.coll.combinations(`,
+      {},
+      {
+        signatures: [],
+        activeSignature: undefined,
+        activeParameter: undefined,
+      },
     );
   });
 });


### PR DESCRIPTION
We were trying to access `procedureSignatures` and `functionSignatures` on the schema, even if it was empty, which was causing VSCode to show crashes.