### PR TITLE
support signature help below as well

### DIFF
--- a/.changeset/chilled-dots-guess.md
+++ b/.changeset/chilled-dots-guess.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/react-codemirror": patch
+---
+
+allow signature help panel to render below editor when there's not enough space above it

--- a/packages/react-codemirror/src/lang-cypher/createCypherTheme.ts
+++ b/packages/react-codemirror/src/lang-cypher/createCypherTheme.ts
@@ -102,13 +102,13 @@ export const createCypherTheme = ({
     },
     '& .cm-signature-help-panel': {
       backgroundColor: settings.autoCompletionPanel.backgroundColor,
-      maxWidth: '700px',
       maxHeight: '250px',
+      maxWidth: '700px',
       fontFamily: 'Fira Code, Menlo, Monaco, Lucida Console, monospace',
     },
     '& .cm-signature-help-panel-contents': {
       overflow: 'auto',
-      maxHeight: '100%',
+      maxHeight: '250px',
     },
     '& .cm-signature-help-panel-current-argument': {
       color: settings.autoCompletionPanel.matchingTextColor,

--- a/packages/react-codemirror/src/lang-cypher/createCypherTheme.ts
+++ b/packages/react-codemirror/src/lang-cypher/createCypherTheme.ts
@@ -102,8 +102,8 @@ export const createCypherTheme = ({
     },
     '& .cm-signature-help-panel': {
       backgroundColor: settings.autoCompletionPanel.backgroundColor,
-      maxHeight: '250px',
       maxWidth: '700px',
+      maxHeight: '250px',
       fontFamily: 'Fira Code, Menlo, Monaco, Lucida Console, monospace',
     },
     '& .cm-signature-help-panel-contents': {

--- a/packages/react-codemirror/src/lang-cypher/signatureHelp.ts
+++ b/packages/react-codemirror/src/lang-cypher/signatureHelp.ts
@@ -105,7 +105,6 @@ function getSignatureHelpTooltip(
           {
             pos: caretPosition,
             above: true,
-            strictSide: true,
             arrow: true,
             create: createSignatureHelpElement({ signature, activeParameter }),
           },


### PR DESCRIPTION
This change let's the signature help appear below the editor if there's not enough space to render it above. I'm not 100% certain why, when the tooltip rendered below it started overflowing again unless I set the max height directly. 