### PR TITLE
Add row limit to query execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "prettier": "^2.8.1",
         "prettier-plugin-organize-imports": "^3.2.1",
         "semver": "^7.6.1",
-        "turbo": "^1.13.2",
+        "turbo": "^1.13.4",
         "turbowatch": "^2.29.4",
         "typescript": "4.9.5",
         "vitest": "^2.0.4"
@@ -21377,31 +21377,98 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.13.2",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
+      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
       "dev": true,
-      "license": "MPL-2.0",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.2",
-        "turbo-darwin-arm64": "1.13.2",
-        "turbo-linux-64": "1.13.2",
-        "turbo-linux-arm64": "1.13.2",
-        "turbo-windows-64": "1.13.2",
-        "turbo-windows-arm64": "1.13.2"
+        "turbo-darwin-64": "1.13.4",
+        "turbo-darwin-arm64": "1.13.4",
+        "turbo-linux-64": "1.13.4",
+        "turbo-linux-arm64": "1.13.4",
+        "turbo-windows-64": "1.13.4",
+        "turbo-windows-arm64": "1.13.4"
       }
     },
-    "node_modules/turbo-linux-64": {
-      "version": "1.13.2",
+    "node_modules/turbo-darwin-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
+      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
+      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
+      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
+      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
+      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
+      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/turbowatch": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier": "^2.8.1",
     "prettier-plugin-organize-imports": "^3.2.1",
     "semver": "^7.6.1",
-    "turbo": "^1.13.2",
+    "turbo": "^1.13.4",
     "turbowatch": "^2.29.4",
     "typescript": "4.9.5",
     "vitest": "^2.0.4"

--- a/packages/schema-poller/src/index.ts
+++ b/packages/schema-poller/src/index.ts
@@ -1,7 +1,7 @@
 export { FRIENDLY_ERROR_MESSAGES } from './connectionErrorHandler';
 export type { ConnectionError } from './connectionErrorHandler';
 export type { MetadataPoller } from './metadataPoller';
-export type { Neo4jConnection } from './neo4jConnection';
+export type { Neo4jConnection, QueryResultWithLimit } from './neo4jConnection';
 export type { Database } from './queries/databases';
 export { Neo4jSchemaPoller } from './schemaPoller';
 export type { ConnnectionResult } from './schemaPoller';

--- a/packages/vscode-extension/src/webviews/resultWindow.ts
+++ b/packages/vscode-extension/src/webviews/resultWindow.ts
@@ -1,3 +1,4 @@
+import type { QueryResultWithLimit } from '@neo4j-cypher/schema-poller';
 import { QueryResult } from 'neo4j-driver';
 import path from 'path';
 import { Uri, ViewColumn, Webview, WebviewPanel, window } from 'vscode';
@@ -208,25 +209,12 @@ export default class ResultWindow {
     }
   }
 
-  private async runQuery(query: string): Promise<QueryResult | Error> {
+  private async runQuery(query: string): Promise<QueryResultWithLimit | Error> {
     const connection = this.schemaPoller.connection;
 
     if (connection) {
       try {
-        const result = await connection.runSdkQuery(
-          {
-            query: query,
-            queryConfig: {
-              resultTransformer: (result) => {
-                return result;
-              },
-              routing: 'WRITE',
-            },
-          },
-          { queryType: 'user-direct' },
-        );
-
-        return result;
+        return connection.runCypherQuery({ query });
       } catch (e) {
         const error = e as Error;
         return error;
@@ -240,7 +228,7 @@ export default class ResultWindow {
 
   private async executeStatement(statement: string, index: number) {
     const webview = this.panel.webview;
-    const result: QueryResult | Error = await this.runQuery(statement);
+    const result = await this.runQuery(statement);
     let message: ResultMessage;
 
     if (result instanceof Error) {

--- a/packages/vscode-extension/src/webviews/resultWindow.ts
+++ b/packages/vscode-extension/src/webviews/resultWindow.ts
@@ -217,7 +217,7 @@ export default class ResultWindow {
 
     if (connection) {
       try {
-        return connection.runCypherQuery({ query });
+        return await connection.runCypherQuery({ query });
       } catch (e) {
         const error = e as Error;
         return error;

--- a/packages/vscode-extension/src/webviews/resultWindow.ts
+++ b/packages/vscode-extension/src/webviews/resultWindow.ts
@@ -1,5 +1,4 @@
 import type { QueryResultWithLimit } from '@neo4j-cypher/schema-poller';
-import { QueryResult } from 'neo4j-driver';
 import path from 'path';
 import { Uri, ViewColumn, Webview, WebviewPanel, window } from 'vscode';
 import { Connection } from '../connectionService';
@@ -7,7 +6,7 @@ import { getExtensionContext, getSchemaPoller } from '../contextService';
 import { getNonce } from '../getNonce';
 import { toNativeTypes } from '../typeUtils';
 
-export function querySummary(result: QueryResult): string[] {
+export function querySummary(result: QueryResultWithLimit): string[] {
   const rows = result.records.length;
   const counters = result.summary.counters;
   const output: string[] = [];
@@ -16,7 +15,11 @@ export function querySummary(result: QueryResult): string[] {
   if (rows > 0) {
     // Started streaming 1 records after 5 ms and completed after 10  ms.
     output.push(
-      `Started streaming ${rows} record${
+      `${
+        result.recordLimitHit
+          ? `Fetch limit hit at ${result.records.length} records. `
+          : ''
+      }Started streaming ${rows} record${
         rows === 1 ? '' : 's'
       } after ${result.summary.resultConsumedAfter.toString()} ms and completed after ${result.summary.resultAvailableAfter.toString()}ms.`,
     );


### PR DESCRIPTION
Adds a new cypher running function for user queries instead of the one created for Neo4j SDK functions. It's using the [AsyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) api in the driver to stop consuming records after a set limit is hit. I also update the view to inform the user if the limit was hit.

I got an error message from Turborepo that told me to update the version 🤷 