### PR TITLE
Fixes bug with canary release script

### DIFF
--- a/release-canary.js
+++ b/release-canary.js
@@ -71,7 +71,7 @@ function buildProject() {
   exec(`
     cd ${wd} &&
     npm i &&
-    npm run build
+    npm run build -- --filter=react-codemirror --filter=language-support
   `);
 }
 


### PR DESCRIPTION
Builds only `language-support` and `react-codemirror` when releasing canary packages.

## Why

Because when we merged #216 the process to release to canary started to fail. That is because a new prop was added to `react-codemirror`, and the script does not update the package.json of `react-codemirror-playground` package that depends on it, so it was failing on build.

Building only the packages we intend to publish to npm as canary releases solves the issue.