### PR TITLE
Adds minor nits to the VSCode extension

### DIFF
--- a/.changeset/loud-shrimps-push.md
+++ b/.changeset/loud-shrimps-push.md
@@ -1,0 +1,6 @@
+---
+'@neo4j-cypher/react-codemirror': patch
+'@neo4j-cypher/language-server': patch
+---
+
+Fixes bug with auto-completions

--- a/packages/language-server/src/autocompletion.ts
+++ b/packages/language-server/src/autocompletion.ts
@@ -22,7 +22,8 @@ export function doAutoCompletion(
     const offset = textDocument.offsetAt(position);
 
     const completions: CompletionItem[] = autocomplete(
-      textDocument.getText(),
+      // TODO This is a temporary hack because completions are not working well
+      textDocument.getText().slice(0, offset),
       neo4j.metadata?.dbSchema ?? {},
       offset,
       completionParams.context.triggerKind === CompletionTriggerKind.Invoked,

--- a/packages/react-codemirror/src/lang-cypher/autocomplete.ts
+++ b/packages/react-codemirror/src/lang-cypher/autocomplete.ts
@@ -77,7 +77,8 @@ export const cypherAutocomplete: (config: CypherConfig) => CompletionSource =
     }
 
     const options = autocomplete(
-      documentText,
+      // TODO This is a temporary hack because completions are not working well
+      documentText.slice(0, context.pos),
       config.schema ?? {},
       context.pos,
       context.explicit,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # neo4j-for-vscode
 
+## 1.5.1
+
+- Fixes bug with auto-completions
+
 ## 1.5.0
 
 - Adds ability to execute highlighted queries

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -68,6 +68,10 @@
       {
         "command": "neo4j.runCypher",
         "title": "Neo4j: Run Cypher Statements"
+      },
+      {
+        "command": "neo4j.cypherFileFromSelection",
+        "title": "Neo4j: Create Cypher file from selection"
       }
     ],
     "keybindings": [
@@ -92,6 +96,11 @@
         {
           "command": "neo4j.runCypher",
           "when": "resourceLangId == cypher || (editorHasSelection && (resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python))",
+          "group": "z_commands"
+        },
+        {
+          "command": "neo4j.cypherFileFromSelection",
+          "when": "editorHasSelection && (resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python)",
           "group": "z_commands"
         }
       ],

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -8,6 +8,7 @@ export const CONSTANTS = {
     DISCONNECT_COMMAND: 'neo4j.disconnect',
     SWITCH_DATABASE_COMMAND: 'neo4j.switchDatabase',
     RUN_CYPHER: 'neo4j.runCypher',
+    CYPHER_FILE_FROM_SELECTION: 'neo4j.cypherFileFromSelection',
   },
   MESSAGES: {
     CONNECTED_MESSAGE: 'Connected to Neo4j.',

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -1,6 +1,7 @@
 import { commands, Disposable, window, workspace } from 'vscode';
 import {
   createOrShowConnectionPanelForConnectionItem,
+  cypherFileFromSelection,
   handleNeo4jConfigurationChangedEvent,
   promptUserToDeleteConnectionAndDisplayConnectionResult,
   runCypher,
@@ -67,6 +68,10 @@ export function registerDisposables(): Disposable[] {
     commands.registerCommand(
       CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
       (connectionItem: ConnectionItem) => switchToDatabase(connectionItem),
+    ),
+    commands.registerCommand(
+      CONSTANTS.COMMANDS.CYPHER_FILE_FROM_SELECTION,
+      cypherFileFromSelection,
     ),
   );
 


### PR DESCRIPTION
## What
* Completions are a bit broken, so I'm going to push a small hotfix that reverts to just reparsing up to the cursor. That would come with a performance hit, but it won't be noticeable unless on a big query. I prefer the demo tomorrow to be neat.
* It would be handy to get a button on the context menu to open the current selection in a temp file selecting the language cypher (instead of the user having to copy paste text, create the file manually, etc)

<img width="904" alt="vscode-menu" src="https://github.com/user-attachments/assets/6b6dadcc-e9e9-4645-8974-6bdbe016a789">

## Why
Ahead of the NODES talk, we want the VSCode extension to work smoothly