### PR TITLE
Fixes bug reporting missing label / rel type when inside opposite pattern

### DIFF
--- a/.changeset/silent-kangaroos-melt.md
+++ b/.changeset/silent-kangaroos-melt.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes bug reporting missing label / rel type when inside opposite pattern

--- a/packages/language-support/src/helpers.ts
+++ b/packages/language-support/src/helpers.ts
@@ -95,19 +95,23 @@ export const antlrUtils = antlrDefaultExport as unknown as AntlrDefaultExport;
 export function inNodeLabel(stopNode: ParserRuleContext) {
   const nodePattern = findParent(
     stopNode,
-    (p) => p instanceof NodePatternContext,
+    (p) =>
+      p instanceof NodePatternContext ||
+      p instanceof RelationshipPatternContext,
   );
 
-  return isDefined(nodePattern);
+  return nodePattern instanceof NodePatternContext;
 }
 
 export function inRelationshipType(stopNode: ParserRuleContext) {
   const relPattern = findParent(
     stopNode,
-    (p) => p instanceof RelationshipPatternContext,
+    (p) =>
+      p instanceof NodePatternContext ||
+      p instanceof RelationshipPatternContext,
   );
 
-  return isDefined(relPattern);
+  return relPattern instanceof RelationshipPatternContext;
 }
 
 export function findCaret(

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -88,7 +88,7 @@ function couldCreateNewLabel(ctx: ParserRuleContext): boolean {
 }
 
 export type LabelOrRelType = {
-  labeltype: LabelType;
+  labelType: LabelType;
   labelText: string;
   couldCreateNewLabel: boolean;
   line: number;
@@ -236,7 +236,7 @@ class LabelAndRelTypesCollector extends ParseTreeListener {
       // RETURN would be idenfified as the label in that case
       if (ctx.parentCtx && ctx.parentCtx.start === ctx.start) {
         this.labelOrRelTypes.push({
-          labeltype: getLabelType(ctx),
+          labelType: getLabelType(ctx),
           labelText: ctx.getText(),
           couldCreateNewLabel: couldCreateNewLabel(ctx),
           line: ctx.start.line,
@@ -256,7 +256,7 @@ class LabelAndRelTypesCollector extends ParseTreeListener {
         ctx.parentCtx.start === ctx.start
       ) {
         this.labelOrRelTypes.push({
-          labeltype: getLabelType(ctx),
+          labelType: getLabelType(ctx),
           labelText: symbolicName.start.text,
           couldCreateNewLabel: couldCreateNewLabel(ctx),
           line: ctx.start.line,

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -29,16 +29,16 @@ function detectNonDeclaredLabel(
   const labelName = labelOrRelType.labelText;
   const normalizedLabelName = labelName.replace(/^`|`$/g, '');
   const notInDatabase =
-    (labelOrRelType.labeltype === LabelType.nodeLabelType &&
+    (labelOrRelType.labelType === LabelType.nodeLabelType &&
       !dbLabels.has(normalizedLabelName)) ||
-    (labelOrRelType.labeltype === LabelType.relLabelType &&
+    (labelOrRelType.labelType === LabelType.relLabelType &&
       !dbRelationshipTypes.has(normalizedLabelName)) ||
     (!dbLabels.has(normalizedLabelName) &&
       !dbRelationshipTypes.has(normalizedLabelName));
 
   if (notInDatabase && !labelOrRelType.couldCreateNewLabel) {
     const message =
-      labelOrRelType.labeltype +
+      labelOrRelType.labelType +
       ' ' +
       labelName +
       " is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application";

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -1059,4 +1059,32 @@ describe('Syntactic validation spec', () => {
       ).toEqual([]);
     },
   );
+
+  test('Existing relationship types are not incorrectly reported inside node predicates', () => {
+    const query = `MATCH ()-[]->*(n WHERE COUNT{ (n)-[:R]->()} = 0) RETURN n`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: [],
+          relationshipTypes: ['R'],
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  test('Existing node labels are not incorrectly reported inside relationship predicates', () => {
+    const query = `MATCH ()-[r WHERE COUNT{ (n:A)-[]->()} = 0]->() RETURN r`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['A'],
+          relationshipTypes: [],
+        },
+      }),
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

We are reporting a missing label for a relationship type when it's a node predicate. This pr fixes that bug.

## Why

Because we were traversing the tree to check whether we were inside a node pattern first, without accounting for the fact we could be in a relationship type inside a node predicate.