### PR TITLE
(Very minor) Using Set over List for already given return names in YIELD

### DIFF
--- a/.changeset/old-shoes-provide.md
+++ b/.changeset/old-shoes-provide.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Adds autocompletions following YIELD in a procedure call

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -477,12 +477,12 @@ export function completionCoreCompletion(
         );
         if (callContext instanceof CallClauseContext) {
           const procedureNameCtx = callContext.procedureName();
-          const existingYieldItems = callContext
-            .procedureResultItem_list()
-            .map((a) => a.getText());
+          const existingYieldItems = new Set(
+            callContext.procedureResultItem_list().map((a) => a.getText()),
+          );
           const name = getMethodName(procedureNameCtx);
           return procedureReturnCompletions(name, dbSchema).filter(
-            (a) => !existingYieldItems.includes(a?.label),
+            (a) => !existingYieldItems.has(a?.label),
           );
         }
       }

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -477,8 +477,13 @@ export function completionCoreCompletion(
         );
         if (callContext instanceof CallClauseContext) {
           const procedureNameCtx = callContext.procedureName();
+          const existingYieldItems = callContext
+            .procedureResultItem_list()
+            .map((a) => a.getText());
           const name = getMethodName(procedureNameCtx);
-          return procedureReturnCompletions(name, dbSchema);
+          return procedureReturnCompletions(name, dbSchema).filter(
+            (a) => !existingYieldItems.includes(a?.label),
+          );
         }
       }
 

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -64,7 +64,7 @@ const procedureReturnCompletions = (
   dbSchema: DbSchema,
 ): CompletionItem[] => {
   return (
-    dbSchema?.procedures[procedureName]?.returnDescription?.map((x) => {
+    dbSchema?.procedures?.[procedureName]?.returnDescription?.map((x) => {
       return { label: x.name, kind: CompletionItemKind.Variable };
     }) ?? []
   );

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -13,6 +13,7 @@ import {
   LabelNameIsContext,
   LabelOrRelTypeContext,
   ProcedureNameContext,
+  ProcedureResultItemContext,
   StatementOrCommandContext,
   StatementsOrCommandsContext,
   SymbolicNameStringContext,
@@ -304,6 +305,12 @@ class VariableCollector implements ParseTreeListener {
       );
 
       if (variable && !nextTokenIsEOF && definesVariable) {
+        this.variables.push(variable);
+      }
+    }
+    if (ctx instanceof ProcedureResultItemContext) {
+      const variable = ctx.symbolicNameString().getText();
+      if (variable) {
         this.variables.push(variable);
       }
     }

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -310,6 +310,33 @@ class VariableCollector implements ParseTreeListener {
   }
 }
 
+export function getMethodName(
+  ctx: ProcedureNameContext | FunctionNameContext,
+): string {
+  const namespaces = ctx.namespace().symbolicNameString_list();
+  const methodName = ctx.symbolicNameString();
+
+  const normalizedName = [...namespaces, methodName]
+    .map((symbolicName) => {
+      return getNamespaceString(symbolicName);
+    })
+    .join('.');
+
+  return normalizedName;
+}
+
+function getNamespaceString(ctx: SymbolicNameStringContext): string {
+  const text = ctx.getText();
+  const isEscaped = Boolean(ctx.escapedSymbolicNameString());
+  const hasDot = text.includes('.');
+
+  if (isEscaped && !hasDot) {
+    return text.slice(1, -1);
+  }
+
+  return text;
+}
+
 // This listener collects all functions and procedures
 class MethodsCollector extends ParseTreeListener {
   public procedures: ParsedProcedure[] = [];
@@ -336,7 +363,7 @@ class MethodsCollector extends ParseTreeListener {
       ctx instanceof FunctionNameContext ||
       ctx instanceof ProcedureNameContext
     ) {
-      const methodName = this.getMethodName(ctx);
+      const methodName = getMethodName(ctx);
 
       const startTokenIndex = ctx.start.tokenIndex;
       const stopTokenIndex = ctx.stop.tokenIndex;
@@ -365,33 +392,6 @@ class MethodsCollector extends ParseTreeListener {
         this.procedures.push(result);
       }
     }
-  }
-
-  private getMethodName(
-    ctx: ProcedureNameContext | FunctionNameContext,
-  ): string {
-    const namespaces = ctx.namespace().symbolicNameString_list();
-    const methodName = ctx.symbolicNameString();
-
-    const normalizedName = [...namespaces, methodName]
-      .map((symbolicName) => {
-        return this.getNamespaceString(symbolicName);
-      })
-      .join('.');
-
-    return normalizedName;
-  }
-
-  private getNamespaceString(ctx: SymbolicNameStringContext): string {
-    const text = ctx.getText();
-    const isEscaped = Boolean(ctx.escapedSymbolicNameString());
-    const hasDot = text.includes('.');
-
-    if (isEscaped && !hasDot) {
-      return text.slice(1, -1);
-    }
-
-    return text;
   }
 }
 

--- a/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
@@ -18,6 +18,7 @@ describe('Procedures auto-completion', () => {
       'db.stats.retrieve': procedures['db.stats.retrieve'],
       'db.stats.collect': procedures['db.stats.collect'],
       'db.stats.clear': procedures['db.stats.clear'],
+      'dbms.components': procedures['dbms.components'],
       'cdc.current': procedures['cdc.current'],
       'jwt.security.requestAccess': {
         ...testData.emptyProcedure,
@@ -286,6 +287,68 @@ describe('Procedures auto-completion', () => {
           tags: [CompletionItemTag.Deprecated],
         },
       ],
+    });
+  });
+
+  test('Correctly completes YIELD', () => {
+    const query = 'CALL dbms.components() YIELD ';
+
+    testCompletions({
+      query,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+  });
+
+  test('Correctly completes YIELD when we have extra spaces in the procedure name', () => {
+    const query = 'CALL dbms    .    components  () YIELD ';
+
+    testCompletions({
+      query,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+  });
+
+  test('Correctly completes YIELD when we have backticks in the procedure name', () => {
+    const query1 = 'CALL `dbms`.`components`() YIELD ';
+    const query2 = 'CALL db.`stats`.`collect`   () YIELD ';
+
+    testCompletions({
+      query: query1,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+    testCompletions({
+      query: query2,
+      dbSchema,
+      expected: [
+        { label: 'section', kind: CompletionItemKind.Variable },
+        { label: 'success', kind: CompletionItemKind.Variable },
+        { label: 'message', kind: CompletionItemKind.Variable },
+      ],
+    });
+  });
+
+  test('Returns empty YIELD elements when procedure does not exist', () => {
+    const query = 'CALL does.not.exist() YIELD ';
+
+    testCompletions({
+      query,
+      dbSchema,
+      expected: [],
     });
   });
 });

--- a/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
@@ -318,6 +318,51 @@ describe('Procedures auto-completion', () => {
     });
   });
 
+  test('Does not autocomplete duplicate variables for YIELD', () => {
+    const query1 = 'CALL dbms.components() YIELD name,  ';
+    const query2 = 'CALL dbms.components() YIELD versions,  ve';
+
+    testCompletions({
+      query: query1,
+      dbSchema,
+      excluded: [{ label: 'name', kind: CompletionItemKind.Variable }],
+    });
+
+    testCompletions({
+      query: query2,
+      dbSchema,
+      excluded: [{ label: 'versions', kind: CompletionItemKind.Variable }],
+    });
+  });
+
+  test('Correctly completes RETURN when we have variables from a YIELD statement', () => {
+    const query1 = 'CALL dbms.components() YIELD name, edition RETURN ';
+    const query2 = 'CALL dbms.components() YIELD name, versions RETURN ';
+    const query3 =
+      'CALL dbms.components() YIELD name, edition RETURN edition, nam';
+    testCompletions({
+      query: query1,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+    testCompletions({
+      query: query2,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+      ],
+    });
+    testCompletions({
+      query: query3,
+      dbSchema,
+      expected: [{ label: 'name', kind: CompletionItemKind.Variable }],
+    });
+  });
+
   test('Correctly completes YIELD when we have started the return value name', () => {
     const query1 = 'CALL dbms.components() YIELD n';
     const query2 = 'CALL dbms.components() YIELD name, ed';

--- a/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
@@ -318,6 +318,39 @@ describe('Procedures auto-completion', () => {
     });
   });
 
+  test('Correctly completes YIELD when we have started the return value name', () => {
+    const query1 = 'CALL dbms.components() YIELD n';
+    const query2 = 'CALL dbms.components() YIELD name, ed';
+    const query3 = 'CALL dbms.components() YIELD name, edition,';
+    testCompletions({
+      query: query1,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+    testCompletions({
+      query: query2,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'edition', kind: CompletionItemKind.Variable },
+      ],
+    });
+    testCompletions({
+      query: query3,
+      dbSchema,
+      expected: [
+        { label: 'name', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+        { label: 'versions', kind: CompletionItemKind.Variable },
+      ],
+    });
+  });
+
   test('Correctly completes YIELD when we have backticks in the procedure name', () => {
     const query1 = 'CALL `dbms`.`components`() YIELD ';
     const query2 = 'CALL db.`stats`.`collect`   () YIELD ';

--- a/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/procedureCompletion.test.ts
@@ -380,7 +380,6 @@ describe('Procedures auto-completion', () => {
       query: query2,
       dbSchema,
       expected: [
-        { label: 'name', kind: CompletionItemKind.Variable },
         { label: 'versions', kind: CompletionItemKind.Variable },
         { label: 'edition', kind: CompletionItemKind.Variable },
       ],
@@ -388,11 +387,7 @@ describe('Procedures auto-completion', () => {
     testCompletions({
       query: query3,
       dbSchema,
-      expected: [
-        { label: 'name', kind: CompletionItemKind.Variable },
-        { label: 'versions', kind: CompletionItemKind.Variable },
-        { label: 'versions', kind: CompletionItemKind.Variable },
-      ],
+      expected: [{ label: 'versions', kind: CompletionItemKind.Variable }],
     });
   });
 


### PR DESCRIPTION
Updates existing change adding YIELD autocompletions so that we check suggestions against existing elements stored in a Set (Hash-set) so that it's reliably quick in case of large amounts of return names.