### PR TITLE
Fixes bug with preparser options making semantic errors not show up correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22570,10 +22570,10 @@
     },
     "packages/language-server": {
       "name": "@neo4j-cypher/language-server",
-      "version": "2.0.0-next.11",
+      "version": "2.0.0-next.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.10",
+        "@neo4j-cypher/language-support": "2.0.0-next.11",
         "lodash.debounce": "^4.0.8",
         "neo4j-driver": "^5.3.0",
         "vscode-languageserver": "^8.1.0",
@@ -23001,7 +23001,7 @@
     },
     "packages/language-support": {
       "name": "@neo4j-cypher/language-support",
-      "version": "2.0.0-next.10",
+      "version": "2.0.0-next.11",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "*",
@@ -23019,7 +23019,7 @@
     },
     "packages/react-codemirror": {
       "name": "@neo4j-cypher/react-codemirror",
-      "version": "2.0.0-next.13",
+      "version": "2.0.0-next.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
@@ -23031,7 +23031,7 @@
         "@codemirror/view": "^6.29.1",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.10",
+        "@neo4j-cypher/language-support": "2.0.0-next.11",
         "@types/prismjs": "^1.26.3",
         "@types/workerpool": "^6.4.7",
         "ayu": "^8.0.1",
@@ -23066,15 +23066,15 @@
     },
     "packages/react-codemirror-playground": {
       "name": "@neo4j-cypher/react-codemirror-playground",
-      "version": "2.0.0-next.13",
+      "version": "2.0.0-next.14",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
         "@codemirror/commands": "^6.2.2",
         "@codemirror/language": "^6.6.0",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.10",
-        "@neo4j-cypher/react-codemirror": "2.0.0-next.13",
+        "@neo4j-cypher/language-support": "2.0.0-next.11",
+        "@neo4j-cypher/react-codemirror": "2.0.0-next.14",
         "react": "^18.2.0",
         "react-d3-tree": "^3.6.1",
         "react-dom": "^18.2.0",
@@ -24425,10 +24425,10 @@
     },
     "packages/schema-poller": {
       "name": "@neo4j-cypher/schema-poller",
-      "version": "2.0.0-next.10",
+      "version": "2.0.0-next.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.10",
+        "@neo4j-cypher/language-support": "2.0.0-next.11",
         "ajv": "^8.12.0",
         "neo4j-driver": "^5.12.0"
       },
@@ -24459,7 +24459,7 @@
       "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-server": "2.0.0-next.11",
+        "@neo4j-cypher/language-server": "2.0.0-next.12",
         "@neo4j-ndl/base": "^2.12.3",
         "@neo4j-ndl/react": "^2.16.5",
         "neo4j-driver": "^5.12.0",

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -426,13 +426,16 @@ function parseToCommand(
   if (stmt) {
     const { start, stop } = stmt;
 
-    const cypherStmt = stmt.preparsedStatement();
+    const cypherStmt = stmt.preparsedStatement()?.statement();
     if (cypherStmt) {
       // we get the original text input to preserve whitespace
+      // stripping the preparser part of it
       const inputstream = start.getInputStream();
-      const statement = inputstream.getText(start.start, stop.stop);
+      const stmtStart = cypherStmt.start;
+      const stmtStop = cypherStmt.stop;
+      const statement = inputstream.getText(stmtStart.start, stmtStop.stop);
 
-      return { type: 'cypher', statement, start, stop };
+      return { type: 'cypher', statement, start: stmtStart, stop: stmtStop };
     }
 
     if (isEmptyStatement) {

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -53,32 +53,6 @@ describe('Semantic validation spec', () => {
     ]);
   });
 
-  test('Semantic errors work when we also have preparser options', () => {
-    const query = 'EXPLAIN MATCH (n)';
-
-    expect(getDiagnosticsForQuery({ query })).toEqual([
-      {
-        message:
-          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
-        offsets: {
-          end: 17,
-          start: 8,
-        },
-        range: {
-          end: {
-            character: 17,
-            line: 0,
-          },
-          start: {
-            character: 8,
-            line: 0,
-          },
-        },
-        severity: 1,
-      },
-    ]);
-  });
-
   test('Handles multiple statements in semantic analysis', () => {
     const query = `MATCH (n) RETURN m;
     
@@ -119,6 +93,51 @@ describe('Semantic validation spec', () => {
           start: {
             character: 4,
             line: 3,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Semantic errors work when we also have preparser options', () => {
+    const query = `EXPLAIN MATCH (n);
+                   PROFILE MATCH (m) RETURN n`;
+
+    expect(getDiagnosticsForQuery({ query })).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 17,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 17,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message: 'Variable `n` not defined',
+        offsets: {
+          end: 64,
+          start: 63,
+        },
+        range: {
+          end: {
+            character: 45,
+            line: 1,
+          },
+          start: {
+            character: 44,
+            line: 1,
           },
         },
         severity: 1,

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -53,6 +53,32 @@ describe('Semantic validation spec', () => {
     ]);
   });
 
+  test('Semantic errors work when we also have preparser options', () => {
+    const query = 'EXPLAIN MATCH (n)';
+
+    expect(getDiagnosticsForQuery({ query })).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 17,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 17,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
   test('Handles multiple statements in semantic analysis', () => {
     const query = `MATCH (n) RETURN m;
     


### PR DESCRIPTION
## What

It only extracts the statement in the command parsing, omitting the preparsing options.

## Why

We were not showing semantic errors correctly for queries that included a preparsing option, because the semantic analysis does not have a preparser inside, it expects already a pre-processed query.

```
EXPLAIN MATCH (n)
// It should be showing an error in the MATCH (n) here because we are missing a RETURN
```