### PR TITLE
update trigger characters to match codemirrors

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -35,7 +35,7 @@ connection.onInitialize(() => {
       // Tell the client what features does the server support
       completionProvider: {
         resolveProvider: false,
-        triggerCharacters: ['.'],
+        triggerCharacters: ['.', ':', '{', '$'],
       },
       semanticTokensProvider: {
         documentSelector: null,


### PR DESCRIPTION
We have no support for parameters in VS Code yet so the `$` will not really do anything for now, but we might as well add it in for when we do