### PR TITLE
Re-export language support from react codemirror

### DIFF
--- a/.changeset/young-llamas-teach.md
+++ b/.changeset/young-llamas-teach.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Re-export language support from react codemirror

--- a/packages/react-codemirror/src/index.ts
+++ b/packages/react-codemirror/src/index.ts
@@ -1,7 +1,4 @@
-export {
-  CypherParser,
-  _internalFeatureFlags,
-} from '@neo4j-cypher/language-support';
+export * as LanguageSupport from '@neo4j-cypher/language-support';
 export { CypherEditor } from './CypherEditor';
 export { cypher } from './lang-cypher/langCypher';
 export { darkThemeConstants, lightThemeConstants } from './themes';


### PR DESCRIPTION
No need to list all the public exports `@neo4j-cypher/language-support` on by one