### PR TITLE
Disables flaky debouncing test

### DIFF
--- a/packages/react-codemirror/src/e2e_tests/debounce.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/debounce.spec.tsx
@@ -28,43 +28,47 @@ test.fail(
 );
 
 // TODO Fix this test
-test.skip('onExecute updates should override debounce updates', async ({
-  mount,
-  page,
-}) => {
-  const editorPage = new CypherEditorPage(page);
-  let value = '';
+test.fixme(
+  'onExecute updates should override debounce updates',
+  async ({ mount, page }) => {
+    const editorPage = new CypherEditorPage(page);
+    let value = '';
 
-  const onExecute = () => {
-    value = '';
-    void component.update(
+    const onExecute = () => {
+      value = '';
+      void component.update(
+        <CypherEditor
+          value={value}
+          onChange={onChange}
+          onExecute={onExecute}
+        />,
+      );
+    };
+
+    const onChange = (val: string) => {
+      value = val;
+      void component.update(
+        <CypherEditor value={val} onChange={onChange} onExecute={onExecute} />,
+      );
+    };
+
+    const component = await mount(
       <CypherEditor value={value} onChange={onChange} onExecute={onExecute} />,
     );
-  };
 
-  const onChange = (val: string) => {
-    value = val;
-    void component.update(
-      <CypherEditor value={val} onChange={onChange} onExecute={onExecute} />,
-    );
-  };
+    await editorPage.getEditor().pressSequentially('RETURN 1');
+    await editorPage.getEditor().press('Enter');
+    await page.waitForTimeout(DEBOUNCE_TIME_WITH_MARGIN);
+    await expect(component).not.toContainText('RETURN 1');
 
-  const component = await mount(
-    <CypherEditor value={value} onChange={onChange} onExecute={onExecute} />,
-  );
-
-  await editorPage.getEditor().pressSequentially('RETURN 1');
-  await editorPage.getEditor().press('Enter');
-  await page.waitForTimeout(DEBOUNCE_TIME_WITH_MARGIN);
-  await expect(component).not.toContainText('RETURN 1');
-
-  await editorPage.getEditor().pressSequentially('RETURN 1');
-  await editorPage.getEditor().pressSequentially('');
-  await editorPage.getEditor().pressSequentially('RETURN 1');
-  await editorPage.getEditor().press('Enter');
-  await page.waitForTimeout(DEBOUNCE_TIME_WITH_MARGIN);
-  await expect(component).not.toContainText('RETURN 1');
-});
+    await editorPage.getEditor().pressSequentially('RETURN 1');
+    await editorPage.getEditor().pressSequentially('');
+    await editorPage.getEditor().pressSequentially('RETURN 1');
+    await editorPage.getEditor().press('Enter');
+    await page.waitForTimeout(DEBOUNCE_TIME_WITH_MARGIN);
+    await expect(component).not.toContainText('RETURN 1');
+  },
+);
 
 test('onExecute should fire after debounced updates', async ({
   mount,

--- a/packages/react-codemirror/src/e2e_tests/debounce.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/debounce.spec.tsx
@@ -27,7 +27,8 @@ test.fail(
   },
 );
 
-test('onExecute updates should override debounce updates', async ({
+// TODO Fix this test
+test.skip('onExecute updates should override debounce updates', async ({
   mount,
   page,
 }) => {


### PR DESCRIPTION
I've carded this as one of the paper cuts we should address in Q1.

## Why

After a serious of PRs trying to address debouncing problems, the functionality seems to still be flaky somehow

https://github.com/neo4j/cypher-language-support/pulls?q=is%3Apr+author%3Adanieladugyan+is%3Aclosed