### PR TITLE
Wires internal feature flags

### DIFF
--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -21,7 +21,7 @@ import {
 
 import { ParsedStatement } from '../parserWrapper';
 
-import { consoleCommandEnabled } from '../parserWrapper';
+import { _internalFeatureFlags } from '../featureFlags';
 
 const uniq = <T>(arr: T[]) => Array.from(new Set(arr));
 
@@ -346,7 +346,7 @@ export function completionCoreCompletion(
 
     // Either enable the helper rules for lexer clashes,
     // or collect all console commands like below with symbolicNameString
-    ...(consoleCommandEnabled()
+    ...(_internalFeatureFlags.consoleCommands
       ? [
           CypherParser.RULE_useCompletionRule,
           CypherParser.RULE_listCompletionRule,

--- a/packages/language-support/src/featureFlags.ts
+++ b/packages/language-support/src/featureFlags.ts
@@ -1,0 +1,14 @@
+interface FeatureFlags {
+  consoleCommands: boolean;
+}
+
+export const _internalFeatureFlags: FeatureFlags = {
+  /* 
+  Because the parserWrapper is done as a single-ton global variable, the setting for 
+  console commands was also easiest to do as a global variable as it avoid messing with the cache
+
+  It would make sense for the client to initialize and own the ParserWrapper, then each editor can have
+  it's own cache and preference on if console commands are enabled or not.
+  */
+  consoleCommands: false,
+};

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -1,13 +1,10 @@
 export type { ParserRuleContext } from 'antlr4';
 export { autocomplete } from './autocompletion/autocompletion';
 export type { DbSchema } from './dbSchema';
+export { _internalFeatureFlags } from './featureFlags';
 export { antlrUtils } from './helpers';
 export { CypherTokenType, lexerSymbols } from './lexerSymbols';
-export {
-  parse,
-  parserWrapper,
-  setConsoleCommandsEnabled,
-} from './parserWrapper';
+export { parse, parserWrapper } from './parserWrapper';
 export { signatureHelp, toSignatureInformation } from './signatureHelp';
 export {
   applySyntaxColouring,
@@ -24,6 +21,5 @@ export type { SyntaxDiagnostic } from './syntaxValidation/syntaxValidationHelper
 export { testData } from './tests/testData';
 export type { Neo4jFunction, Neo4jProcedure } from './types';
 export { CypherLexer, CypherParser };
-
 import CypherLexer from './generated-parser/CypherCmdLexer';
 import CypherParser from './generated-parser/CypherCmdParser';

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -4,6 +4,7 @@ import { CharStreams, CommonTokenStream, ParseTreeListener } from 'antlr4';
 import CypherLexer from './generated-parser/CypherCmdLexer';
 
 import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
+import { _internalFeatureFlags } from './featureFlags';
 import {
   ClauseContext,
   default as CypherParser,
@@ -145,7 +146,7 @@ export function createParsingResult(query: string): ParsingResult {
       const diagnostics = isEmptyStatement ? [] : errorListener.errors;
       const collectedCommand = parseToCommand(ctx, isEmptyStatement);
 
-      if (!consoleCommandEnabled()) {
+      if (!_internalFeatureFlags.consoleCommands) {
         diagnostics.push(...errorOnNonCypherCommands(collectedCommand));
       }
 
@@ -440,22 +441,6 @@ class ParserWrapper {
   clearCache() {
     this.parsingResult = undefined;
   }
-}
-
-/* 
- Because the parserWrapper is done as a single-ton global variable, the setting for 
- console commands was also easiest to do as a global variable as it avoid messing with the cache
-
-It would make sense for the client to initialize and own the ParserWrapper, then each editor can have
-it's own cache and preference on if console commands are enabled or not.
-
-*/
-let enableConsoleCommands = false;
-export function setConsoleCommandsEnabled(enabled: boolean) {
-  enableConsoleCommands = enabled;
-}
-export function consoleCommandEnabled() {
-  return enableConsoleCommands;
 }
 
 export const parserWrapper = new ParserWrapper();

--- a/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
+++ b/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
@@ -2,6 +2,7 @@ import { Token } from 'antlr4';
 import type { ParserRuleContext } from 'antlr4-c3';
 import { CodeCompletionCore } from 'antlr4-c3';
 import { distance } from 'fastest-levenshtein';
+import { _internalFeatureFlags } from '../featureFlags';
 import CypherLexer from '../generated-parser/CypherCmdLexer';
 import CypherParser from '../generated-parser/CypherCmdParser';
 import {
@@ -10,7 +11,6 @@ import {
   lexerSymbols,
   tokenNames,
 } from '../lexerSymbols';
-import { consoleCommandEnabled } from '../parserWrapper';
 
 /*
 We ask for 0.7 similarity (number between 0 and 1) for 
@@ -46,7 +46,7 @@ export function completionCoreErrormessage(
     [CypherParser.RULE_symbolicAliasName]: 'a database name',
     // Either enable the helper rules for lexer clashes,
     // or collect all console commands like below with symbolicNameString
-    ...(consoleCommandEnabled()
+    ...(_internalFeatureFlags.consoleCommands
       ? {
           [CypherParser.RULE_useCompletionRule]: 'use',
           [CypherParser.RULE_listCompletionRule]: 'list',

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -1,9 +1,6 @@
 import { autocomplete } from '../autocompletion/autocompletion';
-import {
-  ParsedCommandNoPosition,
-  parserWrapper,
-  setConsoleCommandsEnabled,
-} from '../parserWrapper';
+import { _internalFeatureFlags } from '../featureFlags';
+import { ParsedCommandNoPosition, parserWrapper } from '../parserWrapper';
 import { applySyntaxColouring } from '../syntaxColouring/syntaxColouring';
 import { testData } from './testData';
 
@@ -40,10 +37,10 @@ function expectErrorMessage(query: string, msg: string) {
 
 describe('sanity checks', () => {
   beforeAll(() => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
   });
   afterAll(() => {
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
 
   test('parses simple commands without args ', () => {
@@ -145,10 +142,10 @@ describe('sanity checks', () => {
 
 describe(':use', () => {
   beforeAll(() => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
   });
   afterAll(() => {
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
   test('parses without arg', () => {
     expectParsedCommands(':use', [{ type: 'use' }]);
@@ -211,10 +208,10 @@ describe(':use', () => {
 
 describe('parameters', () => {
   beforeAll(() => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
   });
   afterAll(() => {
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
   test('basic param usage', () => {
     expectParsedCommands(':param', [{ type: 'list-parameters' }]);
@@ -447,10 +444,10 @@ describe('parameters', () => {
 
 describe('command parser also handles cypher', () => {
   beforeAll(() => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
   });
   afterAll(() => {
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
   test('parses cypher', () => {
     expectParsedCommands('MATCH (n) RETURN n', [

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -1,4 +1,4 @@
-import { setConsoleCommandsEnabled } from '../../parserWrapper';
+import { _internalFeatureFlags } from '../../featureFlags';
 import { testData } from '../testData';
 import { getDiagnosticsForQuery } from './helpers';
 
@@ -1252,7 +1252,8 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
   });
 
   test('gives error on console commands when they are disabled', () => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
+
     expect(
       getDiagnosticsForQuery({ query: 'RETURN a;:clear; RETURN b;:history;' }),
     ).toEqual([
@@ -1293,11 +1294,11 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         severity: 1,
       },
     ]);
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
 
   test('Handles multiple cypher statements in a single query', () => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
     expect(getDiagnosticsForQuery({ query: 'RETURN a; RETURN b;' })).toEqual([
       {
         message: 'Variable `a` not defined',
@@ -1336,11 +1337,11 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         severity: 1,
       },
     ]);
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
 
   test('Handles cypher mixed with client commands', () => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
     expect(
       getDiagnosticsForQuery({
         query: ':clear;RETURN a;:clear; RETURN b;:history;',
@@ -1383,11 +1384,11 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         severity: 1,
       },
     ]);
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
 
   test('Handles cypher mixed with complex client command', () => {
-    setConsoleCommandsEnabled(true);
+    _internalFeatureFlags.consoleCommands = true;
     expect(
       getDiagnosticsForQuery({
         query: `
@@ -1418,7 +1419,7 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         severity: 1,
       },
     ]);
-    setConsoleCommandsEnabled(false);
+    _internalFeatureFlags.consoleCommands = false;
   });
 
   test('Does not provide semantic validation for pluggeable functions when schema is not available', () => {

--- a/packages/react-codemirror/src/index.ts
+++ b/packages/react-codemirror/src/index.ts
@@ -1,4 +1,7 @@
-export { CypherParser } from '@neo4j-cypher/language-support';
+export {
+  CypherParser,
+  _internalFeatureFlags,
+} from '@neo4j-cypher/language-support';
 export { CypherEditor } from './CypherEditor';
 export { cypher } from './lang-cypher/langCypher';
 export { darkThemeConstants, lightThemeConstants } from './themes';

--- a/packages/react-codemirror/src/lang-cypher/langCypher.ts
+++ b/packages/react-codemirror/src/lang-cypher/langCypher.ts
@@ -4,7 +4,7 @@ import {
   LanguageSupport,
 } from '@codemirror/language';
 import {
-  setConsoleCommandsEnabled,
+  _internalFeatureFlags,
   type DbSchema,
 } from '@neo4j-cypher/language-support';
 import { cypherAutocomplete } from './autocomplete';
@@ -25,7 +25,7 @@ export type CypherConfig = {
 };
 
 export function cypher(config: CypherConfig) {
-  setConsoleCommandsEnabled(true);
+  _internalFeatureFlags.consoleCommands = true;
   const parserAdapter = new ParserAdapter(facet, config);
 
   const cypherLanguage = new Language(facet, parserAdapter, [], 'cypher');


### PR DESCRIPTION
* Exposes `_internalFeatureFlags` in both the `language-support` and the `react-codemirror` package for internal consumption.
* Makes the old `enableConsoleCommands` into the first feature flag.
