### PR TITLE
Listing databases for an active Connection

### DIFF
--- a/packages/schema-poller/src/index.ts
+++ b/packages/schema-poller/src/index.ts
@@ -1,4 +1,6 @@
 export { FRIENDLY_ERROR_MESSAGES } from './connectionErrorHandler';
 export type { ConnectionError } from './connectionErrorHandler';
+export type { Neo4jConnection } from './neo4jConnection';
+export type { Database } from './queries/databases';
 export { Neo4jSchemaPoller } from './schemaPoller';
 export type { ConnnectionResult } from './schemaPoller';

--- a/packages/schema-poller/src/neo4jConnection.ts
+++ b/packages/schema-poller/src/neo4jConnection.ts
@@ -33,7 +33,7 @@ export class Neo4jConnection {
   constructor(
     public connectedUser: string,
     public protocolVersion: string,
-    databases: Database[],
+    public databases: Database[],
     public driver: Driver,
     database?: string,
   ) {

--- a/packages/vscode-extension/e2e_tests/helpers.ts
+++ b/packages/vscode-extension/e2e_tests/helpers.ts
@@ -63,7 +63,6 @@ export async function eventually(
 export function getMockConnection(activate: boolean = false): Connection {
   return {
     key: getNonce(16),
-    name: 'mock-connection',
     database: 'neo4j',
     user: 'neo4j',
     host: 'localhost',

--- a/packages/vscode-extension/e2e_tests/mocks/mockSchemaPoller.ts
+++ b/packages/vscode-extension/e2e_tests/mocks/mockSchemaPoller.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ConnnectionResult } from '@neo4j-cypher/schema-poller';
+import {
+  ConnnectionResult,
+  Neo4jConnection,
+} from '@neo4j-cypher/schema-poller';
 import EventEmitter from 'events';
 import { Config } from 'neo4j-driver';
 
 export class MockSchemaPoller {
+  connection?: Neo4jConnection;
   events: EventEmitter = new EventEmitter();
 
   async connect(

--- a/packages/vscode-extension/e2e_tests/suiteSetup.ts
+++ b/packages/vscode-extension/e2e_tests/suiteSetup.ts
@@ -13,7 +13,6 @@ export async function saveDefaultConnection(): Promise<void> {
   await vscode.commands.executeCommand(
     CONSTANTS.COMMANDS.SAVE_CONNECTION_COMMAND,
     {
-      name: defaultConnectionKey,
       key: defaultConnectionKey,
       scheme: scheme,
       host: host,

--- a/packages/vscode-extension/e2e_tests/tests/connectionService.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/connectionService.spec.ts
@@ -767,7 +767,6 @@ suite('Connection service spec', () => {
         host: undefined,
         port: '7687',
         key: 'mock-key',
-        name: 'mock-connection',
         user: 'neo4j',
         state: 'inactive',
       });

--- a/packages/vscode-extension/e2e_tests/tests/connectionTreeDataProvider.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/connectionTreeDataProvider.spec.ts
@@ -1,0 +1,248 @@
+import { Database } from '@neo4j-cypher/schema-poller/dist/cjs/src/queries/databases';
+import * as assert from 'assert';
+import { afterEach, beforeEach } from 'mocha';
+import * as sinon from 'sinon';
+import { TreeItemCollapsibleState } from 'vscode';
+import * as connectionService from '../../src/connectionService';
+import { Connection } from '../../src/connectionService';
+import {
+  ConnectionItem,
+  ConnectionTreeDataProvider,
+} from '../../src/connectionTreeDataProvider';
+
+suite('Connection tree data provider spec', () => {
+  const mockConnections: Connection[] = [
+    {
+      key: 'test-connection',
+      state: 'active',
+      host: 'localhost',
+      scheme: 'neo4j',
+      user: 'neo4j',
+    },
+    {
+      key: 'test-connection-2',
+      state: 'active',
+      host: 'localhost',
+      scheme: 'neo4j',
+      user: 'neo4j',
+      database: 'schemas',
+    },
+    {
+      key: 'test-connection-3',
+      state: 'inactive',
+      host: 'localhost',
+      scheme: 'neo4j',
+      user: 'neo4j',
+      port: '7687',
+    },
+    {
+      key: 'test-connection-4',
+      state: 'activating',
+      host: 'localhost',
+      scheme: 'neo4j',
+      user: 'neo4j',
+    },
+    {
+      key: 'test-connection-5',
+      state: 'error',
+      host: 'localhost',
+      scheme: 'neo4j',
+      user: 'neo4j',
+    },
+  ];
+
+  const mockDatabases: Partial<Database>[] = [
+    { name: 'neo4j', home: true, default: true },
+    { name: 'schemas', home: false },
+  ];
+
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    sandbox
+      .stub(connectionService, 'getAllConnections')
+      .returns(mockConnections);
+
+    sandbox
+      .stub(connectionService, 'getConnectionByKey')
+      .callsFake((key: string) => {
+        return mockConnections.find((connection) => connection.key === key);
+      });
+
+    sandbox
+      .stub(connectionService, 'getConnectionDatabases')
+      .returns(mockDatabases as Database[]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  test('An active Connection should show as connected', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+
+    const actual = children.find((child) => child.key === 'test-connection');
+    const expected: ConnectionItem = {
+      collapsibleState: TreeItemCollapsibleState.Collapsed,
+      contextValue: 'activeConnection',
+      description: 'connected',
+      id: 'test-connection',
+      key: 'test-connection',
+      label: 'neo4j@neo4j://localhost',
+      tooltip: 'neo4j@neo4j://localhost',
+      type: 'activeConnection',
+    };
+
+    assert.deepStrictEqual({ ...actual }, expected);
+  });
+
+  test('An active Connection should have a list of child databases', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+    const connection = children.find(
+      (child) => child.key === 'test-connection',
+    );
+
+    const databases = testConnectionItem.getChildren({ ...connection });
+
+    assert.equal(databases.length, 2);
+  });
+
+  test('An active Connection should show the default database as active if no database is specified', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+    const connection = children.find(
+      (child) => child.key === 'test-connection',
+    );
+    const databases = testConnectionItem.getChildren({ ...connection });
+
+    const database = { ...databases.find((child) => child.key === 'neo4j') };
+    const actual = {
+      ...database,
+      resourceUri: { ...database.resourceUri },
+    };
+    const expected = {
+      collapsibleState: 0,
+      contextValue: 'activeDatabase',
+      description: 'active',
+      iconPath: '.',
+      key: 'neo4j',
+      label: 'neo4j 🏠',
+      resourceUri: {
+        _formatted: null,
+        _fsPath: null,
+        authority: '',
+        fragment: '',
+        path: '/',
+        query: 'type=activeDatabase',
+        scheme: 'file',
+      },
+      tooltip: 'neo4j 🏠',
+      type: 'activeDatabase',
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('An active Connection should show the specified database as active', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+    const connection = children.find(
+      (child) => child.key === 'test-connection-2',
+    );
+    const databases = testConnectionItem.getChildren({ ...connection });
+
+    const database = { ...databases.find((child) => child.key === 'schemas') };
+    const actual = {
+      ...database,
+      resourceUri: { ...database.resourceUri },
+    };
+    const expected = {
+      collapsibleState: 0,
+      contextValue: 'activeDatabase',
+      description: 'active',
+      iconPath: '.',
+      key: 'schemas',
+      label: 'schemas',
+      resourceUri: {
+        _formatted: null,
+        _fsPath: null,
+        authority: '',
+        fragment: '',
+        path: '/',
+        query: 'type=activeDatabase',
+        scheme: 'file',
+      },
+      tooltip: 'schemas',
+      type: 'activeDatabase',
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('An activating Connection should show as connecting', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+
+    const actual = {
+      ...children.find((child) => child.key === 'test-connection-4'),
+    };
+    const expected: ConnectionItem = {
+      collapsibleState: TreeItemCollapsibleState.None,
+      contextValue: 'connection',
+      description: 'connecting...',
+      id: 'test-connection-4',
+      key: 'test-connection-4',
+      label: 'neo4j@neo4j://localhost',
+      tooltip: 'neo4j@neo4j://localhost',
+      type: 'connection',
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('An errored Connection should show as connecting', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+
+    const actual = {
+      ...children.find((child) => child.key === 'test-connection-5'),
+    };
+    const expected: ConnectionItem = {
+      collapsibleState: TreeItemCollapsibleState.None,
+      contextValue: 'connection',
+      description: 'connecting...',
+      id: 'test-connection-5',
+      key: 'test-connection-5',
+      label: 'neo4j@neo4j://localhost',
+      tooltip: 'neo4j@neo4j://localhost',
+      type: 'connection',
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('An inactive Connection should not show as connected or connecting', () => {
+    const testConnectionItem = new ConnectionTreeDataProvider();
+    const children = testConnectionItem.getChildren();
+
+    const actual = {
+      ...children.find((child) => child.key === 'test-connection-3'),
+    };
+    const expected: ConnectionItem = {
+      collapsibleState: TreeItemCollapsibleState.None,
+      contextValue: 'connection',
+      description: '',
+      id: 'test-connection-3',
+      key: 'test-connection-3',
+      label: 'neo4j@neo4j://localhost:7687',
+      tooltip: 'neo4j@neo4j://localhost:7687',
+      type: 'connection',
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+});

--- a/packages/vscode-extension/e2e_tests/tests/connectionTreeDataProvider.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/connectionTreeDataProvider.spec.ts
@@ -1,4 +1,4 @@
-import { Database } from '@neo4j-cypher/schema-poller/dist/cjs/src/queries/databases';
+import { Database } from '@neo4j-cypher/schema-poller';
 import * as assert from 'assert';
 import { afterEach, beforeEach } from 'mocha';
 import * as sinon from 'sinon';
@@ -7,7 +7,7 @@ import * as connectionService from '../../src/connectionService';
 import { Connection } from '../../src/connectionService';
 import {
   ConnectionItem,
-  ConnectionTreeDataProvider,
+  connectionTreeDataProvider,
 } from '../../src/connectionTreeDataProvider';
 
 suite('Connection tree data provider spec', () => {
@@ -81,8 +81,7 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An active Connection should show as connected', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
 
     const actual = children.find((child) => child.key === 'test-connection');
     const expected: ConnectionItem = {
@@ -100,24 +99,22 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An active Connection should have a list of child databases', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
     const connection = children.find(
       (child) => child.key === 'test-connection',
     );
 
-    const databases = testConnectionItem.getChildren({ ...connection });
+    const databases = connectionTreeDataProvider.getChildren({ ...connection });
 
     assert.equal(databases.length, 2);
   });
 
   test('An active Connection should show the default database as active if no database is specified', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
     const connection = children.find(
       (child) => child.key === 'test-connection',
     );
-    const databases = testConnectionItem.getChildren({ ...connection });
+    const databases = connectionTreeDataProvider.getChildren({ ...connection });
 
     const database = { ...databases.find((child) => child.key === 'neo4j') };
     const actual = {
@@ -148,12 +145,11 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An active Connection should show the specified database as active', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
     const connection = children.find(
       (child) => child.key === 'test-connection-2',
     );
-    const databases = testConnectionItem.getChildren({ ...connection });
+    const databases = connectionTreeDataProvider.getChildren({ ...connection });
 
     const database = { ...databases.find((child) => child.key === 'schemas') };
     const actual = {
@@ -184,8 +180,7 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An activating Connection should show as connecting', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
 
     const actual = {
       ...children.find((child) => child.key === 'test-connection-4'),
@@ -205,8 +200,7 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An errored Connection should show as connecting', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
 
     const actual = {
       ...children.find((child) => child.key === 'test-connection-5'),
@@ -226,8 +220,7 @@ suite('Connection tree data provider spec', () => {
   });
 
   test('An inactive Connection should not show as connected or connecting', () => {
-    const testConnectionItem = new ConnectionTreeDataProvider();
-    const children = testConnectionItem.getChildren();
+    const children = connectionTreeDataProvider.getChildren();
 
     const actual = {
       ...children.find((child) => child.key === 'test-connection-3'),

--- a/packages/vscode-extension/e2e_tests/tests/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/syntaxValidation.spec.ts
@@ -153,7 +153,6 @@ suite('Syntax validation spec', () => {
     const { scheme, host, port, user, database, password } =
       getNeo4jConfiguration();
     const connection = {
-      name: defaultConnectionKey,
       key: defaultConnectionKey,
       scheme: scheme,
       host: host,

--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -2,6 +2,7 @@ import { Neo4jSettings } from '@neo4j-cypher/language-server/src/types';
 import {
   ConnectionError,
   ConnnectionResult,
+  Database,
 } from '@neo4j-cypher/schema-poller';
 import { commands, workspace } from 'vscode';
 import { CONSTANTS } from './constants';
@@ -19,7 +20,6 @@ export type State = 'inactive' | 'activating' | 'active' | 'error';
  */
 export type Connection = {
   key: string;
-  name: string;
   scheme: Scheme;
   host: string;
   port?: string | undefined;
@@ -276,6 +276,11 @@ export async function establishPersistentConnectionToSchemaPoller(
     : attachSchemaPollerConnectionFailedEventListeners();
 
   return result;
+}
+
+export function getConnectionDatabases(): Database[] {
+  const schemaPoller = getSchemaPoller();
+  return schemaPoller.connection?.databases ?? [];
 }
 
 /**

--- a/packages/vscode-extension/src/connectionTreeDataProvider.ts
+++ b/packages/vscode-extension/src/connectionTreeDataProvider.ts
@@ -1,4 +1,4 @@
-import { Database } from '@neo4j-cypher/schema-poller/dist/cjs/src/queries/databases';
+import { Database } from '@neo4j-cypher/schema-poller';
 import {
   Event,
   EventEmitter,
@@ -125,6 +125,8 @@ export class ConnectionTreeDataProvider
       : `${connection.user}@${connection.scheme}://${connection.host}`;
   }
 }
+
+export const connectionTreeDataProvider = new ConnectionTreeDataProvider();
 
 /**
  * Extends the TreeItem class to represent a connection in the tree view.

--- a/packages/vscode-extension/src/connectionTreeDecorationProvider.ts
+++ b/packages/vscode-extension/src/connectionTreeDecorationProvider.ts
@@ -1,0 +1,26 @@
+import {
+  FileDecoration,
+  FileDecorationProvider,
+  ProviderResult,
+  ThemeColor,
+  Uri,
+} from 'vscode';
+import { ConnectionItemType } from './connectionTreeDataProvider';
+
+export class ConnectionTreeDecorationProvider
+  implements FileDecorationProvider
+{
+  provideFileDecoration(uri: Uri): ProviderResult<FileDecoration> {
+    const params: URLSearchParams = new URLSearchParams(uri.query);
+    const type: ConnectionItemType = params.get('type') as ConnectionItemType;
+
+    switch (type) {
+      case 'activeDatabase':
+        return {
+          color: new ThemeColor('charts.green'),
+        };
+      default:
+        return undefined;
+    }
+  }
+}

--- a/packages/vscode-extension/src/connectionTreeDecorationProvider.ts
+++ b/packages/vscode-extension/src/connectionTreeDecorationProvider.ts
@@ -7,9 +7,7 @@ import {
 } from 'vscode';
 import { ConnectionItemType } from './connectionTreeDataProvider';
 
-export class ConnectionTreeDecorationProvider
-  implements FileDecorationProvider
-{
+class ConnectionTreeDecorationProvider implements FileDecorationProvider {
   provideFileDecoration(uri: Uri): ProviderResult<FileDecoration> {
     const params: URLSearchParams = new URLSearchParams(uri.query);
     const type: ConnectionItemType = params.get('type') as ConnectionItemType;
@@ -24,3 +22,6 @@ export class ConnectionTreeDecorationProvider
     }
   }
 }
+
+export const connectionTreeDecorationProvider =
+  new ConnectionTreeDecorationProvider();

--- a/packages/vscode-extension/src/contextService.ts
+++ b/packages/vscode-extension/src/contextService.ts
@@ -1,6 +1,7 @@
 import { Neo4jSettings } from '@neo4j-cypher/language-server/src/types';
 import {
   ConnnectionResult,
+  Neo4jConnection,
   Neo4jSchemaPoller,
 } from '@neo4j-cypher/schema-poller';
 import EventEmitter from 'events';
@@ -12,6 +13,7 @@ type LanguageClient = {
 };
 
 type SchemaPoller = {
+  connection?: Neo4jConnection;
   events: EventEmitter;
   connect(
     url: string,

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -10,6 +10,7 @@ import {
   ConnectionItem,
   ConnectionTreeDataProvider,
 } from './connectionTreeDataProvider';
+import { ConnectionTreeDecorationProvider } from './connectionTreeDecorationProvider';
 import { CONSTANTS } from './constants';
 
 /**
@@ -19,12 +20,15 @@ import { CONSTANTS } from './constants';
 export function registerDisposables(): Disposable[] {
   const disposables = Array<Disposable>();
   const connectionTreeDataProvider = new ConnectionTreeDataProvider();
+  const connectionTreeDecorationProvider =
+    new ConnectionTreeDecorationProvider();
 
   disposables.push(
     window.registerTreeDataProvider(
       'neo4jConnections',
       connectionTreeDataProvider,
     ),
+    window.registerFileDecorationProvider(connectionTreeDecorationProvider),
     workspace.onDidChangeConfiguration(handleNeo4jConfigurationChangedEvent),
     commands.registerCommand(
       CONSTANTS.COMMANDS.SAVE_CONNECTION_COMMAND,

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -8,9 +8,9 @@ import {
 } from './commandHandlers';
 import {
   ConnectionItem,
-  ConnectionTreeDataProvider,
+  connectionTreeDataProvider,
 } from './connectionTreeDataProvider';
-import { ConnectionTreeDecorationProvider } from './connectionTreeDecorationProvider';
+import { connectionTreeDecorationProvider } from './connectionTreeDecorationProvider';
 import { CONSTANTS } from './constants';
 
 /**
@@ -19,9 +19,6 @@ import { CONSTANTS } from './constants';
  */
 export function registerDisposables(): Disposable[] {
   const disposables = Array<Disposable>();
-  const connectionTreeDataProvider = new ConnectionTreeDataProvider();
-  const connectionTreeDecorationProvider =
-    new ConnectionTreeDecorationProvider();
 
   disposables.push(
     window.registerTreeDataProvider(

--- a/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
+++ b/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
@@ -77,7 +77,6 @@ export function getConnection(): Connection | null {
 
   return {
     key: key.value,
-    name: 'Default connection',
     scheme: scheme.value,
     host: host.value,
     port: port.value,


### PR DESCRIPTION
This change updates the connection tree view to include a dropdown for active connections that will list the database available for that connection.

The home database is annotated with a 'Home' emoji

The active database is highlighted green, and annotated with an 'active' label

To facilitate this, I am exposing the databases array that's established in the neo4j connection - my thinking is we needn't over complicate this by doing anything too clever, like automatically refreshing the list of databases when the schema poller refetches data since databases are likely to be fairly static