### PR TITLE
Fixes bug in yaml files for the VSCode publish job

### DIFF
--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -3,7 +3,7 @@ name: Publish VSCode extension to Marketplace and OpenVSX
 on:
   push:
     tags:
-      - "neo4j-for-vscode@*.*.*"
+      - 'neo4j-for-vscode@*.*.*'
 
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'
@@ -32,15 +32,13 @@ jobs:
 
       - name: Publish to VSCode Marketplace
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           cd packages/vscode-extension
           npx vsce package
           npx vsce publish
-      
+
       - name: Publish to OpenVSX
         env:
-          VSX_PAT: ${{ secrets.VSX_PAT }}: 
+          VSX_PAT: ${{ secrets.VSX_PAT }}
         run: npx ovsx publish -p $VSX_PAT
-
- 


### PR DESCRIPTION
Because there was a minor bug in that file:

<img width="500" alt="Screenshot 2024-05-21 at 19 04 48" src="https://github.com/neo4j/cypher-language-support/assets/5649971/c6075483-e5a5-47fa-97e2-a49c9f0a50ec">
