### PR TITLE
fix bug where symbolicname completions could return invalid completions

### DIFF
--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -691,4 +691,6 @@ function completeSymbolicName({
       })),
     ];
   }
+
+  return [];
 }

--- a/packages/language-support/src/tests/autocompletion/miscCompletions.test.ts
+++ b/packages/language-support/src/tests/autocompletion/miscCompletions.test.ts
@@ -1,5 +1,8 @@
 import { CompletionItemKind } from 'vscode-languageserver-types';
-import { testCompletions } from './completionAssertionHelpers';
+import {
+  testCompletions,
+  testCompletionsExactly,
+} from './completionAssertionHelpers';
 
 describe('Misc auto-completion', () => {
   test('Correctly completes empty statement', () => {
@@ -187,6 +190,20 @@ describe('Inserts correct text when symbolic name is not display name', () => {
       query,
       expected: [
         { label: 'allShortestPaths', kind: CompletionItemKind.Keyword },
+      ],
+    });
+  });
+
+  test("doesn't give invalid/undefined completion after CREATE INDEX", () => {
+    // CREATE INDEX uses symbolic name but has no valid completions
+    // there was a bug that allowed this situation to lead to an invalid completion
+    // hence this test
+    testCompletionsExactly({
+      query: 'CREATE INDEX ',
+      expected: [
+        { kind: 14, label: 'FOR' },
+        { kind: 14, label: 'IF NOT EXISTS FOR' },
+        { kind: 14, label: 'ON' },
       ],
     });
   });


### PR DESCRIPTION
When completing something that could have a symbolic name completion but there are none, there was a code path that returned undefined (surprised ts didn't catch this, we should harden the config). 

repro steps in image:
![CleanShot 2024-04-03 at 10 17 21@2x](https://github.com/neo4j/cypher-language-support/assets/10564538/92658b28-946a-4b4d-a82c-db1a12026908)
