### PR TITLE
Replace ts-ignore with proper Vite types

### DIFF
--- a/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
+++ b/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
@@ -5,12 +5,9 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 import workerpool from 'workerpool';
 import type { CypherConfig } from './langCypher';
 import type { LinterTask, LintWorker } from './lintWorker';
+import WorkerURL from './lintWorker?worker&url';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore ignore: https://v3.vitejs.dev/guide/features.html#import-with-query-suffixes
-import WorkerURL from './lintWorker?url&worker';
-
-const pool = workerpool.pool(WorkerURL as string, {
+const pool = workerpool.pool(WorkerURL, {
   minWorkers: 2,
   workerOpts: { type: 'module' },
   workerTerminateTimeout: 2000,

--- a/packages/react-codemirror/src/viteEnv.d.ts
+++ b/packages/react-codemirror/src/viteEnv.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
I noticed a minor stylistic issue in how a worker was imported. Fixed by adding the [Vite client types](https://vitejs.dev/guide/features#client-types).