### PR TITLE
Add an ariaLabel prop to CypherEditor

### DIFF
--- a/.changeset/curvy-singers-greet.md
+++ b/.changeset/curvy-singers-greet.md
@@ -1,0 +1,6 @@
+---
+"@neo4j-cypher/react-codemirror-playground": patch
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Add an ariaLabel prop to CypherEditor

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -109,6 +109,7 @@ export function App() {
               theme={darkMode ? 'dark' : 'light'}
               history={Object.values(demos)}
               schema={schema}
+              ariaLabel="Cypher Editor"
             />
 
             {commandRanCount > 0 && (

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -138,7 +138,6 @@ export interface CypherEditorProps {
 
   /**
    * String value to assign to the aria-label attribute of the editor
-   *
    */
   ariaLabel?: string;
 }

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -135,6 +135,12 @@ export interface CypherEditorProps {
    * @default false
    */
   readonly?: boolean;
+
+  /**
+   * String value to assign to the aria-label attribute of the editor
+   *
+   */
+  ariaLabel?: string;
 }
 
 const executeKeybinding = (onExecute?: (cmd: string) => void) =>
@@ -311,6 +317,11 @@ export class CypherEditor extends Component<
             ? EditorView.domEventHandlers(this.props.domEventHandlers)
             : [],
         ),
+        this.props.ariaLabel
+          ? EditorView.contentAttributes.of({
+              'aria-label': this.props.ariaLabel,
+            })
+          : [],
       ],
       doc: this.props.value,
     });

--- a/packages/react-codemirror/src/e2e_tests/configuration.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/configuration.spec.tsx
@@ -100,10 +100,7 @@ test('aria-label is not set by default', async ({ mount, page }) => {
   await mount(<CypherEditor />);
 
   const textField = page.getByRole('textbox');
-
-  await expect(async () => {
-    expect(await textField.getAttribute('aria-label')).toBeNull();
-  }).toPass();
+  expect(await textField.getAttribute('aria-label')).toBeNull();
 });
 
 test('can set aria-label', async ({ mount, page }) => {
@@ -112,8 +109,5 @@ test('can set aria-label', async ({ mount, page }) => {
   await mount(<CypherEditor ariaLabel={ariaLabel} />);
 
   const textField = page.getByRole('textbox');
-
-  await expect(async () => {
-    expect(await textField.getAttribute('aria-label')).toEqual(ariaLabel);
-  }).toPass();
+  expect(await textField.getAttribute('aria-label')).toEqual(ariaLabel);
 });

--- a/packages/react-codemirror/src/e2e_tests/configuration.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/configuration.spec.tsx
@@ -95,3 +95,25 @@ test('can set/unset onFocus/onBlur', async ({ mount, page }) => {
     expect(blurFireCount).toBe(1);
   }).toPass();
 });
+
+test('aria-label is not set by default', async ({ mount, page }) => {
+  await mount(<CypherEditor />);
+
+  const textField = page.getByRole('textbox');
+
+  await expect(async () => {
+    expect(await textField.getAttribute('aria-label')).toBeNull();
+  }).toPass();
+});
+
+test('can set aria-label', async ({ mount, page }) => {
+  const ariaLabel = 'Cypher Editor';
+
+  await mount(<CypherEditor ariaLabel={ariaLabel} />);
+
+  const textField = page.getByRole('textbox');
+
+  await expect(async () => {
+    expect(await textField.getAttribute('aria-label')).toEqual(ariaLabel);
+  }).toPass();
+});


### PR DESCRIPTION
Adding an 'ariaLabel' prop to the CyperEditor props so that we can set an aria-label attribute on the codemirror editor.

This uses the [contentAttributes](https://codemirror.net/docs/ref/#view.EditorView^contentAttributes) facet, which may be extended later to add more DOM attributes, or changed to accept a kvp/Record so that DOM attributes may be fully flexible.

with the `ariaLabel` property set, we can see the attribute set in the playground:

![Screenshot 2024-05-22 at 12 23 52](https://github.com/neo4j/cypher-language-support/assets/4467057/4894f846-5102-4445-8e61-0ea5ba653179)


The property is optional, so not setting it should result in the aria-label attribute not being added to the editor:
![Screenshot 2024-05-22 at 12 24 19](https://github.com/neo4j/cypher-language-support/assets/4467057/7c82a180-7fab-4494-863e-a50a63544df1)


