### PR TITLE
[DO NOT MERGE] Measures performance with normal parser

### DIFF
--- a/packages/language-support/src/tests/benchmarks/benchmark.ts
+++ b/packages/language-support/src/tests/benchmarks/benchmark.ts
@@ -1,21 +1,9 @@
 /* eslint-disable no-console */
 import Benchmark from 'benchmark';
-import { autocomplete } from '../../autocompletion/autocompletion';
-import { parse, parserWrapper } from '../../parserWrapper';
-import { signatureHelp } from '../../signatureHelp';
-import { applySyntaxColouring } from '../../syntaxColouring/syntaxColouring';
-import {
-  lintCypherQuery,
-  validateSyntax,
-} from '../../syntaxValidation/syntaxValidation';
+import { parserWrapper } from '../../parserWrapper';
+import { validateSyntax } from '../../syntaxValidation/syntaxValidation';
 import { testData } from '../testData';
-import {
-  autocompletionQueries,
-  createMovieDb,
-  largePokemonquery,
-  simpleQuery,
-  tictactoe,
-} from './benchmarkQueries';
+import { largePokemonquery, simpleQuery, tictactoe } from './benchmarkQueries';
 
 const periodicIterate = 'CALL apoc.periodic.iterate(';
 const periodicIterateFirstArg = '"MATCH (p:Person) RETURN id(p) as personId", ';
@@ -26,108 +14,116 @@ Benchmark.options.maxTime = 1;
 const suite = new Benchmark.Suite();
 
 suite
-  .add('simple - parse', function () {
-    parse(simpleQuery);
-  })
-  .add('simple - highlight', function () {
-    parserWrapper.clearCache();
-    applySyntaxColouring(simpleQuery);
-  })
-  .add('simple - validate syntax', function () {
+  // .add('simple - parse', function () {
+  //   parse(simpleQuery);
+  // })
+  // .add('simple - highlight', function () {
+  //   parserWrapper.clearCache();
+  //   applySyntaxColouring(simpleQuery);
+  // })
+  .add('simple query - validate syntax', function () {
     parserWrapper.clearCache();
     validateSyntax(simpleQuery, testData.mockSchema);
   })
-  .add('simple - autocomplete next statement', function () {
+  .add('tictactoe query - validate syntax', function () {
     parserWrapper.clearCache();
-    autocomplete(simpleQuery, testData.mockSchema);
+    validateSyntax(tictactoe, testData.mockSchema);
   })
-  .add('movies - parse', function () {
-    parse(createMovieDb);
-  })
-  .add('movies - highlight', function () {
+  .add('large query - validate syntax', function () {
     parserWrapper.clearCache();
-    applySyntaxColouring(createMovieDb);
-  })
-  .add('movies - validate syntax', function () {
-    parserWrapper.clearCache();
-    lintCypherQuery(createMovieDb, testData.mockSchema);
-  })
-  .add('movies - autocomplete next statement', function () {
-    parserWrapper.clearCache();
-    autocomplete(createMovieDb, testData.mockSchema);
-  })
-  .add('movies - signature help', function () {
-    const subQuery = createMovieDb + periodicIterate;
-    const query = createMovieDb + periodicIterate + periodicIterateFirstArg;
-    parserWrapper.clearCache();
-    signatureHelp(query, testData.mockSchema, query.length - 1);
-    signatureHelp(query, testData.mockSchema, subQuery.length - 1);
-  })
-  .add('tictactoe - parse', function () {
-    parserWrapper.clearCache();
-    parse(tictactoe);
-  })
-  .add('tictactoe - highlight', function () {
-    parserWrapper.clearCache();
-    applySyntaxColouring(tictactoe);
-  })
-  .add('tictactoe - validate syntax', function () {
-    parserWrapper.clearCache();
-    lintCypherQuery(tictactoe, testData.mockSchema);
-  })
-  .add('tictactoe - autocomplete next statement - no Schema', function () {
-    parserWrapper.clearCache();
-    autocomplete(tictactoe, {});
-  })
-  .add('tictactoe - autocomplete next statement - medium Schema', function () {
-    parserWrapper.clearCache();
-    autocomplete(tictactoe, testData.mockSchema);
-  })
-  .add('tictactoe - signature help', function () {
-    const subQuery = tictactoe + periodicIterate;
-    const query = tictactoe + periodicIterate + periodicIterateFirstArg;
-    parserWrapper.clearCache();
-    signatureHelp(query, testData.mockSchema, query.length - 1);
-    signatureHelp(query, testData.mockSchema, subQuery.length - 1);
-  })
-  .add('pokemon - parse', function () {
-    parserWrapper.clearCache();
-    parse(largePokemonquery);
-  })
-  .add('pokemon - parserwrapper parse', function () {
-    parserWrapper.clearCache();
-    parserWrapper.parse(largePokemonquery);
-  })
-  .add('pokemon - syntax highlight', function () {
-    parserWrapper.clearCache();
-    applySyntaxColouring(largePokemonquery);
-  })
-  .add('pokemon - signature help', function () {
-    const subQuery = largePokemonquery + periodicIterate;
-    const query = largePokemonquery + periodicIterate + periodicIterateFirstArg;
-    parserWrapper.clearCache();
-    // This mimics getting the cursor back in the query and retriggering signature help
-    signatureHelp(query, testData.mockSchema, query.length);
-    signatureHelp(query, testData.mockSchema, subQuery.length);
-  })
-  .add('multistatement - autocompletion', function () {
-    const query = tictactoe + ';\n' + tictactoe;
-    const subQuery = tictactoe;
-    parserWrapper.clearCache();
-    // This mimics getting the cursor back in the query and retriggering auto-completion
-    autocomplete(query, testData.mockSchema);
-    autocomplete(query, testData.mockSchema, subQuery.length);
+    validateSyntax(largePokemonquery, testData.mockSchema);
   });
+// .add('simple - autocomplete next statement', function () {
+//   parserWrapper.clearCache();
+//   autocomplete(simpleQuery, testData.mockSchema);
+// })
+// .add('movies - parse', function () {
+//   parse(createMovieDb);
+// })
+// .add('movies - highlight', function () {
+//   parserWrapper.clearCache();
+//   applySyntaxColouring(createMovieDb);
+// })
+// .add('movies - validate syntax', function () {
+//   parserWrapper.clearCache();
+//   validateSyntax(createMovieDb, testData.mockSchema);
+// })
+// .add('movies - autocomplete next statement', function () {
+//   parserWrapper.clearCache();
+//   autocomplete(createMovieDb, testData.mockSchema);
+// })
+// .add('movies - signature help', function () {
+//   const subQuery = createMovieDb + periodicIterate;
+//   const query = createMovieDb + periodicIterate + periodicIterateFirstArg;
+//   parserWrapper.clearCache();
+//   signatureHelp(query, testData.mockSchema, query.length - 1);
+//   signatureHelp(query, testData.mockSchema, subQuery.length - 1);
+// })
+// .add('tictactoe - parse', function () {
+//   parserWrapper.clearCache();
+//   parse(tictactoe);
+// })
+// .add('tictactoe - highlight', function () {
+//   parserWrapper.clearCache();
+//   applySyntaxColouring(tictactoe);
+// })
+// .add('tictactoe - validate syntax', function () {
+//   parserWrapper.clearCache();
+//   validateSyntax(tictactoe, testData.mockSchema);
+// });
+// .add('tictactoe - autocomplete next statement - no Schema', function () {
+//   parserWrapper.clearCache();
+//   autocomplete(tictactoe, {});
+// })
+// .add('tictactoe - autocomplete next statement - medium Schema', function () {
+//   parserWrapper.clearCache();
+//   autocomplete(tictactoe, testData.mockSchema);
+// })
+// .add('tictactoe - signature help', function () {
+//   const subQuery = tictactoe + periodicIterate;
+//   const query = tictactoe + periodicIterate + periodicIterateFirstArg;
+//   parserWrapper.clearCache();
+//   signatureHelp(query, testData.mockSchema, query.length - 1);
+//   signatureHelp(query, testData.mockSchema, subQuery.length - 1);
+// })
+// .add('pokemon - parse', function () {
+//   parserWrapper.clearCache();
+//   parse(largePokemonquery);
+// })
+// .add('pokemon - parserwrapper parse', function () {
+//   parserWrapper.clearCache();
+//   parserWrapper.parse(largePokemonquery);
+// })
+// .add('pokemon - syntax highlight', function () {
+//   parserWrapper.clearCache();
+//   applySyntaxColouring(largePokemonquery);
+// })
+// .add('pokemon - signature help', function () {
+//   const subQuery = largePokemonquery + periodicIterate;
+//   const query = largePokemonquery + periodicIterate + periodicIterateFirstArg;
+//   parserWrapper.clearCache();
+//   // This mimics getting the cursor back in the query and retriggering signature help
+//   signatureHelp(query, testData.mockSchema, query.length);
+//   signatureHelp(query, testData.mockSchema, subQuery.length);
+// })
+// .add('multistatement - autocompletion', function () {
+//   const query = tictactoe + ';\n' + tictactoe;
+//   const subQuery = tictactoe;
+//   parserWrapper.clearCache();
+//   // This mimics getting the cursor back in the query and retriggering auto-completion
+//   autocomplete(query, testData.mockSchema);
+//   autocomplete(query, testData.mockSchema, subQuery.length);
+// });
 
-Object.entries(autocompletionQueries).forEach(([name, query]) => {
-  suite.add(`autocomplete - ${name} (parse.time.only)`, function () {
-    parse(query);
-  });
-  suite.add(`autocomplete - ${name}`, function () {
-    parserWrapper.clearCache();
-    autocomplete(query, testData.mockSchema);
-  });
-});
+// Object.entries(autocompletionQueries).forEach(([name, query]) => {
+//   suite.add(`autocomplete - ${name} (parse.time.only)`, function () {
+//     parse(query);
+//   });
+//   suite.add(`autocomplete - ${name}`, function () {
+//     parserWrapper.clearCache();
+//     autocomplete(query, testData.mockSchema);
+//   });
+// });
 
 suite
   .on('cycle', function (event: { target: { toString: () => string } }) {

--- a/packages/language-support/src/tests/benchmarks/benchmarkQueries.ts
+++ b/packages/language-support/src/tests/benchmarks/benchmarkQueries.ts
@@ -1,4 +1,4 @@
-export const simpleQuery = `MATCH (a:Person)-[:FRIEND_OF]->(b:Person), (b)-[:WORKS_AT]->(c:Company) WHERE c.name = 'Company Corp' RETURN a, b, c`;
+export const simpleQuery = `MATCH (a:Person)-[:FRIEND_OF]->(b:Person), (b)-[:WORKS_AT]->(c:Company) WERE c.name = 'Company Corp' RETURN a, b, c`;
 
 export const createMovieDb = `CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real World'})
 CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})
@@ -613,7 +613,7 @@ CALL {
 WITH * ORDER BY isWinningMove DESC
 LIMIT 1
 
-SET candidate.state = $symbol`;
+SE candidate.state = $symbol`;
 
 export const autocompletionQueries = {
   databaseName: 'ALTER ALIAS a.b.c. ',
@@ -2453,7 +2453,7 @@ CREATE
 (Marshadow)-[:HAS]->(MarshadowZenithMarshadow)
 
 
-CREATE 
+CEATE 
 (Bulbasaur)-[:IS]->(Grass), 
 (Bulbasaur)-[:IS]->(Poison), 
 (Ivysaur)-[:IS]->(Grass), 


### PR DESCRIPTION
## With normal parser
```
simple query - validate syntax x 6,449 ops/sec ±0.94% (29 runs sampled)
tictactoe query - validate syntax x 82.27 ops/sec ±2.48% (24 runs sampled)
large query - validate syntax x 3.62 ops/sec ±2.24% (11 runs sampled)
```

## With webworker

```
simple query - validate syntax x 257 ops/sec ±2.07% (11 runs sampled)
tictactoe query - validate syntax x 18.14 ops/sec ±3.63% (9 runs sampled)
For the large query I could only do one run - 0.0208 ops/sec
```

So overall:

```
x25 times slower
x4.53 times slower
x174 times slower
```