### PR TITLE
Fix bug causing debounced value to override value

### DIFF
--- a/.changeset/eleven-scissors-type.md
+++ b/.changeset/eleven-scissors-type.md
@@ -1,0 +1,6 @@
+---
+"@neo4j-cypher/react-codemirror-playground": patch
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Fix bug causing debouncing to override value

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -105,7 +105,10 @@ export function App() {
               value={value}
               onChange={setValue}
               prompt="neo4j$"
-              onExecute={() => setCommandRanCount((c) => c + 1)}
+              onExecute={() => {
+                setCommandRanCount((c) => c + 1);
+                setValue('');
+              }}
               theme={darkMode ? 'dark' : 'light'}
               history={Object.values(demos)}
               schema={schema}

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -425,6 +425,7 @@ export class CypherEditor extends Component<
     const currentCmValue = this.editorView.current.state?.doc.toString() ?? '';
 
     if (this.props.value !== undefined && currentCmValue !== this.props.value) {
+      this.debouncedOnChange?.cancel();
       this.editorView.current.dispatch({
         changes: {
           from: 0,


### PR DESCRIPTION
This PR fixes the issue outlined below.
> A side effect of typing and executing a query quickly is that it stick around in the editor, see video:
> https://github.com/user-attachments/assets/431bec1a-21ce-479c-a71e-9855e175af81
> 
> I think this might have been a problem before, but I feel it might be more noticeable with these changes. It looks like the debounced `onChange` event fires after the `execute` callback fires it's  `setCodemirrorVal('');`. 
> 
> I think the proper way to get around it is to cancel the debounced update if the `value` prop is externally set. I think this would do the trick: 
> ![CleanShot 2024-07-15 at 14 19 23@2x](https://github.com/user-attachments/assets/0f717aac-d438-4342-a952-5bbc9bdb6a76)

_Originally posted by @OskarDamkjaer in https://github.com/neo4j/upx/issues/2992#issuecomment-2228371035_
            