### PR TITLE
Adding a 'switch to database' command to databases in the tree view

### DIFF
--- a/packages/vscode-extension/e2e_tests/tests/commandHandlers.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/commandHandlers.spec.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach } from 'mocha';
 import * as sinon from 'sinon';
 import { ConfigurationChangeEvent } from 'vscode';
-import { handleNeo4jConfigurationChangedEvent } from '../../src/commandHandlers';
+import {
+  handleNeo4jConfigurationChangedEvent,
+  switchToDatabase,
+} from '../../src/commandHandlers';
 import * as connection from '../../src/connectionService';
 import { getMockConnection } from '../helpers';
 import { MockLanguageClient } from '../mocks/mockLanguageClient';
+import { MockSchemaPoller } from '../mocks/mockSchemaPoller';
 import { setupMockContextStubs } from '../mocks/setupMockContextStubs';
 
 suite('Command handlers spec', () => {
   let sandbox: sinon.SinonSandbox;
 
   let mockLanguageClient: MockLanguageClient;
+  let mockSchemaPoller: MockSchemaPoller;
 
   let getActiveConnectionStub: sinon.SinonStub;
 
@@ -20,6 +25,7 @@ suite('Command handlers spec', () => {
     const stubs = setupMockContextStubs(sandbox);
 
     mockLanguageClient = stubs.mockLanguageClient;
+    mockSchemaPoller = stubs.mockSchemaPoller;
   });
 
   afterEach(() => {
@@ -85,6 +91,80 @@ suite('Command handlers spec', () => {
     await handleNeo4jConfigurationChangedEvent({
       affectsConfiguration: () => true,
     } as ConfigurationChangeEvent);
+
+    sandbox.assert.notCalled(sendNotificationSpy);
+  });
+
+  test('Switching a database should notify the language server', async () => {
+    const sendNotificationSpy = sandbox.spy(
+      mockLanguageClient,
+      'sendNotification',
+    );
+    getActiveConnectionStub = sandbox
+      .stub(connection, 'getActiveConnection')
+      .returns(getMockConnection(true));
+
+    await switchToDatabase({
+      type: 'database',
+      label: '',
+      description: 'active',
+      collapsibleState: 0,
+      key: 'schemas',
+    });
+
+    sandbox.assert.calledOnceWithExactly(
+      sendNotificationSpy,
+      'connectionUpdated',
+      {
+        trace: { server: 'off' },
+        connect: true,
+        connectURL: 'neo4j://localhost:7687',
+        database: 'schemas',
+        user: 'neo4j',
+        password: null,
+      },
+    );
+  });
+
+  test('Switching to a bad database should not notify the language server', async () => {
+    sandbox
+      .stub(mockSchemaPoller, 'connect')
+      .resolves({ success: false, retriable: true });
+    const sendNotificationSpy = sandbox.spy(
+      mockLanguageClient,
+      'sendNotification',
+    );
+    getActiveConnectionStub = sandbox
+      .stub(connection, 'getActiveConnection')
+      .returns(getMockConnection(true));
+
+    await switchToDatabase({
+      type: 'database',
+      label: '',
+      description: 'active',
+      collapsibleState: 0,
+      key: 'bad-database',
+    });
+
+    sandbox.assert.notCalled(sendNotificationSpy);
+  });
+
+  test('Switching to a non-database should do nothing', async () => {
+    const sendNotificationSpy = sandbox.spy(
+      mockLanguageClient,
+      'sendNotification',
+    );
+    getActiveConnectionStub = sandbox
+      .stub(connection, 'getActiveConnection')
+      .returns(getMockConnection(true));
+
+    await switchToDatabase({
+      type: 'activeDatabase',
+      label: '',
+      description: 'active',
+      collapsibleState: 0,
+      key: 'neo4j',
+    });
 
     sandbox.assert.notCalled(sendNotificationSpy);
   });

--- a/packages/vscode-extension/e2e_tests/tests/commandHandlers.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/commandHandlers.spec.ts
@@ -95,7 +95,7 @@ suite('Command handlers spec', () => {
     sandbox.assert.notCalled(sendNotificationSpy);
   });
 
-  test('Switching a database should notify the language server', async () => {
+  test('Switching a database should notify the language server with connectionUpdated', async () => {
     const sendNotificationSpy = sandbox.spy(
       mockLanguageClient,
       'sendNotification',
@@ -126,9 +126,9 @@ suite('Command handlers spec', () => {
     );
   });
 
-  test('Switching to a bad database should not notify the language server', async () => {
+  test('Switching to a bad database should notify the language server with connectionDisconnected', async () => {
     sandbox
-      .stub(mockSchemaPoller, 'connect')
+      .stub(mockSchemaPoller, 'persistentConnect')
       .resolves({ success: false, retriable: true });
     const sendNotificationSpy = sandbox.spy(
       mockLanguageClient,
@@ -146,7 +146,11 @@ suite('Command handlers spec', () => {
       key: 'bad-database',
     });
 
-    sandbox.assert.notCalled(sendNotificationSpy);
+    sandbox.assert.calledOnceWithExactly(
+      sendNotificationSpy,
+      'connectionDisconnected',
+      undefined,
+    );
   });
 
   test('Switching to a non-database should do nothing', async () => {

--- a/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
@@ -303,4 +303,40 @@ suite('Execute commands spec', () => {
       );
     });
   });
+
+  suite('switchDatabaseCommand', () => {
+    test('Switching a database should show a success message', async () => {
+      await commands.executeCommand(
+        CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
+        { type: 'database', key: 'movies' },
+      );
+
+      sandbox.assert.calledWith(
+        showInformationMessageStub,
+        `${CONSTANTS.MESSAGES.SUCCESSFULLY_SWITCHED_DATABASE_MESSAGE} 'movies'.`,
+      );
+    });
+
+    test('Switching to a bad database should show a failure message', async () => {
+      await commands.executeCommand(
+        CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
+        { type: 'database', key: 'bad-database' },
+      );
+
+      sandbox.assert.calledWith(
+        showErrorMessageStub,
+        `${CONSTANTS.MESSAGES.ERROR_SWITCHING_DATABASE_MESSAGE} 'bad-database'. Unable to get a routing table for database 'bad-database' because this database does not exist. Double check that the database exists.`,
+      );
+    });
+
+    test('Switching to a non-database should do nothing', async () => {
+      await commands.executeCommand(
+        CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
+        { type: 'activeDatabase', key: 'neo4j' },
+      );
+
+      sandbox.assert.notCalled(showInformationMessageStub);
+      sandbox.assert.notCalled(showErrorMessageStub);
+    });
+  });
 });

--- a/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
+++ b/packages/vscode-extension/e2e_tests/tests/executeCommands.spec.ts
@@ -305,6 +305,11 @@ suite('Execute commands spec', () => {
   });
 
   suite('switchDatabaseCommand', () => {
+    beforeEach(async () => {
+      await saveDefaultConnection();
+      sandbox.resetHistory();
+    });
+
     test('Switching a database should show a success message', async () => {
       await commands.executeCommand(
         CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -60,6 +60,10 @@
       {
         "command": "neo4j.saveConnection",
         "title": "Create Connection..."
+      },
+      {
+        "command": "neo4j.switchDatabase",
+        "title": "Switch to database..."
       }
     ],
     "viewsWelcome": [
@@ -111,6 +115,10 @@
           "command": "neo4j.deleteConnection",
           "when": "view == neo4jConnections && viewItem == connection || viewItem == activeConnection",
           "group": "01_management@2"
+        },
+        {
+          "command": "neo4j.switchDatabase",
+          "when": "view == neo4jConnections && viewItem == database"
         }
       ]
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -59,11 +59,11 @@
       },
       {
         "command": "neo4j.saveConnection",
-        "title": "Create Connection..."
+        "title": "Create Connection"
       },
       {
         "command": "neo4j.switchDatabase",
-        "title": "Switch to database..."
+        "title": "Switch to database"
       }
     ],
     "viewsWelcome": [

--- a/packages/vscode-extension/src/commandHandlers.ts
+++ b/packages/vscode-extension/src/commandHandlers.ts
@@ -9,6 +9,7 @@ import {
   getDatabaseConnectionSettings,
   getPasswordForConnection,
   saveConnectionAndUpdateDatabaseConnection,
+  switchDatabase,
   toggleConnectionAndUpdateDatabaseConnection,
 } from './connectionService';
 import { ConnectionItem } from './connectionTreeDataProvider';
@@ -170,10 +171,6 @@ export async function switchToDatabase(
   }
   const database = connectionItem.key;
   const connection = getActiveConnection();
-  const password = await getPasswordForConnection(connection.key);
-  const result = await saveConnectionAndUpdateDatabaseConnection(
-    { ...connection, database },
-    password,
-  );
+  const result = await switchDatabase({ ...connection, database });
   displayMessageForSwitchDatabaseResult(database, result);
 }

--- a/packages/vscode-extension/src/commandHandlers.ts
+++ b/packages/vscode-extension/src/commandHandlers.ts
@@ -1,7 +1,4 @@
-import {
-  ConnnectionResult,
-  FRIENDLY_ERROR_MESSAGES,
-} from '@neo4j-cypher/schema-poller';
+import { ConnnectionResult } from '@neo4j-cypher/schema-poller';
 import { commands, ConfigurationChangeEvent, window } from 'vscode';
 import {
   Connection,
@@ -18,7 +15,12 @@ import { ConnectionItem } from './connectionTreeDataProvider';
 import { CONSTANTS } from './constants';
 import { getExtensionContext } from './contextService';
 import { sendNotificationToLanguageClient } from './languageClientService';
-import { displayMessageForConnectionResult } from './uiUtils';
+import {
+  displayConfirmConnectionDeletionPrompt,
+  displayMessageForConnectionResult,
+  displayMessageForSwitchDatabaseResult,
+  displaySaveConnectionAnywayPrompt,
+} from './uiUtils';
 import { ConnectionPanel } from './webviews/connectionPanel';
 
 /**
@@ -154,31 +156,24 @@ export async function toggleConnectionItemsConnectionState(
 }
 
 /**
- * Utility function to prompt the user to save a connection that failed with a retriable error.
- * @returns A promise that resolves with the result of the prompt ("Yes" or null).
+ * Handler for SWITCH_DATABASE_COMMAND (neo4j.switchDatabase)
+ * This may only be triggered from the Connection tree view.
+ * Switches the active database of the active Connection and updates the database connection, reconnecting the connection.
+ * @param connectionItem The ConnectionItem of the database to switch to.
+ * @returns A promise that resolves when the handler has completed.
  */
-async function displaySaveConnectionAnywayPrompt(): Promise<string | null> {
-  return await window.showWarningMessage<string>(
-    'Unable to connect to Neo4j. Would you like to save the Connection anyway?',
-    {
-      modal: true,
-      detail: `${FRIENDLY_ERROR_MESSAGES.ServiceUnavailable}.`,
-    },
-    'Yes',
-  );
-}
-
-/**
- * Utility function to prompt the user whether they're sure they want to delete a Connection.
- * @param connectionItem The ConnectionItem to prompt for deletion.
- * @returns A promise that resolves with the result of the prompt ("Yes" or null).
- */
-async function displayConfirmConnectionDeletionPrompt(
+export async function switchToDatabase(
   connectionItem: ConnectionItem,
-): Promise<string | null> {
-  return await window.showWarningMessage<string>(
-    `Are you sure you want to delete connection ${connectionItem.label}?`,
-    { modal: true },
-    'Yes',
+): Promise<void> {
+  if (connectionItem.type !== 'database') {
+    return;
+  }
+  const database = connectionItem.key;
+  const connection = getActiveConnection();
+  const password = await getPasswordForConnection(connection.key);
+  const result = await saveConnectionAndUpdateDatabaseConnection(
+    { ...connection, database },
+    password,
   );
+  displayMessageForSwitchDatabaseResult(database, result);
 }

--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -91,6 +91,21 @@ export async function saveConnectionAndUpdateDatabaseConnection(
 }
 
 /**
+ * Saves a connection and updates the database connection.
+ * This function is used when switching databases, and avoids the need to reinitialize the driver.
+ * @param connection The Conection to save.
+ * @returns A promise that resolves with the Connection result.
+ */
+export async function switchDatabase(connection: Connection | null) {
+  if (!connection) {
+    return;
+  }
+
+  await saveConnection(connection);
+  return await updateDatabaseConnectionAndNotifyLanguageClient(connection);
+}
+
+/**
  * Toggles the connect flag and connection state of a Connection and updates the database connection.
  * If the Connection's connect flag is true, any current database connections will be dropped.
  * @param connection The Connection to toggle.

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -6,6 +6,7 @@ export const CONSTANTS = {
     REFRESH_CONNECTIONS_COMMAND: 'neo4j.refreshConnections',
     CONNECT_COMMAND: 'neo4j.connect',
     DISCONNECT_COMMAND: 'neo4j.disconnect',
+    SWITCH_DATABASE_COMMAND: 'neo4j.switchDatabase',
   },
   MESSAGES: {
     CONNECTED_MESSAGE: 'Connected to Neo4j.',
@@ -14,5 +15,7 @@ export const CONSTANTS = {
     CONNECTION_SAVED: 'Neo4j connection saved.',
     CONNECTION_DELETED: 'Neo4j connection deleted.',
     CONNECTION_VALIDATION_MESSAGE: 'Please fill in all required fields.',
+    SUCCESSFULLY_SWITCHED_DATABASE_MESSAGE: 'Switched to database',
+    ERROR_SWITCHING_DATABASE_MESSAGE: 'Error switching to database',
   },
 };

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -4,6 +4,7 @@ import {
   handleNeo4jConfigurationChangedEvent,
   promptUserToDeleteConnectionAndDisplayConnectionResult,
   saveConnectionAndDisplayConnectionResult,
+  switchToDatabase,
   toggleConnectionItemsConnectionState,
 } from './commandHandlers';
 import {
@@ -54,6 +55,10 @@ export function registerDisposables(): Disposable[] {
       () => {
         connectionTreeDataProvider.refresh();
       },
+    ),
+    commands.registerCommand(
+      CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
+      (connectionItem: ConnectionItem) => switchToDatabase(connectionItem),
     ),
   );
 

--- a/packages/vscode-extension/src/uiUtils.ts
+++ b/packages/vscode-extension/src/uiUtils.ts
@@ -1,6 +1,10 @@
-import { ConnnectionResult } from '@neo4j-cypher/schema-poller';
+import {
+  ConnnectionResult,
+  FRIENDLY_ERROR_MESSAGES,
+} from '@neo4j-cypher/schema-poller';
 import { window } from 'vscode';
 import { Connection } from './connectionService';
+import { ConnectionItem } from './connectionTreeDataProvider';
 import { CONSTANTS } from './constants';
 
 /**
@@ -29,4 +33,54 @@ export function displayMessageForConnectionResult(
       `${result.error?.message}. ${result.error?.friendlyMessage}.`,
     );
   }
+}
+
+/**
+ * Utility function to prompt the user to save a connection that failed with a retriable error.
+ * @returns A promise that resolves with the result of the prompt ("Yes" or null).
+ */
+export async function displaySaveConnectionAnywayPrompt(): Promise<
+  string | null
+> {
+  return await window.showWarningMessage<string>(
+    'Unable to connect to Neo4j. Would you like to save the Connection anyway?',
+    {
+      modal: true,
+      detail: `${FRIENDLY_ERROR_MESSAGES.ServiceUnavailable}.`,
+    },
+    'Yes',
+  );
+}
+
+/**
+ * Utility function to prompt the user whether they're sure they want to delete a Connection.
+ * @param connectionItem The ConnectionItem to prompt for deletion.
+ * @returns A promise that resolves with the result of the prompt ("Yes" or null).
+ */
+export async function displayConfirmConnectionDeletionPrompt(
+  connectionItem: ConnectionItem,
+): Promise<string | null> {
+  return await window.showWarningMessage<string>(
+    `Are you sure you want to delete connection ${connectionItem.label}?`,
+    { modal: true },
+    'Yes',
+  );
+}
+
+/**
+ * Utility function to display a message to the user based on the result of switching databases.
+ * @param database The database that was switched to.
+ * @param result The result of the switch database attempt.
+ */
+export function displayMessageForSwitchDatabaseResult(
+  database: string,
+  result: ConnnectionResult,
+): void {
+  result.success
+    ? void window.showInformationMessage(
+        `${CONSTANTS.MESSAGES.SUCCESSFULLY_SWITCHED_DATABASE_MESSAGE} '${database}'.`,
+      )
+    : void window.showErrorMessage(
+        `${CONSTANTS.MESSAGES.ERROR_SWITCHING_DATABASE_MESSAGE} '${database}'. ${result.error?.message}. ${result.error?.friendlyMessage}.`,
+      );
 }

--- a/packages/vscode-extension/src/webviews/connectionPanel.ts
+++ b/packages/vscode-extension/src/webviews/connectionPanel.ts
@@ -122,7 +122,6 @@ export class ConnectionPanel {
                 scheme: message.connection?.scheme,
                 host: message.connection?.host,
                 port: message.connection?.port,
-                database: message.connection?.database,
                 user: message.connection?.user,
               };
               this._password = message.password;
@@ -253,12 +252,6 @@ export class ConnectionPanel {
                     }" data-invalid="${this.urlIsInvalid()}" />
                   </div>
                   <div class="form--input-wrapper">
-                    <label for="database">Database</label>
-                    <input type="text" id="database" placeholder="neo4j" value="${
-                      this._connection?.database ?? ''
-                    }" data-invalid="${this.databaseIsInvalid()}" />
-                  </div>
-                  <div class="form--input-wrapper">
                     <label for="user">User *</label>
                     <input type="text" id="user" required placeholder="neo4j" value="${
                       this._connection?.user ?? 'neo4j'
@@ -288,13 +281,6 @@ export class ConnectionPanel {
       'Neo.ClientError.Security.Unauthorized',
       'Neo.ClientError.Security.TokenExpired',
     ].includes(this._lastResult?.error?.code);
-  }
-
-  private databaseIsInvalid(): boolean {
-    return (
-      this._lastResult?.error?.code ===
-      'Neo.ClientError.Database.DatabaseNotFound'
-    );
   }
 
   private urlIsInvalid(): boolean {

--- a/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
+++ b/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
@@ -69,7 +69,6 @@ export function getConnection(): Connection | null {
   const host = document.getElementById('host') as HTMLInputElement;
   const port = document.getElementById('port') as HTMLInputElement;
   const user = document.getElementById('user') as HTMLInputElement;
-  const database = document.getElementById('database') as HTMLInputElement;
 
   if (!isValidScheme(scheme.value)) {
     return null;
@@ -81,7 +80,6 @@ export function getConnection(): Connection | null {
     host: host.value,
     port: port.value,
     user: user.value,
-    database: database.value,
     state: 'activating',
   };
 }


### PR DESCRIPTION
This change updates the connection tree view to include a context menu option to databases in the treeview and accompanying command handler to switch databases. It also removes the optional `database` field in the connection form.

