### PR TITLE
Added hint when using function as procedure and vice versa

### DIFF
--- a/.changeset/cuddly-vans-flash.md
+++ b/.changeset/cuddly-vans-flash.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Adds hints to the error when using a procedure/function where the other would be appropriate

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -89,10 +89,8 @@ function detectNonDeclaredFunction(
 ): SyntaxDiagnostic | undefined {
   const exists = functionExists(parsedFunction, functionsSchema);
   if (!exists) {
-    let existsAsProcedure = false;
-    if (procedureSchema) {
-      existsAsProcedure = Boolean(procedureSchema[parsedFunction.name]);
-    }
+    const existsAsProcedure =
+      procedureSchema && Boolean(procedureSchema[parsedFunction.name]);
     if (existsAsProcedure) {
       return generateProcedureUsedAsFunctionError(parsedFunction);
     }
@@ -101,7 +99,7 @@ function detectNonDeclaredFunction(
 }
 
 function functionExists(
-  functionCandidate: ParsedFunction  ,
+  functionCandidate: ParsedFunction,
   functionsSchema: Record<string, Neo4jFunction>,
 ): boolean {
   if (!functionCandidate || !functionsSchema) {
@@ -115,15 +113,11 @@ function functionExists(
     functionsSchema[lowercaseFunctionName];
 
   // Built-in functions are case-insensitive in the database
-  if (
+  return (
     functionExistsWithExactName ||
     (caseInsensitiveFunctionInDatabase &&
       caseInsensitiveFunctionInDatabase.isBuiltIn)
-  ) {
-    return true;
-  } else {
-    return false;
-  }
+  );
 }
 
 function generateFunctionUsedAsProcedureError(
@@ -133,7 +127,7 @@ function generateFunctionUsedAsProcedureError(
     parsedProcedure.rawText,
     parsedProcedure,
     DiagnosticSeverity.Error,
-    `Procedure ${parsedProcedure.name} is not present in the database. Did you mean to call the function ${parsedProcedure.name}? Only procedures can be called inside a CALL clause.`,
+    `${parsedProcedure.name} is a function, not a procedure. Did you mean to use the function ${parsedProcedure.name} with a RETURN instead of a CALL clause?`,
   );
 }
 
@@ -155,7 +149,7 @@ function generateProcedureUsedAsFunctionError(
     parsedFunction.rawText,
     parsedFunction,
     DiagnosticSeverity.Error,
-    `Function ${parsedFunction.name} is not present in the database. Did you mean to call the procedure ${parsedFunction.name}? Procedures must be called inside a CALL clause.`,
+    `${parsedFunction.name} is a procedure, not a function. Did you mean to call the procedure ${parsedFunction.name} inside a CALL clause?`,
   );
 }
 

--- a/packages/language-support/src/tests/syntaxValidation/functionsValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/functionsValidation.test.ts
@@ -74,6 +74,42 @@ describe('Functions semantic validation spec', () => {
     ]);
   });
 
+  test('Syntax validation error on function used as procedure returns helpful message', () => {
+    const query = `CALL abs(-50) YIELD *`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          functions: testData.mockSchema.functions,
+          procedures: testData.mockSchema.procedures,
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          'Procedure abs is not present in the database. Did you mean to call the function abs? Only procedures can be called inside a CALL clause.',
+        offsets: {
+          end: 8,
+          start: 5,
+        },
+        range: {
+          end: {
+            character: 8,
+            line: 0,
+          },
+          start: {
+            character: 5,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
   test('Syntax validation errors on missing function when database can be contacted', () => {
     const query = `RETURN dontpanic("marvin")`;
 

--- a/packages/language-support/src/tests/syntaxValidation/functionsValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/functionsValidation.test.ts
@@ -90,7 +90,7 @@ describe('Functions semantic validation spec', () => {
     ).toEqual([
       {
         message:
-          'Procedure abs is not present in the database. Did you mean to call the function abs? Only procedures can be called inside a CALL clause.',
+          'abs is a function, not a procedure. Did you mean to use the function abs with a RETURN instead of a CALL clause?',
         offsets: {
           end: 8,
           start: 5,
@@ -98,6 +98,78 @@ describe('Functions semantic validation spec', () => {
         range: {
           end: {
             character: 8,
+            line: 0,
+          },
+          start: {
+            character: 5,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Using improved message for function used as procedure is not case sensitive for built-in functions', () => {
+    const query = `CALL aBs(-50) YIELD *`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          functions: testData.mockSchema.functions,
+          procedures: testData.mockSchema.procedures,
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          'aBs is a function, not a procedure. Did you mean to use the function aBs with a RETURN instead of a CALL clause?',
+        offsets: {
+          end: 8,
+          start: 5,
+        },
+        range: {
+          end: {
+            character: 8,
+            line: 0,
+          },
+          start: {
+            character: 5,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Using improved message for function used as procedure is case sensitive for external functions', () => {
+    const query = `CALL apoc.text.TOUpperCase("message") YIELD *`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          functions: testData.mockSchema.functions,
+          procedures: testData.mockSchema.procedures,
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          "Procedure apoc.text.TOUpperCase is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 26,
+          start: 5,
+        },
+        range: {
+          end: {
+            character: 26,
             line: 0,
           },
           start: {

--- a/packages/language-support/src/tests/syntaxValidation/proceduresValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/proceduresValidation.test.ts
@@ -75,7 +75,43 @@ meaning that it expects at least 3 arguments of types NODE, STRING, ANY
     ).toEqual([
       {
         message:
-          'Function apoc.create.uuids is not present in the database. Did you mean to call the procedure apoc.create.uuids? Procedures must be called inside a CALL clause.',
+          'apoc.create.uuids is a procedure, not a function. Did you mean to call the procedure apoc.create.uuids inside a CALL clause?',
+        offsets: {
+          end: 24,
+          start: 7,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 7,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Using improved message for procedure used as function is case sensitive', () => {
+    const query = `RETURN apoc.cReAtE.uuids(50)`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          functions: testData.mockSchema.functions,
+          procedures: testData.mockSchema.procedures,
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          "Function apoc.cReAtE.uuids is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
         offsets: {
           end: 24,
           start: 7,

--- a/packages/language-support/src/tests/syntaxValidation/proceduresValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/proceduresValidation.test.ts
@@ -59,6 +59,42 @@ meaning that it expects at least 3 arguments of types NODE, STRING, ANY
     ]);
   });
 
+  test('Syntax validation error on procedure used as function returns helpful message', () => {
+    const query = `RETURN apoc.create.uuids(50)`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          functions: testData.mockSchema.functions,
+          procedures: testData.mockSchema.procedures,
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          'Function apoc.create.uuids is not present in the database. Did you mean to call the procedure apoc.create.uuids? Procedures must be called inside a CALL clause.',
+        offsets: {
+          end: 24,
+          start: 7,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 7,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
   test('Syntax validation warns on missing procedures when database can be contacted', () => {
     const query = `CALL dontpanic("marvin")`;
 


### PR DESCRIPTION
Will yield errors like:
`CALL abs(-50) YIELD *` -> Procedure abs is not present in the database. Did you mean to call the function abs? Only procedures can be called inside a CALL clause.
and
`RETURN apoc.create.uuids(50)` -> Function apoc.create.uuids is not present in the database. Did you mean to call the procedure apoc.create.uuids? Procedures must be called inside a CALL clause.

Instead of the regular "Procedure/Function is not present in the database"-messages.