### PR TITLE
Changes param in cmd-parser to take escaped strings too

### DIFF
--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -24,7 +24,7 @@ paramsCmd: PARAM paramsArgs?;
 
 paramsArgs: (CLEAR | listCompletionRule | map | lambda);
 
-lambda: symbolicNameString EQ GT expression;
+lambda: parameterName["ANY"] EQ GT expression;
 
 clearCmd: CLEAR;
 

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -24,7 +24,7 @@ paramsCmd: PARAM paramsArgs?;
 
 paramsArgs: (CLEAR | listCompletionRule | map | lambda);
 
-lambda: unescapedSymbolicNameString EQ GT expression;
+lambda: symbolicNameString EQ GT expression;
 
 clearCmd: CLEAR;
 

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -509,7 +509,7 @@ function parseToCommand(
         }
 
         const lambda = paramArgs.lambda();
-        const name = lambda?.symbolicNameString()?.getText();
+        const name = lambda?.parameterName()?.getText();
         const expression = lambda?.expression()?.getText();
         if (name && expression) {
           return {

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -509,7 +509,7 @@ function parseToCommand(
         }
 
         const lambda = paramArgs.lambda();
-        const name = lambda?.unescapedSymbolicNameString()?.getText();
+        const name = lambda?.symbolicNameString()?.getText();
         const expression = lambda?.expression()?.getText();
         if (name && expression) {
           return {

--- a/packages/language-support/src/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouring.ts
@@ -14,6 +14,7 @@ import {
   ListItemsPredicateContext,
   NumberLiteralContext,
   ParameterContext,
+  ParameterNameContext,
   ParamsArgsContext,
   ProcedureNameContext,
   ProcedureResultItemContext,
@@ -173,6 +174,10 @@ class SyntaxHighlighter extends CypherParserListener {
   };
 
   exitVariable = (ctx: VariableContext) => {
+    this.addToken(ctx.start, CypherTokenType.variable, ctx.getText());
+  };
+
+  exitParameterName = (ctx: ParameterNameContext) => {
     this.addToken(ctx.start, CypherTokenType.variable, ctx.getText());
   };
 

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -317,6 +317,25 @@ describe('parameters', () => {
     ]);
   });
 
+  test('allows setting parameters with escaped name', () => {
+    expectParsedCommands(':param `foo foo` => bar', [
+      {
+        type: 'set-parameters',
+        parameters: [{ name: '`foo foo`', expression: 'bar' }],
+      },
+    ]);
+
+    expectParsedCommands(':param {`a a a`: 2, `b-b-b`: rand()}', [
+      {
+        type: 'set-parameters',
+        parameters: [
+          { name: '`a a a`', expression: '2' },
+          { name: '`b-b-b`', expression: 'rand()' },
+        ],
+      },
+    ]);
+  });
+
   test('autocompletes expressions', () => {
     const arrowCompletions = autocomplete(':param foo => ', {
       functions: {
@@ -456,7 +475,7 @@ describe('parameters', () => {
         length: 1,
         position: { line: 0, startCharacter: 7, startOffset: 7 },
         token: 'x',
-        tokenType: 'variable',
+        tokenType: 'symbolicName',
       },
       {
         length: 1,

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -475,7 +475,7 @@ describe('parameters', () => {
         length: 1,
         position: { line: 0, startCharacter: 7, startOffset: 7 },
         token: 'x',
-        tokenType: 'symbolicName',
+        tokenType: 'variable',
       },
       {
         length: 1,

--- a/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
+++ b/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
@@ -60,7 +60,7 @@ export class CypherEditorPage {
   }
 
   async checkNoNotificationMessage(type: 'error' | 'warning') {
-    await this.page.waitForTimeout(3000);
+    await this.page.waitForTimeout(1000);
     await expect(this.page.locator('.cm-lintRange-' + type)).toHaveCount(0, {
       timeout: 3000,
     });

--- a/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
+++ b/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
@@ -59,6 +59,16 @@ export class CypherEditorPage {
     return this.checkNotificationMessage('warning', queryChunk, expectedMsg);
   }
 
+  async checkNoNotificationMessage(type: 'error' | 'warning') {
+    await this.page.waitForTimeout(3000);
+    await expect(this.page.locator('.cm-lintRange-' + type)).toHaveCount(0, {
+      timeout: 3000,
+    });
+    await expect(this.page.locator('.cm-lintPoint-' + type)).toHaveCount(0, {
+      timeout: 3000,
+    });
+  }
+
   private async checkNotificationMessage(
     type: 'error' | 'warning',
     queryChunk: string,

--- a/packages/react-codemirror/src/e2e_tests/helpers.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/helpers.spec.tsx
@@ -1,0 +1,17 @@
+import { test } from '@playwright/experimental-ct-react';
+import { CypherEditor } from '../CypherEditor';
+import { CypherEditorPage } from './e2eUtils';
+
+test.use({ viewport: { width: 1000, height: 500 } });
+
+test.fail(
+  'checkNoNotification fails on query with error',
+  async ({ page, mount }) => {
+    const editorPage = new CypherEditorPage(page);
+
+    const query = 'METCH (n) RETURN n';
+    await mount(<CypherEditor value={query} />);
+
+    await editorPage.checkNoNotificationMessage('error');
+  },
+);

--- a/packages/react-codemirror/src/e2e_tests/syntaxValidation.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/syntaxValidation.spec.tsx
@@ -48,23 +48,16 @@ test('Syntactic errors are surfaced', async ({ page, mount }) => {
   );
 });
 
-test('Does not trigger syntax errors for backticked parameters in parameter creation', async ({ page, mount }) => {
+test('Does not trigger syntax errors for backticked parameters in parameter creation', async ({
+  page,
+  mount,
+}) => {
   const editorPage = new CypherEditorPage(page);
 
   const query = ':param x => "abc"';
   await mount(<CypherEditor value={query} />);
 
   await editorPage.checkNoNotificationMessage('error');
-});
-
-test('Unit test that checkNoNotification fails on query with error', async ({ page, mount }) => {
-  const editorPage = new CypherEditorPage(page);
-
-  const query = 'METCH (n) RETURN n';
-  await mount(<CypherEditor value={query} />);
-
-  await editorPage.checkNoNotificationMessage('error');
-  await editorPage.checkNoNotificationMessage('warning');
 });
 
 test('Errors for undefined labels are surfaced', async ({ page, mount }) => {

--- a/packages/react-codemirror/src/e2e_tests/syntaxValidation.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/syntaxValidation.spec.tsx
@@ -48,6 +48,25 @@ test('Syntactic errors are surfaced', async ({ page, mount }) => {
   );
 });
 
+test('Does not trigger syntax errors for backticked parameters in parameter creation', async ({ page, mount }) => {
+  const editorPage = new CypherEditorPage(page);
+
+  const query = ':param x => "abc"';
+  await mount(<CypherEditor value={query} />);
+
+  await editorPage.checkNoNotificationMessage('error');
+});
+
+test('Unit test that checkNoNotification fails on query with error', async ({ page, mount }) => {
+  const editorPage = new CypherEditorPage(page);
+
+  const query = 'METCH (n) RETURN n';
+  await mount(<CypherEditor value={query} />);
+
+  await editorPage.checkNoNotificationMessage('error');
+  await editorPage.checkNoNotificationMessage('warning');
+});
+
 test('Errors for undefined labels are surfaced', async ({ page, mount }) => {
   const editorPage = new CypherEditorPage(page);
   const query = 'MATCH (n: Person) RETURN n';


### PR DESCRIPTION
Cypher5/25Parser.g4 define
parameter[String paramType]
   : DOLLAR parameterName[paramType]
   ;

parameterName[String paramType]
   : (symbolicNameString | UNSIGNED_DECIMAL_INTEGER)
   ;
   
 In CypherCmdParser.g4 instead we had:
 paramsCmd: PARAM paramsArgs?;

paramsArgs: (CLEAR | listCompletionRule | map | lambda);

lambda: unescapedSymbolicNameString EQ GT expression;

So params created with lambda could never be escaped, even though regular parser allows it. this aligns cmd-parser with regular.