### PR TITLE
Adjusts VSCode extension GitHub Actions job

### DIFF
--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -42,4 +42,6 @@ jobs:
       - name: Publish to OpenVSX
         env:
           VSX_PAT: ${{ secrets.VSX_PAT }}
-        run: npx ovsx publish -p $VSX_PAT
+        run: |
+          cd packages/vscode-extension
+          npx ovsx publish -p $VSX_PAT

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neo4j-cypher/vscode-extension
 
+## 1.2.1
+
+### Patch changes
+
+- Fixes logo in VSCode Marketplace
+
 ## 1.2.0
 
 - Adds basic connection pane to connect to Neo4j using VSCode menus

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "neo4j-extensions",
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "preview": true,
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
I've published the new version v1.2.1 manually so that the icon doesn't stay broken for the weekend.

## Marketplace changes
Checks out the repo with git lfs in the release job. Because the logo of the extension wasn't being packaged correctly:

<img width="689" src="https://github.com/neo4j/cypher-language-support/assets/5649971/67cbf281-0569-401e-a8bf-00bc986045d6">

## Ovsx changes
We were failing in the publish job with:

```
Run npx ovsx publish -p $VSX_PAT
  npx ovsx publish -p $VSX_PAT
  shell: /usr/bin/bash -e {0}
  env:
    NODE_OPTIONS: --max_old_space_size=[4](https://github.com/neo4j/cypher-language-support/actions/runs/9598143476/job/26468739762#step:8:4)096
    VSX_PAT: ***
  
❌  Missing required field 'publisher'.
See the documentation for more information:
https://github.com/eclipse/openvsx/wiki/Publishing-Extensions
Error: Process completed with exit code 1.
```

Unfortunately OVSX seems to be [flakey](https://github.com/eclipse/openvsx/issues/945) at the moment so I'll retry to publish the v1.2.0 there on Monday