### PR TITLE
Speeds up build and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,10 +48,7 @@ jobs:
       - name: Install dependencies with frozen lock file and generate parser
         run: npm ci
 
-      - name: Build project
-        run: npm run build
-
-      - name: Run tests
+      - name: Builds and run tests
         # Tests with the same flags that VSCode does
         run: |
           npm test -- --filter=!antlr4 -- --passWithNoTests --testLocationInResults

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,6 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
+  preset: 'ts-jest/presets/default',
   testEnvironment: 'node',
   modulePathIgnorePatterns: ['out', 'e2e_tests', 'dist'],
 };

--- a/packages/language-support/tsconfig.json
+++ b/packages/language-support/tsconfig.json
@@ -4,7 +4,6 @@
   "exclude": ["**/semanticAnalysis.js"],
   "compilerOptions": {
     "outDir": "out",
-    "declaration": true,
-    "allowJs": true
+    "declaration": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "allowJs": true,
+    "allowJs": false,
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["dom", "ESNext"],


### PR DESCRIPTION
This makes `tsc` not care about the `semanticAnalysis.js` file when emitting type declarations, but it's still bundling it with `esbuild`

Before:
<img width="354"  src="https://github.com/neo4j/cypher-language-support/assets/5649971/7ddeb33f-a15a-487b-840d-e8f96c1d3929">

After:
<img width="350"   src="https://github.com/neo4j/cypher-language-support/assets/5649971/25103592-b8ea-424a-b7ba-4a47bf2f5c5a">


Also the semantic analysis tests run really fast now and the debugger works way way faster when setting up a debug point in the code.
