### PR TITLE
Fixes outputs missing in turbo with the language-server

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,8 @@
       "dependsOn": [
         "@neo4j-cypher/language-support#build",
         "@neo4j-cypher/schema-poller#build"
-      ]
+      ],
+      "outputs": ["dist/**"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Because the `dist` output for the language-server is still missing if we clean and rebuild. If we override a `#build` project inside turbo, we need to also add the `outputs`