### PR TITLE
Relints documents when connecting / disconnecting to a database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19600,10 +19600,10 @@
     },
     "packages/language-server": {
       "name": "@neo4j-cypher/language-server",
-      "version": "2.0.0-next.12",
+      "version": "2.0.0-next.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.11",
+        "@neo4j-cypher/language-support": "2.0.0-next.12",
         "lodash.debounce": "^4.0.8",
         "neo4j-driver": "^5.3.0",
         "vscode-languageserver": "^8.1.0",
@@ -20031,7 +20031,7 @@
     },
     "packages/language-support": {
       "name": "@neo4j-cypher/language-support",
-      "version": "2.0.0-next.11",
+      "version": "2.0.0-next.12",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "4.13.2",
@@ -20049,7 +20049,7 @@
     },
     "packages/react-codemirror": {
       "name": "@neo4j-cypher/react-codemirror",
-      "version": "2.0.0-next.14",
+      "version": "2.0.0-next.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
@@ -20061,7 +20061,7 @@
         "@codemirror/view": "^6.29.1",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.11",
+        "@neo4j-cypher/language-support": "2.0.0-next.12",
         "@types/prismjs": "^1.26.3",
         "@types/workerpool": "^6.4.7",
         "ayu": "^8.0.1",
@@ -20096,15 +20096,15 @@
     },
     "packages/react-codemirror-playground": {
       "name": "@neo4j-cypher/react-codemirror-playground",
-      "version": "2.0.0-next.14",
+      "version": "2.0.0-next.15",
       "dependencies": {
         "@codemirror/autocomplete": "^6.5.1",
         "@codemirror/commands": "^6.2.2",
         "@codemirror/language": "^6.6.0",
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
-        "@neo4j-cypher/language-support": "2.0.0-next.11",
-        "@neo4j-cypher/react-codemirror": "2.0.0-next.14",
+        "@neo4j-cypher/language-support": "2.0.0-next.12",
+        "@neo4j-cypher/react-codemirror": "2.0.0-next.15",
         "react": "^18.2.0",
         "react-d3-tree": "^3.6.1",
         "react-dom": "^18.2.0",
@@ -21455,10 +21455,10 @@
     },
     "packages/schema-poller": {
       "name": "@neo4j-cypher/schema-poller",
-      "version": "2.0.0-next.11",
+      "version": "2.0.0-next.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-support": "2.0.0-next.11",
+        "@neo4j-cypher/language-support": "2.0.0-next.12",
         "ajv": "^8.12.0",
         "neo4j-driver": "^5.12.0"
       },
@@ -21486,10 +21486,10 @@
     },
     "packages/vscode-extension": {
       "name": "neo4j-for-vscode",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neo4j-cypher/language-server": "2.0.0-next.12",
+        "@neo4j-cypher/language-server": "2.0.0-next.13",
         "@neo4j-ndl/base": "^2.12.3",
         "@neo4j-ndl/react": "^2.16.5",
         "neo4j-driver": "^5.12.0",

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -2,7 +2,7 @@ import { validateSyntax } from '@neo4j-cypher/language-support';
 import { Neo4jSchemaPoller } from '@neo4j-cypher/schema-poller';
 import debounce from 'lodash.debounce';
 import { join } from 'path';
-import { Diagnostic, TextDocumentChangeEvent } from 'vscode-languageserver';
+import { Diagnostic } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import workerpool from 'workerpool';
 import { LinterTask, LintWorker } from './lintWorker';
@@ -15,12 +15,10 @@ const pool = workerpool.pool(join(__dirname, 'lintWorker.js'), {
 let lastSemanticJob: LinterTask | undefined;
 
 async function rawLintDocument(
-  change: TextDocumentChangeEvent<TextDocument>,
+  document: TextDocument,
   sendDiagnostics: (diagnostics: Diagnostic[]) => void,
   neo4j: Neo4jSchemaPoller,
 ) {
-  const { document } = change;
-
   const query = document.getText();
   if (query.length === 0) {
     sendDiagnostics([]);

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neo4j-for-vscode
 
+## 1.6.1
+
+- Makes the editor relint all documents when connecting / disconnecting from a database
+- Adds warnings for deprecated procedures / functions
+- Improves backticking of completions
+
 ## 1.6.0
 
 - Updates grammar to LTS version

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "neo4j-extensions",
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "preview": true,
   "categories": [
     "Programming Languages",

--- a/packages/vscode-extension/tests/fixtures/deprecated-by.cypher
+++ b/packages/vscode-extension/tests/fixtures/deprecated-by.cypher
@@ -1,0 +1,2 @@
+CALL apoc.create.uuids(5);
+RETURN apoc.create.uuid();

--- a/packages/vscode-extension/tests/suiteSetup.ts
+++ b/packages/vscode-extension/tests/suiteSetup.ts
@@ -25,6 +25,18 @@ export async function saveDefaultConnection(): Promise<void> {
   );
 }
 
+export async function connectDefault(): Promise<void> {
+  await vscode.commands.executeCommand(CONSTANTS.COMMANDS.CONNECT_COMMAND, {
+    key: defaultConnectionKey,
+  });
+}
+
+export async function disconnectDefault(): Promise<void> {
+  await vscode.commands.executeCommand(CONSTANTS.COMMANDS.DISCONNECT_COMMAND, {
+    key: defaultConnectionKey,
+  });
+}
+
 export async function createTestDatabase(): Promise<void> {
   const { scheme, host, port, user, password } = getNeo4jConfiguration();
 


### PR DESCRIPTION
The failing behaviour can be seen in the test added by 706f9ec.

## Why

Because if we ask to lint a document when the schema is yet not fetched, we will never see schema dependent errors (non existent labels, deprecation warnings, non existent procedures, etc). This can happen when we open the  the editor open with a cypher file when we haven't yet connected to a database.

Conversely, when we disconnect from a database, this should also relint the document.

This will become more relevant when we have several connections and we can be connected to different databases with different procedures / functions, different labels, ...