### PR TITLE
List -> Set in checking existing yield items 

### DIFF
--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -478,12 +478,12 @@ export function completionCoreCompletion(
         );
         if (callContext instanceof CallClauseContext) {
           const procedureNameCtx = callContext.procedureName();
-          const existingYieldItems = callContext
-            .procedureResultItem_list()
-            .map((a) => a.getText());
+          const existingYieldItems = new Set(
+            callContext.procedureResultItem_list().map((a) => a.getText()),
+          );
           const name = getMethodName(procedureNameCtx);
           return procedureReturnCompletions(name, dbSchema).filter(
-            (a) => !existingYieldItems.includes(a?.label),
+            (a) => !existingYieldItems.has(a?.label),
           );
         }
       }


### PR DESCRIPTION
Updates existing change adding YIELD autocompletions so that we check suggestions against existing elements stored in a Set (Hash-set) so that it's reliably quick in case of large amounts of return names.