### PR TITLE
Expose tab focus mode prop so we can override tab-trapping behaviour

### DIFF
--- a/.changeset/shiny-dodos-rush.md
+++ b/.changeset/shiny-dodos-rush.md
@@ -2,4 +2,4 @@
 '@neo4j-cypher/react-codemirror': patch
 ---
 
-Expose CodeMirror setTabFocusMode property in the CypherEditor
+Expose moveFocusOnTab property on the CypherEditor component to conditionally disable tab keymappings

--- a/.changeset/shiny-dodos-rush.md
+++ b/.changeset/shiny-dodos-rush.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/react-codemirror': patch
+---
+
+Expose CodeMirror setTabFocusMode property in the CypherEditor

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -166,14 +166,14 @@ export interface CypherEditorProps {
   ariaLabel?: string;
 
   /**
-   * Whether to enable or disable tab focus mode.
+   * Whether keybindings for inserting indents with the Tab key should be disabled.
    *
-   * true will allow the brower's default tabbing behavior.
-   * false will enable tab-trapping within the editor.
+   * true will not create keybindings for inserting indents.
+   * false will create keybindings for inserting indents.
    *
    * @default false
    */
-  setTabFocusMode?: boolean;
+  moveFocusOnTab?: boolean;
 }
 
 const executeKeybinding = (
@@ -320,7 +320,7 @@ export class CypherEditor extends Component<
     theme: 'light',
     lineNumbers: true,
     newLineOnEnter: false,
-    setTabFocusMode: false,
+    moveFocusOnTab: false,
   };
 
   private debouncedOnChange = this.props.onChange
@@ -344,7 +344,6 @@ export class CypherEditor extends Component<
       featureFlags,
       onExecute,
       newLineOnEnter,
-      setTabFocusMode,
     } = this.props;
 
     this.schemaRef.current = {
@@ -395,7 +394,7 @@ export class CypherEditor extends Component<
           ]),
         ),
         historyNavigation(this.props),
-        basicNeo4jSetup(),
+        basicNeo4jSetup(this.props),
         themeCompartment.of(themeExtension),
         changeListener,
         cypher(this.schemaRef.current),
@@ -428,8 +427,6 @@ export class CypherEditor extends Component<
       state: this.editorState.current,
       parent: this.editorContainer.current,
     });
-
-    this.editorView.current.setTabFocusMode(setTabFocusMode);
 
     if (this.props.autofocus) {
       this.focus();

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -161,9 +161,19 @@ export interface CypherEditorProps {
   readonly?: boolean;
 
   /**
-   * String value to assign to the aria-label attribute of the editor
+   * String value to assign to the aria-label attribute of the editor.
    */
   ariaLabel?: string;
+
+  /**
+   * Whether to enable or disable tab focus mode.
+   *
+   * true will allow the brower's default tabbing behavior.
+   * false will enable tab-trapping within the editor.
+   *
+   * @default false
+   */
+  setTabFocusMode?: boolean;
 }
 
 const executeKeybinding = (
@@ -310,6 +320,7 @@ export class CypherEditor extends Component<
     theme: 'light',
     lineNumbers: true,
     newLineOnEnter: false,
+    setTabFocusMode: false,
   };
 
   private debouncedOnChange = this.props.onChange
@@ -333,6 +344,7 @@ export class CypherEditor extends Component<
       featureFlags,
       onExecute,
       newLineOnEnter,
+      setTabFocusMode,
     } = this.props;
 
     this.schemaRef.current = {
@@ -416,6 +428,8 @@ export class CypherEditor extends Component<
       state: this.editorState.current,
       parent: this.editorContainer.current,
     });
+
+    this.editorView.current.setTabFocusMode(setTabFocusMode);
 
     if (this.props.autofocus) {
       this.focus();

--- a/packages/react-codemirror/src/neo4jSetup.tsx
+++ b/packages/react-codemirror/src/neo4jSetup.tsx
@@ -61,7 +61,13 @@ const insertTab: StateCommand = (cmd) => {
   return true;
 };
 
-export const basicNeo4jSetup = (): Extension[] => {
+type SetupProps = {
+  moveFocusOnTab?: boolean;
+};
+
+export const basicNeo4jSetup = ({
+  moveFocusOnTab = false,
+}: SetupProps): Extension[] => {
   const keymaps: KeyBinding[] = [
     closeBracketsKeymap,
     defaultKeymap,
@@ -70,22 +76,27 @@ export const basicNeo4jSetup = (): Extension[] => {
     foldKeymap,
     completionKeymap,
     lintKeymap,
-    {
-      key: 'Tab',
-      preventDefault: true,
-      run: acceptCompletion,
-    },
-    {
-      key: 'Tab',
-      preventDefault: true,
-      run: insertTab,
-    },
-    {
-      key: 'Shift-Tab',
-      preventDefault: true,
-      run: indentLess,
-    },
   ].flat();
+
+  if (!moveFocusOnTab) {
+    keymaps.push(
+      {
+        key: 'Tab',
+        preventDefault: true,
+        run: acceptCompletion,
+      },
+      {
+        key: 'Tab',
+        preventDefault: true,
+        run: insertTab,
+      },
+      {
+        key: 'Shift-Tab',
+        preventDefault: true,
+        run: indentLess,
+      },
+    );
+  }
 
   const extensions: Extension[] = [];
 


### PR DESCRIPTION
It would be useful to expose this property so that we are able to override the tab behaviour of the editor.

By default in the neo4j setup, we set up handlers for Tab and Shift-Tab - however this traps the user in the editor. Whilst it's then possible to use Esc to remove focus from the editor, in some circumstances (e.g. the editor is in a modal where Esc closes the modal), it'd be nice to be able to disable tab trapping - even though this does mean disabling Tab for accepting autocompletions

https://codemirror.net/docs/ref/#view.EditorView.setTabFocusMode