### PR TITLE
Fixes release job

### DIFF
--- a/.github/workflows/publish-npm-packages.yaml
+++ b/.github/workflows/publish-npm-packages.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
   canary-release-to-npm:
     name: 'Canary release to npm'
+    needs: stable-release-to-npm
     environment: publish-npm
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +35,6 @@ jobs:
 
   stable-release-to-npm:
     name: 'Stable release to npm'
-    needs: canary-release-to-npm
     environment: publish-npm
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When a changeset PR gets merged, the versions are bumped to non-canary ones. If the canary job release happened before the fixed version release, `npm` would complain those versions are not around when trying to build the project.