### PR TITLE
Fixes bug with signature help of functions nested inside procedures

### DIFF
--- a/.changeset/gentle-pans-rescue.md
+++ b/.changeset/gentle-pans-rescue.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes bug in signature help of functions nested inside procedure calls

--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -70,7 +70,7 @@ class SignatureHelper extends CypherCmdParserListener {
     super();
   }
 
-  exitExpression = (ctx: ExpressionContext) => {
+  enterExpression = (ctx: ExpressionContext) => {
     // If the caret is at (
     if (this.caretToken.type === CypherParser.LPAREN) {
       /* We need to compute the next token that is not 
@@ -106,7 +106,7 @@ class SignatureHelper extends CypherCmdParserListener {
     }
   };
 
-  exitFunctionInvocation = (ctx: FunctionInvocationContext) => {
+  enterFunctionInvocation = (ctx: FunctionInvocationContext) => {
     if (
       ctx.start.start <= this.caretToken.start &&
       this.caretToken.stop <= ctx.stop.stop &&
@@ -127,7 +127,7 @@ class SignatureHelper extends CypherCmdParserListener {
     }
   };
 
-  exitCallClause = (ctx: CallClauseContext) => {
+  enterCallClause = (ctx: CallClauseContext) => {
     if (
       ctx.start.start <= this.caretToken.start &&
       this.caretToken.stop <= ctx.stop.stop &&

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -389,4 +389,12 @@ describe('Functions signature help', () => {
     testSignatureHelp(`CALL apoc.do.when`, undefined, emptyResult);
     testSignatureHelp(`CALL apoc.do.when`, {}, emptyResult);
   });
+
+  test('Provides signature help for functions inside procedures', () => {
+    testSignatureHelp(
+      'CALL apoc.do.when(apoc.coll.combinations(',
+      dbSchema,
+      expectedArgIndex(0),
+    );
+  });
 });

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -390,11 +390,19 @@ describe('Functions signature help', () => {
     testSignatureHelp(`CALL apoc.do.when`, {}, emptyResult);
   });
 
-  test('Provides signature help for functions inside procedures', () => {
+  test('Provides signature help for functions inside procedures, first argument', () => {
     testSignatureHelp(
       'CALL apoc.do.when(apoc.coll.combinations(',
       dbSchema,
       expectedArgIndex(0),
+    );
+  });
+
+  test('Provides signature help for functions inside procedures, second argument', () => {
+    testSignatureHelp(
+      'CALL apoc.do.when(apoc.coll.combinations(coll,',
+      dbSchema,
+      expectedArgIndex(1),
     );
   });
 });

--- a/packages/language-support/src/tests/signatureHelp.test.ts
+++ b/packages/language-support/src/tests/signatureHelp.test.ts
@@ -218,6 +218,14 @@ describe('Procedures signature help', () => {
     testSignatureHelp(`CALL apoc.do.when`, undefined, emptyResult);
     testSignatureHelp(`CALL apoc.do.when`, {}, emptyResult);
   });
+
+  test('Provides signature help for procedures when another argument is a function', () => {
+    testSignatureHelp(
+      'CALL apoc.do.when(apoc.coll.combinations(coll, something), ',
+      dbSchema,
+      expectedArgIndex(1),
+    );
+  });
 });
 
 describe('Functions signature help', () => {


### PR DESCRIPTION
## What

Fixes bug with showing wrong signature help of a function nested inside a procedure `CALL`.
![](https://github.com/neo4j/cypher-language-support/assets/5649971/71f441c2-e9b2-427a-997f-df0c34adab1b)


## How

We were setting the signature help on exiting contexts. That means if we had a `CALL procedure(function(` we were exiting the procedure context last, setting the signature help to the procedure where the caret is contained.

Instead it suffices with the setting the signature help when entering a context.