### PR TITLE
Alter so labels with numbers and underscores dont get needless backticks

### DIFF
--- a/.changeset/nice-jokes-give.md
+++ b/.changeset/nice-jokes-give.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Modified backtick insertion to only happen when really necessary

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -32,7 +32,7 @@ import { CompletionItem, Neo4jFunction, Neo4jProcedure } from '../types';
 const uniq = <T>(arr: T[]) => Array.from(new Set(arr));
 
 function backtickIfNeeded(e: string): string | undefined {
-  if (/\s/.test(e) || /[^a-zA-Z]/.test(e)) {
+  if (/\s/.test(e) || /[^a-zA-Z0-9_]/.test(e)) {
     return `\`${e}\``;
   } else {
     return undefined;

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -32,7 +32,7 @@ import { CompletionItem, Neo4jFunction, Neo4jProcedure } from '../types';
 const uniq = <T>(arr: T[]) => Array.from(new Set(arr));
 
 function backtickIfNeeded(e: string): string | undefined {
-  if (/\s/.test(e) || /[^a-zA-Z0-9_]/.test(e)) {
+  if (/[^\p{L}\p{N}_]/u.test(e) || /[^\p{L}_]/u.test(e[0])) {
     return `\`${e}\``;
   } else {
     return undefined;

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -32,7 +32,9 @@ import { CompletionItem, Neo4jFunction, Neo4jProcedure } from '../types';
 const uniq = <T>(arr: T[]) => Array.from(new Set(arr));
 
 function backtickIfNeeded(e: string): string | undefined {
-  if (/[^\p{L}\p{N}_]/u.test(e) || /[^\p{L}_]/u.test(e[0])) {
+  if (e == null || e == '') {
+    return undefined;
+  } else if (/[^\p{L}\p{N}_]/u.test(e) || /[^\p{L}_]/u.test(e[0])) {
     return `\`${e}\``;
   } else {
     return undefined;

--- a/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
@@ -92,35 +92,8 @@ describe('MATCH auto-completion', () => {
 
     testCompletions({
       query,
-      dbSchema: { labels: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'] },
-      expected: [
-        {
-          label: 'Cat12',
-          kind: CompletionItemKind.TypeParameter,
-        },
-        {
-          label: 'Foo_Bar',
-          kind: CompletionItemKind.TypeParameter,
-        },
-        {
-          label: 'Glögg',
-          kind: CompletionItemKind.TypeParameter,
-        },
-        {
-          label: 'Glühwein',
-          kind: CompletionItemKind.TypeParameter,
-        },
-      ],
-    });
-  });
-
-  test('Completes relationship types with numbers, underscores and non-english letters without backticks in MATCH', () => {
-    const query = 'MATCH (n)-[:';
-
-    testCompletions({
-      query,
       dbSchema: {
-        relationshipTypes: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'],
+        labels: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein', '_GingerBread_'],
       },
       expected: [
         {
@@ -137,6 +110,49 @@ describe('MATCH auto-completion', () => {
         },
         {
           label: 'Glühwein',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '_GingerBread_',
+          kind: CompletionItemKind.TypeParameter,
+        },
+      ],
+    });
+  });
+
+  test('Completes relationship types with numbers, underscores and non-english letters without backticks in MATCH', () => {
+    const query = 'MATCH (n)-[:';
+
+    testCompletions({
+      query,
+      dbSchema: {
+        relationshipTypes: [
+          'Cat12',
+          'Foo_Bar',
+          'Glögg',
+          'Glühwein',
+          '_GingerBread_',
+        ],
+      },
+      expected: [
+        {
+          label: 'Cat12',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Foo_Bar',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glögg',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glühwein',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '_GingerBread_',
           kind: CompletionItemKind.TypeParameter,
         },
       ],

--- a/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
@@ -87,12 +87,12 @@ describe('MATCH auto-completion', () => {
     });
   });
 
-  test('Completes label with numbers and underscores without backticks in MATCH', () => {
+  test('Completes label with numbers, underscores and non-english letters without backticks in MATCH', () => {
     const query = 'MATCH (n:';
 
     testCompletions({
       query,
-      dbSchema: { labels: ['Cat12', 'Foo_Bar'] },
+      dbSchema: { labels: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'] },
       expected: [
         {
           label: 'Cat12',
@@ -100,18 +100,28 @@ describe('MATCH auto-completion', () => {
         },
         {
           label: 'Foo_Bar',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glögg',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glühwein',
           kind: CompletionItemKind.TypeParameter,
         },
       ],
     });
   });
 
-  test('Completes relationship types with numbers and underscores without backticks in MATCH', () => {
+  test('Completes relationship types with numbers, underscores and non-english letters without backticks in MATCH', () => {
     const query = 'MATCH (n)-[:';
 
     testCompletions({
       query,
-      dbSchema: { relationshipTypes: ['Cat12', 'Foo_Bar'] },
+      dbSchema: {
+        relationshipTypes: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'],
+      },
       expected: [
         {
           label: 'Cat12',
@@ -119,6 +129,14 @@ describe('MATCH auto-completion', () => {
         },
         {
           label: 'Foo_Bar',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glögg',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Glühwein',
           kind: CompletionItemKind.TypeParameter,
         },
       ],
@@ -130,7 +148,7 @@ describe('MATCH auto-completion', () => {
 
     testCompletions({
       query,
-      dbSchema: { labels: ['Cat', 'Foo Bar'] },
+      dbSchema: { labels: ['Cat', 'Foo Bar', '1Foo'] },
       expected: [
         {
           label: 'Cat',
@@ -139,6 +157,11 @@ describe('MATCH auto-completion', () => {
         {
           label: 'Foo Bar',
           insertText: '`Foo Bar`',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '1Foo',
+          insertText: '`1Foo`',
           kind: CompletionItemKind.TypeParameter,
         },
       ],
@@ -150,7 +173,7 @@ describe('MATCH auto-completion', () => {
 
     testCompletions({
       query,
-      dbSchema: { labels: ['Cat', 'Foo Bar'] },
+      dbSchema: { labels: ['Cat', 'Foo Bar', '1Foo'] },
       expected: [
         // This first completion would not be offered in a client
         {
@@ -160,6 +183,11 @@ describe('MATCH auto-completion', () => {
         {
           label: 'Foo Bar',
           insertText: '`Foo Bar`',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '1Foo',
+          insertText: '`1Foo`',
           kind: CompletionItemKind.TypeParameter,
         },
       ],
@@ -490,7 +518,7 @@ describe('Type relationship auto-completion', () => {
 
     testCompletions({
       query,
-      dbSchema: { relationshipTypes: ['Rel', 'Foo Bar'] },
+      dbSchema: { relationshipTypes: ['Rel', 'Foo Bar', '1Foo'] },
       expected: [
         {
           label: 'Rel',
@@ -499,6 +527,11 @@ describe('Type relationship auto-completion', () => {
         {
           label: 'Foo Bar',
           insertText: '`Foo Bar`',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '1Foo',
+          insertText: '`1Foo`',
           kind: CompletionItemKind.TypeParameter,
         },
       ],
@@ -510,7 +543,7 @@ describe('Type relationship auto-completion', () => {
 
     testCompletions({
       query,
-      dbSchema: { relationshipTypes: ['Rel', 'Foo Bar'] },
+      dbSchema: { relationshipTypes: ['Rel', 'Foo Bar', '1Foo'] },
       expected: [
         {
           label: 'Rel',
@@ -519,6 +552,11 @@ describe('Type relationship auto-completion', () => {
         {
           label: 'Foo Bar',
           insertText: '`Foo Bar`',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: '1Foo',
+          insertText: '`1Foo`',
           kind: CompletionItemKind.TypeParameter,
         },
       ],

--- a/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
@@ -87,6 +87,25 @@ describe('MATCH auto-completion', () => {
     });
   });
 
+  test('Completes label with numbers and underscores without backticks in MATCH', () => {
+    const query = 'MATCH (n:';
+
+    testCompletions({
+      query,
+      dbSchema: { labels: ['Cat12', 'Foo_Bar'] },
+      expected: [
+        {
+          label: 'Cat12',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Foo_Bar',
+          kind: CompletionItemKind.TypeParameter,
+        },
+      ],
+    });
+  });
+
   test('Correctly completes label with backticks in MATCH', () => {
     const query = 'MATCH (n:';
 

--- a/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/patternCompletion.test.ts
@@ -106,6 +106,25 @@ describe('MATCH auto-completion', () => {
     });
   });
 
+  test('Completes relationship types with numbers and underscores without backticks in MATCH', () => {
+    const query = 'MATCH (n)-[:';
+
+    testCompletions({
+      query,
+      dbSchema: { relationshipTypes: ['Cat12', 'Foo_Bar'] },
+      expected: [
+        {
+          label: 'Cat12',
+          kind: CompletionItemKind.TypeParameter,
+        },
+        {
+          label: 'Foo_Bar',
+          kind: CompletionItemKind.TypeParameter,
+        },
+      ],
+    });
+  });
+
   test('Correctly completes label with backticks in MATCH', () => {
     const query = 'MATCH (n:';
 

--- a/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
@@ -155,12 +155,12 @@ RETURN movie {
     });
   });
 
-  test('Completes node property keys with numbers and underscores without backticks in MATCH', () => {
+  test('Completes node property keys with numbers, underscores and non-english letters without backticks in MATCH', () => {
     const query = 'MATCH (n) WHERE n.';
 
     testCompletions({
       query,
-      dbSchema: { propertyKeys: ['Cat12', 'Foo_Bar'] },
+      dbSchema: { propertyKeys: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'] },
       expected: [
         {
           label: 'Cat12',
@@ -168,6 +168,14 @@ RETURN movie {
         },
         {
           label: 'Foo_Bar',
+          kind: CompletionItemKind.Property,
+        },
+        {
+          label: 'Glögg',
+          kind: CompletionItemKind.Property,
+        },
+        {
+          label: 'Glühwein',
           kind: CompletionItemKind.Property,
         },
       ],

--- a/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
@@ -155,6 +155,25 @@ RETURN movie {
     });
   });
 
+  test('Completes node property keys with numbers and underscores without backticks in MATCH', () => {
+    const query = 'MATCH (n) WHERE n.';
+
+    testCompletions({
+      query,
+      dbSchema: { propertyKeys: ['Cat12', 'Foo_Bar'] },
+      expected: [
+        {
+          label: 'Cat12',
+          kind: CompletionItemKind.Property,
+        },
+        {
+          label: 'Foo_Bar',
+          kind: CompletionItemKind.Property,
+        },
+      ],
+    });
+  });
+
   test('correctly completes property keys with backticks', () => {
     const dbSchema = { propertyKeys: ['foo bar', 'prop'] };
     const query = 'MATCH (n) WHERE n.';

--- a/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/propertykeyCompletion.test.ts
@@ -160,7 +160,15 @@ RETURN movie {
 
     testCompletions({
       query,
-      dbSchema: { propertyKeys: ['Cat12', 'Foo_Bar', 'Glögg', 'Glühwein'] },
+      dbSchema: {
+        propertyKeys: [
+          'Cat12',
+          'Foo_Bar',
+          'Glögg',
+          'Glühwein',
+          '_GingerBread_',
+        ],
+      },
       expected: [
         {
           label: 'Cat12',
@@ -176,6 +184,10 @@ RETURN movie {
         },
         {
           label: 'Glühwein',
+          kind: CompletionItemKind.Property,
+        },
+        {
+          label: '_GingerBread_',
           kind: CompletionItemKind.Property,
         },
       ],


### PR DESCRIPTION
Before if for example had relationship rel_123, we autocompleted `MATCH (n)-[:rel^]` to
` MATCH (n)-[:`\``rel_123`\``] `
Now instead we dont backtick if we have underscore and numbers in label names/rel names/properties and just give
`MATCH (n)-[:rel_123]`