### PR TITLE
Improve debug-ability of vscode extension

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,4 +10,5 @@ packages/language-support/src/highlighting/semanticAnalysis.js
 .eslintrc.js
 vendor/*
 packages/vscode-extension/genTextMate.js
+packages/vscode-extension/esbuild.js
 release-canary.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,24 @@
       "autoAttachChildProcesses": true,
       "sourceMaps": true,
       "preLaunchTask": "npm: build-vscode"
+    },
+    {
+      "type": "extensionHost",
+      "request": "launch",
+      "name": "Debug VSCode Tests",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension",
+        "--extensionTestsPath=${workspaceRoot}/packages/vscode-extension/dist/e2e_tests/testRunner"
+      ],
+      "outFiles": [
+        "${workspaceRoot}/packages/vscode-extension/**/*.js",
+        "${workspaceRoot}/packages/language-support/**/*.js",
+        "${workspaceRoot}/packages/schema-poller/**/*.js"
+      ],
+      "autoAttachChildProcesses": true,
+      "sourceMaps": true,
+      "preLaunchTask": "npm: build-vscode"
     }
   ],
   "type": "pwa-node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
       "outFiles": [
         "${workspaceRoot}/packages/vscode-extension/**/*.js",
         "${workspaceRoot}/packages/language-support/**/*.js",
-        "${workspaceRoot}/packages/schema-poller/**/*.js"
+        "${workspaceRoot}/packages/schema-poller/**/*.js",
+        "${workspaceRoot}/packages/language-server/**/*.js"
       ],
       "autoAttachChildProcesses": true,
       "sourceMaps": true,
@@ -38,7 +39,8 @@
       "outFiles": [
         "${workspaceRoot}/packages/vscode-extension/**/*.js",
         "${workspaceRoot}/packages/language-support/**/*.js",
-        "${workspaceRoot}/packages/schema-poller/**/*.js"
+        "${workspaceRoot}/packages/schema-poller/**/*.js",
+        "${workspaceRoot}/packages/language-server/**/*.js"
       ],
       "autoAttachChildProcesses": true,
       "sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension",
-        "--extensionTestsPath=${workspaceRoot}/packages/vscode-extension/dist/e2e_tests/testRunner"
+        "--extensionTestsPath=${workspaceRoot}/packages/vscode-extension/dist/e2e_tests/testRunnerDebug"
       ],
       "outFiles": [
         "${workspaceRoot}/packages/vscode-extension/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21862,7 +21862,7 @@
     },
     "packages/vscode-extension": {
       "name": "neo4j-for-vscode",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@neo4j-cypher/language-server": "2.0.0-next.7",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepare": "husky install",
     "build": "turbo run build",
-    "build-vscode": "turbo run build --filter=neo4j-for-vscode",
+    "build-vscode": "turbo run build neo4j-for-vscode#build:dev --filter !neo4j-for-vscode",
     "release": "turbo run build && npx changeset publish",
     "clean": "turbo run clean",
     "watch": "turbowatch ./turbowatch.ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepare": "husky install",
     "build": "turbo run build",
-    "build-vscode": "turbo run build neo4j-for-vscode#build:dev --filter !neo4j-for-vscode",
+    "build-vscode": "turbo run neo4j-for-vscode#build:dev",
     "release": "turbo run build && npx changeset publish",
     "clean": "turbo run clean",
     "watch": "turbowatch ./turbowatch.ts",

--- a/packages/vscode-extension/e2e_tests/helpers.ts
+++ b/packages/vscode-extension/e2e_tests/helpers.ts
@@ -72,3 +72,14 @@ export function getMockConnection(connect: boolean = false): Connection {
     port: '7687',
   };
 }
+
+export function getNeo4jConfiguration() {
+  return {
+    scheme: process.env.NEO4J_SCHEME || 'neo4j',
+    host: process.env.NEO4J_HOST || 'localhost',
+    port: process.env.NEO4J_PORT || '7687',
+    user: process.env.NEO4J_USER || 'neo4j',
+    database: process.env.NEO4J_DATABASE || 'neo4j',
+    password: process.env.NEO4J_PASSWORD || 'password',
+  };
+}

--- a/packages/vscode-extension/e2e_tests/main.ts
+++ b/packages/vscode-extension/e2e_tests/main.ts
@@ -1,43 +1,9 @@
-import { Neo4jContainer } from '@testcontainers/neo4j';
 import { runTests } from '@vscode/test-electron';
-import dotenv from 'dotenv';
-import * as fs from 'fs';
 import * as path from 'path';
-
-function setSetting(file: string, variable: RegExp, value: string) {
-  const data = fs.readFileSync(file).toString();
-  const result = data.replace(variable, value);
-  fs.writeFileSync(file, result);
-}
-
-function updateDotenvFile(port: number, password: string) {
-  const dotenvPath = path.join(__dirname, '../../e2e_tests/fixtures/');
-  const dotenvTemplate = path.join(dotenvPath, '.env');
-  const dotenvFile = path.join(dotenvPath, '.env.test');
-  fs.copyFileSync(dotenvTemplate, dotenvFile);
-  setSetting(dotenvFile, /\{PORT\}/g, port.toString());
-  setSetting(dotenvFile, /\{PASSWORD\}/g, password);
-  dotenv.config({ path: dotenvFile });
-}
+import { createAndStartTestContainer } from './setupTestContainer';
 
 async function main() {
-  const password = 'password';
-
-  const container = await new Neo4jContainer('neo4j:5-enterprise')
-    .withExposedPorts(7474, 7687)
-    .withApoc()
-    .withPassword(password)
-    .withEnvironment({ NEO4J_ACCEPT_LICENSE_AGREEMENT: 'yes' })
-    // Giving it a name prevents us from spinning up a different
-    // container every time we run the tests and allows us
-    // closing a lingering one when the tests finish
-    .withName('vscode-integration-tests')
-    .start();
-
-  const port = container.getMappedPort(7687);
-  // This sets up a settings.json file based on the settings-template.json
-  // replacing the random port and password we have given the container
-  updateDotenvFile(port, password);
+  const container = await createAndStartTestContainer();
 
   try {
     /* This is equivalent to running from a command line: 
@@ -64,9 +30,9 @@ async function main() {
   } catch (err) {
     console.error('Failed to run integration tests');
     process.exit(1);
+  } finally {
+    await container.stop();
   }
-
-  await container.stop();
 }
 
 void main();

--- a/packages/vscode-extension/e2e_tests/setupTestContainer.ts
+++ b/packages/vscode-extension/e2e_tests/setupTestContainer.ts
@@ -1,0 +1,41 @@
+import { Neo4jContainer, StartedNeo4jContainer } from '@testcontainers/neo4j';
+import dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export async function createAndStartTestContainer(): Promise<StartedNeo4jContainer> {
+  const password = 'password';
+  const container = await new Neo4jContainer('neo4j:5-enterprise')
+    .withExposedPorts(7474, 7687)
+    .withApoc()
+    .withPassword(password)
+    .withEnvironment({ NEO4J_ACCEPT_LICENSE_AGREEMENT: 'yes' })
+    // Giving it a name prevents us from spinning up a different
+    // container every time we run the tests and allows us
+    // closing a lingering one when the tests finish
+    .withName('vscode-integration-tests')
+    .start();
+
+  const port = container.getMappedPort(7687);
+  // This sets up a settings.json file based on the settings-template.json
+  // replacing the random port and password we have given the container
+  updateDotenvFile(port, password);
+
+  return container;
+}
+
+function setSetting(file: string, variable: RegExp, value: string) {
+  const data = fs.readFileSync(file).toString();
+  const result = data.replace(variable, value);
+  fs.writeFileSync(file, result);
+}
+
+function updateDotenvFile(port: number, password: string) {
+  const dotenvPath = path.join(__dirname, '../../e2e_tests/fixtures/');
+  const dotenvTemplate = path.join(dotenvPath, '.env');
+  const dotenvFile = path.join(dotenvPath, '.env.test');
+  fs.copyFileSync(dotenvTemplate, dotenvFile);
+  setSetting(dotenvFile, /\{PORT\}/g, port.toString());
+  setSetting(dotenvFile, /\{PASSWORD\}/g, password);
+  dotenv.config({ path: dotenvFile });
+}

--- a/packages/vscode-extension/e2e_tests/suiteSetup.ts
+++ b/packages/vscode-extension/e2e_tests/suiteSetup.ts
@@ -1,31 +1,38 @@
 import neo4j from 'neo4j-driver';
 import * as vscode from 'vscode';
 import { constants } from '../src/constants';
+import { getNeo4jConfiguration } from './helpers';
+
+export const testDatabaseKey = 'default-test-connection';
 
 export async function createConnection(): Promise<void> {
+  const { scheme, host, port, user, database, password } =
+    getNeo4jConfiguration();
   await vscode.commands.executeCommand(
     constants.COMMANDS.SAVE_CONNECTION_COMMAND,
     {
-      name: 'test',
-      key: 'test',
-      scheme: process.env.NEO4J_SCHEME || 'neo4j',
-      host: process.env.NEO4J_HOST || 'localhost',
-      port: process.env.NEO4J_PORT || '7687',
-      user: process.env.NEO4J_USER || 'neo4j',
-      database: process.env.NEO4J_DATABASE || 'neo4j',
+      name: testDatabaseKey,
+      key: testDatabaseKey,
+      scheme: scheme,
+      host: host,
+      port: port,
+      user: user,
+      database: database,
       connect: true,
     },
-    process.env.NEO4J_PASSWORD || 'password',
+    password,
   );
 }
 
 export async function createTestDatabase(): Promise<void> {
-  const url = `${process.env.NEO4J_SCHEME}://${process.env.NEO4J_HOST}:${process.env.NEO4J_PORT}`;
+  const { scheme, host, port, user, password } = getNeo4jConfiguration();
 
   const driver = neo4j.driver(
-    url,
-    neo4j.auth.basic(process.env.NEO4J_USER, process.env.NEO4J_PASSWORD),
-    { userAgent: 'vscode-e2e-tests' },
+    `${scheme}://${host}:${port}`,
+    neo4j.auth.basic(user, password),
+    {
+      userAgent: 'vscode-e2e-tests',
+    },
   );
 
   const systemSession = driver.session({ database: 'system' });

--- a/packages/vscode-extension/e2e_tests/testRunnerDebug.ts
+++ b/packages/vscode-extension/e2e_tests/testRunnerDebug.ts
@@ -1,0 +1,7 @@
+import { createAndStartTestContainer } from './setupTestContainer';
+import { run as testRunner } from './testRunner';
+
+export async function run(): Promise<void> {
+  await createAndStartTestContainer();
+  return testRunner();
+}

--- a/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach } from 'mocha';
 import * as sinon from 'sinon';
 import { commands, MessageOptions, window } from 'vscode';
 import { constants } from '../../src/constants';
+import { getNeo4jConfiguration } from '../helpers';
 
 suite('Execute commands', () => {
   let sandbox: sinon.SinonSandbox;
@@ -18,16 +19,17 @@ suite('Execute commands', () => {
 
   suite('saveConnectionCommand', () => {
     test('Creating a valid connection should show a success message', async () => {
+      const { scheme, host, port, user, database } = getNeo4jConfiguration();
       await commands.executeCommand(
         constants.COMMANDS.SAVE_CONNECTION_COMMAND,
         {
           name: 'mock-connection-2',
           key: 'mock-key-2',
-          scheme: process.env.NEO4J_SCHEME || 'neo4j',
-          host: process.env.NEO4J_HOST || 'localhost',
-          port: process.env.NEO4J_PORT || '7687',
-          user: process.env.NEO4J_USER || 'neo4j',
-          database: process.env.NEO4J_DATABASE || 'neo4j',
+          scheme: scheme,
+          host: host,
+          port: port,
+          user: user,
+          database: database,
           connect: true,
         },
         process.env.NEO4J_PASSWORD || 'password',
@@ -41,16 +43,17 @@ suite('Execute commands', () => {
     });
 
     test('Updating a valid connection should show a success message', async () => {
+      const { scheme, host, port, user, database } = getNeo4jConfiguration();
       await commands.executeCommand(
         constants.COMMANDS.SAVE_CONNECTION_COMMAND,
         {
           name: 'mock-connection-2-update',
           key: 'mock-key-2',
-          scheme: process.env.NEO4J_SCHEME || 'neo4j',
-          host: process.env.NEO4J_HOST || 'localhost',
-          port: process.env.NEO4J_PORT || '7687',
-          user: process.env.NEO4J_USER || 'neo4j',
-          database: process.env.NEO4J_DATABASE || 'neo4j',
+          scheme: scheme,
+          host: host,
+          port: port,
+          user: user,
+          database: database,
           connect: true,
         },
         process.env.NEO4J_PASSWORD || 'password',

--- a/packages/vscode-extension/e2e_tests/tests/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/syntaxValidation.spec.ts
@@ -4,6 +4,7 @@ import { constants } from '../../src/constants';
 import {
   eventually,
   getDocumentUri,
+  getNeo4jConfiguration,
   newUntitledFileWithContent,
   openDocument,
 } from '../helpers';
@@ -148,13 +149,14 @@ suite('Syntax validation spec', () => {
   test('Correctly re-validates cypher when switching databases', async () => {
     const textFile = 'movies-syntax-validation.cypher';
     const docUri = getDocumentUri(textFile);
+    const { scheme, host, port, user } = getNeo4jConfiguration();
     const connection = {
       name: 'test',
       key: 'test',
-      scheme: process.env.NEO4J_SCHEME,
-      host: process.env.NEO4J_HOST,
-      port: process.env.NEO4J_PORT,
-      user: process.env.NEO4J_USER,
+      scheme: scheme,
+      host: host,
+      port: port,
+      user: user,
       database: 'movies',
       connect: true,
     };

--- a/packages/vscode-extension/esbuild.js
+++ b/packages/vscode-extension/esbuild.js
@@ -1,0 +1,25 @@
+const esbuild = require('esbuild');
+
+const production = process.argv.includes('--production');
+
+async function main() {
+  const ctx = await esbuild.context({
+    entryPoints: ['src/extension.ts'],
+    bundle: true,
+    format: 'cjs',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'node',
+    outfile: 'dist/extension.js',
+    external: ['vscode'],
+    logLevel: 'silent',
+  });
+  await ctx.rebuild();
+  await ctx.dispose();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -255,9 +255,11 @@
     "gen-textmate": "node ./genTextMate.js",
     "vscode:prepublish": "npm run build",
     "bundle-language-server": "cd ../language-server && npm run bundle && cp dist/cypher-language-server.js ../vscode-extension/dist/ && npm run bundle-worker && cp dist/lintWorker.js ../vscode-extension/dist/",
-    "bundle-extension": "esbuild ./src/extension.ts --bundle --external:vscode --format=cjs --platform=node --minify --outfile=dist/extension.js",
+    "bundle-extension": "node ./esbuild.js --production",
+    "bundle-extension:dev": "node ./esbuild.js",
     "bundle-webview-controller": "esbuild ./src/webviews/controllers/connectionPanelController.ts --bundle --outfile=dist/webviews/connectionPanelController.js --platform=browser",
     "build": "tsc -b && npm run gen-textmate && npm run bundle-extension && npm run bundle-language-server && npm run bundle-webview-controller",
+    "build:dev": "tsc -b && npm run gen-textmate && npm run bundle-extension:dev && npm run bundle-language-server && npm run bundle-webview-controller",
     "clean": "rm -rf dist",
     "test:e2e": "npm run build && rm -rf .vscode-test/user-data && node ./dist/e2e_tests/main.js"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,7 @@
     "neo4j-for-vscode#build:dev": {
       "outputs": [],
       "dependsOn": ["^build"],
+      "cache": false,
       "persistent": true
     },
     "benchmark": {

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,11 @@
       "dependsOn": ["^build"],
       "persistent": true
     },
+    "neo4j-for-vscode#build:dev": {
+      "outputs": [],
+      "dependsOn": ["^build"],
+      "persistent": true
+    },
     "benchmark": {
       "cache": false
     }


### PR DESCRIPTION
This PR improves the debug-ability of the vscode extension, both the e2e/unit tests and the extension itself.

I have extracted these changes out of the side panel PR.

- I am introducing an `esbuild.js` config file that only minifies if we pass a `--production` flag to it, and will otherwise produce a sourcemap for the extension
- I am adding some `dev` namespaced tasks in the extension package that will produce non-minified js and sourcemaps for the extension, which, both the vs code launch tasks will use
- I am adding a new launch task for debugging the extension tests
- I am modifying a few tests that use the `process.env` variables so that they don't fall over when debugging tests, though these are still dependent on you having an instance running locally