### PR TITLE
Update logic for handling externally set values

### DIFF
--- a/.changeset/strong-squids-relax.md
+++ b/.changeset/strong-squids-relax.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Fix a bug causing debounced value updates to get cancelled erroneously


### PR DESCRIPTION
Fix a bug causing debounced value updates to get cancelled erroneously