### PR TITLE
Reverts path of images to get icon in VSCode Marketplace

### DIFF
--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - uses: actions/setup-node@v3
         with:

--- a/feedback.md
+++ b/feedback.md
@@ -1,0 +1,6 @@
+Some feedback:
+
+- When we try to connect with wrong credentials, we are left in the reconnecting state, which. is not ideal. Is there any way we can distinguish wrong credentials from losing a connection?
+- It would be good to write better error messages for the users. For example this one is for wrong url, which is not very helpful?
+
+![](</Users/ncordon/Desktop/Screenshot\ 2024-06-10\ at\ 16.12.23.png>)

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neo4j-cypher/vscode-extension
 
+## 1.2.1
+
+### Patch changes
+
+- Fixes logo in VSCode Marketplace
+
 ## 1.2.0
 
 - Adds basic connection pane to connect to Neo4j using VSCode menus

--- a/packages/vscode-extension/e2e_tests/fixtures/.vscode/settings.json
+++ b/packages/vscode-extension/e2e_tests/fixtures/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "neo4j.connect": true,
+  "neo4j.password": "password",
+  "neo4j.connectURL": "neo4j://localhost:55007",
+  "neo4j.user": "neo4j",
+  "neo4j.trace.server": "off"
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "neo4j-extensions",
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "preview": true,
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
## Why

Because I think this has broken the logo of our extension:

<img width="689" src="https://github.com/neo4j/cypher-language-support/assets/5649971/67cbf281-0569-401e-a8bf-00bc986045d6">
