### PR TITLE
Ignores VSCode in changeset until we make a first non-next release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "ignore": ["neo4j-for-vscode"],
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -7,7 +7,6 @@
     "@neo4j-cypher/react-codemirror": "1.0.0",
     "@neo4j-cypher/react-codemirror-playground": "1.0.0",
     "@neo4j-cypher/schema-poller": "1.0.0",
-    "neo4j-for-vscode": "1.0.0",
     "antlr4": "4.13.1",
     "antlr4-c3": "3.0.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19056,10 +19056,10 @@
     },
     "packages/language-server": {
       "name": "@neo4j-cypher/language-server",
-      "version": "2.0.0-next.5",
+      "version": "2.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.4",
+        "@neo4j-cypher/language-support": "2.0.0-next.5",
         "lodash.debounce": "^4.0.8",
         "neo4j-driver": "^5.3.0",
         "vscode-languageserver": "^8.1.0",
@@ -19084,7 +19084,7 @@
     },
     "packages/language-support": {
       "name": "@neo4j-cypher/language-support",
-      "version": "2.0.0-next.4",
+      "version": "2.0.0-next.5",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "*",
@@ -19103,7 +19103,7 @@
     },
     "packages/react-codemirror": {
       "name": "@neo4j-cypher/react-codemirror",
-      "version": "2.0.0-next.6",
+      "version": "2.0.0-next.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
@@ -19115,7 +19115,7 @@
         "@codemirror/view": "^6.13.2",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.4",
+        "@neo4j-cypher/language-support": "2.0.0-next.5",
         "@types/prismjs": "^1.26.3",
         "@types/workerpool": "^6.4.7",
         "ayu": "^8.0.1",
@@ -19148,15 +19148,15 @@
     },
     "packages/react-codemirror-playground": {
       "name": "@neo4j-cypher/react-codemirror-playground",
-      "version": "2.0.0-next.6",
+      "version": "2.0.0-next.7",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
         "@codemirror/commands": "^6.2.2",
         "@codemirror/language": "^6.6.0",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.4",
-        "@neo4j-cypher/react-codemirror": "2.0.0-next.6",
+        "@neo4j-cypher/language-support": "2.0.0-next.5",
+        "@neo4j-cypher/react-codemirror": "2.0.0-next.7",
         "react": "^18.2.0",
         "react-d3-tree": "^3.6.1",
         "react-dom": "^18.2.0",
@@ -20196,10 +20196,10 @@
     },
     "packages/schema-poller": {
       "name": "@neo4j-cypher/schema-poller",
-      "version": "2.0.0-next.4",
+      "version": "2.0.0-next.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.4",
+        "@neo4j-cypher/language-support": "2.0.0-next.5",
         "neo4j-driver": "^5.12.0"
       },
       "engines": {
@@ -20208,10 +20208,10 @@
     },
     "packages/vscode-extension": {
       "name": "neo4j-for-vscode",
-      "version": "1.0.0",
+      "version": "1.0.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-server": "2.0.0-next.5",
+        "@neo4j-cypher/language-server": "2.0.0-next.6",
         "vscode-languageclient": "^8.1.0"
       },
       "devDependencies": {

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,53 +1,11 @@
 # @neo4j-cypher/vscode-extension
 
-## 1.0.1-next.0
+## 1.1.0
 
-### Patch Changes
+### Minor Changes
 
-- @neo4j-cypher/language-server@2.0.0-next.6
+- Updates grammar and adds semantic analysis for procedures and functions
 
-## 2.0.0-next.5
+## 1.0.0
 
-### Patch Changes
-
-- @neo4j-cypher/language-server@2.0.0-next.5
-
-## 2.0.0-next.4
-
-### Patch Changes
-
-- 1e210cb: Moves semantic analysis to a separate worker file
-- Updated dependencies [8cc77c6]
-- Updated dependencies [1e210cb]
-  - @neo4j-cypher/language-server@2.0.0-next.4
-
-## 2.0.0-next.3
-
-### Patch Changes
-
-- @neo4j-cypher/language-server@2.0.0-next.3
-
-## 2.0.0-next.2
-
-### Patch Changes
-
-- @neo4j-cypher/language-server@2.0.0-next.2
-
-## 2.0.0-next.1
-
-### Patch Changes
-
-- Makes language server executable with npx
-- Updated dependencies
-  - @neo4j-cypher/language-server@2.0.0-next.1
-
-## 2.0.0-next.0
-
-### Major Changes
-
-- 5819f6385: First alpha release of the new Neo4j's Cypher Language Support, including syntax highlighting, auto-completion and linting as features
-
-### Patch Changes
-
-- Updated dependencies [5819f6385]
-  - @neo4j-cypher/language-server@2.0.0-next.0
+- First release of the Neo4j for VSCode plugin, including syntax highlighting, auto-completion and linting as features


### PR DESCRIPTION
Excludes the VScode from changesets.

## Why
Because we have a situation where all of the other packages are in a pre-release mode, but `changesets` looks like it's unable to handle some of the packages being in a pre-release mode and some not (VSCode Marketplace will not admit the `1.0.0-next` naming convention).

Therefore it's better to write the changelogs for VSCode by hand until we get out of pre-release mode.