### PR TITLE
Fixes signature help bug with default arguments in VSCode

### DIFF
--- a/.changeset/angry-beers-explain.md
+++ b/.changeset/angry-beers-explain.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes signature help bug with arguments that include a default value

--- a/package-lock.json
+++ b/package-lock.json
@@ -24456,7 +24456,7 @@
     },
     "packages/vscode-extension": {
       "name": "neo4j-for-vscode",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@neo4j-cypher/language-server": "2.0.0-next.11",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # neo4j-for-vscode
 
+## 1.5.2
+
+- Fixes signature help bug with arguments that include a default value
+
 ## 1.5.1
 
 - Fixes bug with auto-completions

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "neo4j-extensions",
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "preview": true,
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
## Before

<img width="861"  src="https://github.com/user-attachments/assets/8a209a61-f6f6-4bc3-bebe-bb7937b4b29b">

## After

<img width="865" src="https://github.com/user-attachments/assets/0e12b042-1202-48f3-96a7-a495f842e13b">
