### PR TITLE
Adds support for cypher versions in semantic analysis-linting

### DIFF
--- a/.changeset/blue-penguins-worry.md
+++ b/.changeset/blue-penguins-worry.md
@@ -1,0 +1,6 @@
+---
+'@neo4j-cypher/language-support': patch
+'@neo4j-cypher/schema-poller': patch
+---
+
+Updates semantic error worker to use given cypher version

--- a/packages/language-support/src/dbSchema.ts
+++ b/packages/language-support/src/dbSchema.ts
@@ -11,4 +11,5 @@ export interface DbSchema {
   propertyKeys?: string[];
   procedures?: Record<string, Neo4jProcedure>;
   functions?: Record<string, Neo4jFunction>;
+  defaultLanguage?: string;
 }

--- a/packages/language-support/src/dbSchema.ts
+++ b/packages/language-support/src/dbSchema.ts
@@ -1,4 +1,4 @@
-import { Neo4jFunction, Neo4jProcedure } from './types';
+import { CypherVersion, Neo4jFunction, Neo4jProcedure } from './types';
 
 export interface DbSchema {
   labels?: string[];
@@ -11,5 +11,5 @@ export interface DbSchema {
   propertyKeys?: string[];
   procedures?: Record<string, Neo4jProcedure>;
   functions?: Record<string, Neo4jFunction>;
-  defaultLanguage?: string;
+  defaultLanguage?: CypherVersion;
 }

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -432,7 +432,12 @@ class CypherVersionCollector extends ParseTreeListener {
 
   exitEveryRule(ctx: unknown) {
     if (ctx instanceof CypherVersionContext) {
-      this.cypherVersion = `CYPHER ${ctx.getText()}` as CypherVersion;
+      this.cypherVersion =
+        ctx.getText() === '5'
+          ? 'CYPHER 5'
+          : ctx.getText() === '25'
+          ? 'CYPHER 25'
+          : undefined;
     }
   }
 }

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -51,6 +51,7 @@ function copySettingSeverity(
 export function wrappedSemanticAnalysis(
   query: string,
   dbSchema: DbSchema,
+  parsedVersion: string,
 ): SemanticAnalysisResult {
   try {
     if (JSON.stringify(dbSchema) !== JSON.stringify(previousSchema)) {
@@ -63,7 +64,15 @@ export function wrappedSemanticAnalysis(
       });
     }
 
-    const semanticErrorsResult = analyzeQuery(query, 'cypher 5');
+    const validCypherVersions = ['5'];
+    let cypherVersion = 'cypher 5';
+
+    if (parsedVersion && validCypherVersions.includes(parsedVersion)) {
+      cypherVersion = 'cypher ' + parsedVersion;
+    } else if (dbSchema.defaultLanguage) {
+      cypherVersion = dbSchema.defaultLanguage;
+    }
+    const semanticErrorsResult = analyzeQuery(query, cypherVersion);
     const errors: SemanticAnalysisElement[] = semanticErrorsResult.errors;
     const notifications: SemanticAnalysisElement[] =
       semanticErrorsResult.notifications;

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -65,16 +65,12 @@ export function wrappedSemanticAnalysis(
       });
     }
 
-    const validCypherVersions = ['CYPHER 5', 'CYPHER 25'];
     let cypherVersion = 'CYPHER 5';
     const defaultVersion = dbSchema.defaultLanguage?.toUpperCase();
 
-    if (parsedVersion && validCypherVersions.includes(parsedVersion)) {
+    if (parsedVersion) {
       cypherVersion = parsedVersion;
-    } else if (
-      dbSchema.defaultLanguage &&
-      validCypherVersions.includes(defaultVersion)
-    ) {
+    } else if (dbSchema.defaultLanguage) {
       cypherVersion = defaultVersion;
     }
     const semanticErrorsResult = analyzeQuery(

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -64,12 +64,16 @@ export function wrappedSemanticAnalysis(
       });
     }
 
-    const validCypherVersions = ['5'];
+    const validCypherVersions = ['cypher 5', 'cypher 25'];
     let cypherVersion = 'cypher 5';
+    const fullParsedVersion = 'cypher ' + parsedVersion;
 
-    if (parsedVersion && validCypherVersions.includes(parsedVersion)) {
-      cypherVersion = 'cypher ' + parsedVersion;
-    } else if (dbSchema.defaultLanguage) {
+    if (parsedVersion && validCypherVersions.includes(fullParsedVersion)) {
+      cypherVersion = fullParsedVersion;
+    } else if (
+      dbSchema.defaultLanguage &&
+      validCypherVersions.includes(dbSchema.defaultLanguage)
+    ) {
       cypherVersion = dbSchema.defaultLanguage;
     }
     const semanticErrorsResult = analyzeQuery(query, cypherVersion);

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -67,14 +67,15 @@ export function wrappedSemanticAnalysis(
     const validCypherVersions = ['cypher 5', 'cypher 25'];
     let cypherVersion = 'cypher 5';
     const fullParsedVersion = 'cypher ' + parsedVersion;
+    const defaultVersion = dbSchema.defaultLanguage?.toLowerCase();
 
     if (parsedVersion && validCypherVersions.includes(fullParsedVersion)) {
       cypherVersion = fullParsedVersion;
     } else if (
       dbSchema.defaultLanguage &&
-      validCypherVersions.includes(dbSchema.defaultLanguage)
+      validCypherVersions.includes(defaultVersion)
     ) {
-      cypherVersion = dbSchema.defaultLanguage;
+      cypherVersion = defaultVersion;
     }
     const semanticErrorsResult = analyzeQuery(query, cypherVersion);
     const errors: SemanticAnalysisElement[] = semanticErrorsResult.errors;

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -67,7 +67,7 @@ export function wrappedSemanticAnalysis(
 
     const validCypherVersions = ['CYPHER 5', 'CYPHER 25'];
     let cypherVersion = 'CYPHER 5';
-    const defaultVersion = dbSchema.defaultLanguage.toUpperCase();
+    const defaultVersion = dbSchema.defaultLanguage?.toUpperCase();
 
     if (parsedVersion && validCypherVersions.includes(parsedVersion)) {
       cypherVersion = parsedVersion;

--- a/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
+++ b/packages/language-support/src/syntaxValidation/semanticAnalysisWrapper.ts
@@ -6,6 +6,7 @@ import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
 import { DbSchema } from '../dbSchema';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
+import { CypherVersion } from '../types';
 import { analyzeQuery, updateSignatureResolver } from './semanticAnalysis';
 import { SyntaxDiagnostic } from './syntaxValidation';
 
@@ -51,7 +52,7 @@ function copySettingSeverity(
 export function wrappedSemanticAnalysis(
   query: string,
   dbSchema: DbSchema,
-  parsedVersion: string,
+  parsedVersion?: CypherVersion,
 ): SemanticAnalysisResult {
   try {
     if (JSON.stringify(dbSchema) !== JSON.stringify(previousSchema)) {
@@ -64,20 +65,22 @@ export function wrappedSemanticAnalysis(
       });
     }
 
-    const validCypherVersions = ['cypher 5', 'cypher 25'];
-    let cypherVersion = 'cypher 5';
-    const fullParsedVersion = 'cypher ' + parsedVersion;
-    const defaultVersion = dbSchema.defaultLanguage?.toLowerCase();
+    const validCypherVersions = ['CYPHER 5', 'CYPHER 25'];
+    let cypherVersion = 'CYPHER 5';
+    const defaultVersion = dbSchema.defaultLanguage.toUpperCase();
 
-    if (parsedVersion && validCypherVersions.includes(fullParsedVersion)) {
-      cypherVersion = fullParsedVersion;
+    if (parsedVersion && validCypherVersions.includes(parsedVersion)) {
+      cypherVersion = parsedVersion;
     } else if (
       dbSchema.defaultLanguage &&
       validCypherVersions.includes(defaultVersion)
     ) {
       cypherVersion = defaultVersion;
     }
-    const semanticErrorsResult = analyzeQuery(query, cypherVersion);
+    const semanticErrorsResult = analyzeQuery(
+      query,
+      cypherVersion.toLowerCase(),
+    );
     const errors: SemanticAnalysisElement[] = semanticErrorsResult.errors;
     const notifications: SemanticAnalysisElement[] =
       semanticErrorsResult.notifications;

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -256,6 +256,7 @@ export function lintCypherQuery(
         const { notifications, errors } = wrappedSemanticAnalysis(
           cmd.statement,
           dbSchema,
+          current.cypherVersion,
         );
 
         // This contains both the syntax and the semantic errors

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -32,7 +32,7 @@ describe('Semantic validation spec', () => {
     const query1 = 'MATCH (n)-[r]->(m) SET r += m';
     const diagnostics1 = getDiagnosticsForQuery({
       query: query1,
-      dbSchema: { defaultLanguage: 'cypher 25' },
+      dbSchema: { defaultLanguage: 'CYPHER 25' },
     });
     const query2 = 'CYPHER 25 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });
@@ -43,7 +43,7 @@ describe('Semantic validation spec', () => {
     const query1 = 'CYPHER 5 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics1 = getDiagnosticsForQuery({
       query: query1,
-      dbSchema: { defaultLanguage: 'cypher 25' },
+      dbSchema: { defaultLanguage: 'CYPHER 25' },
     });
     const query2 = 'CYPHER 25 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -9,6 +9,47 @@ describe('Semantic validation spec', () => {
     const query2 = 'CYPHER 25 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });
     expect(diagnostics1[0].message).not.toEqual(diagnostics2[0].message);
+    expect(diagnostics1).toEqual([
+      {
+        message:
+          'The use of nodes or relationships for setting properties is deprecated and will be removed in a future version. Please use properties() instead.',
+        offsets: {
+          end: 39,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 38,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+    expect(diagnostics2).toEqual([
+      {
+        message: 'Type mismatch: expected Map but was Node',
+        offsets: {
+          end: 39,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 38,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
   });
 
   test('Semantic analysis defaults to cypher 5 when no default version is given, and no version is given in query', () => {
@@ -17,9 +58,51 @@ describe('Semantic validation spec', () => {
     const query2 = 'MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });
     expect(diagnostics1[0].message).toEqual(diagnostics2[0].message);
+    expect(diagnostics1).toEqual([
+      {
+        message:
+          'The use of nodes or relationships for setting properties is deprecated and will be removed in a future version. Please use properties() instead.',
+        offsets: {
+          end: 39,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 38,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+    expect(diagnostics2).toEqual([
+      {
+        message:
+          'The use of nodes or relationships for setting properties is deprecated and will be removed in a future version. Please use properties() instead.',
+        offsets: {
+          end: 29,
+          start: 28,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 28,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
   });
 
-  //TODO: Maybe this should actually yield a warning
+  //TODO: Maybe this should actually yield a warning - to be fixed in follow-up, ignoring for now
   test('Semantic analysis defaults to cypher 5 when faulty version is given', () => {
     const query1 = 'CYPHER  5 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics1 = getDiagnosticsForQuery({ query: query1 });
@@ -37,6 +120,46 @@ describe('Semantic validation spec', () => {
     const query2 = 'CYPHER 25 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });
     expect(diagnostics1[0].message).toEqual(diagnostics2[0].message);
+    expect(diagnostics1).toEqual([
+      {
+        message: 'Type mismatch: expected Map but was Node',
+        offsets: {
+          end: 29,
+          start: 28,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 28,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+    expect(diagnostics2).toEqual([
+      {
+        message: 'Type mismatch: expected Map but was Node',
+        offsets: {
+          end: 39,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 38,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
   });
 
   test('In-query version takes priority for semantic analysis even if defaultLanguage is defined', () => {
@@ -48,6 +171,47 @@ describe('Semantic validation spec', () => {
     const query2 = 'CYPHER 25 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics2 = getDiagnosticsForQuery({ query: query2 });
     expect(diagnostics1[0].message).not.toEqual(diagnostics2[0].message);
+    expect(diagnostics1).toEqual([
+      {
+        message:
+          'The use of nodes or relationships for setting properties is deprecated and will be removed in a future version. Please use properties() instead.',
+        offsets: {
+          end: 38,
+          start: 37,
+        },
+        range: {
+          end: {
+            character: 38,
+            line: 0,
+          },
+          start: {
+            character: 37,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+    expect(diagnostics2).toEqual([
+      {
+        message: 'Type mismatch: expected Map but was Node',
+        offsets: {
+          end: 39,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 38,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
   });
 
   test('Does not trigger semantic errors when there are syntactic errors', () => {

--- a/packages/language-support/src/types.ts
+++ b/packages/language-support/src/types.ts
@@ -7,7 +7,7 @@ export type ReturnDescription = {
   isDeprecated: boolean;
 };
 
-export type CypherVersion = 'cypher 25' | 'cypher 5';
+export type CypherVersion = 'CYPHER 25' | 'CYPHER 5';
 
 // we could parse this string for better types in the future
 export type Neo4jStringType = string;

--- a/packages/schema-poller/src/metadataPoller.ts
+++ b/packages/schema-poller/src/metadataPoller.ts
@@ -105,6 +105,13 @@ export class MetadataPoller {
           this.dbSchema.aliasNames = result.data.databases.flatMap(
             (db) => db.aliases ?? [],
           );
+          const dbs = result.data.databases;
+          const currentDb = dbs.find(
+            (db) => db.name === this.connection.currentDb,
+          );
+          if (currentDb) {
+            this.dbSchema.defaultLanguage = currentDb.defaultLanguage;
+          }
         }
       },
     });

--- a/packages/schema-poller/src/queries/databases.ts
+++ b/packages/schema-poller/src/queries/databases.ts
@@ -1,3 +1,4 @@
+import { CypherVersion } from '@neo4j-cypher/language-support/dist/types/types';
 import { resultTransformers } from 'neo4j-driver';
 import { ExecuteQueryArgs } from '../types/sdkTypes';
 
@@ -30,7 +31,7 @@ export type Database = {
   writer?: boolean;
   access?: string;
   constituents?: string[];
-  defaultLanguage?: string; // to be introduced
+  defaultLanguage?: CypherVersion;
 };
 
 /**

--- a/packages/schema-poller/src/queries/databases.ts
+++ b/packages/schema-poller/src/queries/databases.ts
@@ -30,6 +30,7 @@ export type Database = {
   writer?: boolean;
   access?: string;
   constituents?: string[];
+  defaultLanguage?: string; // to be introduced
 };
 
 /**


### PR DESCRIPTION
Now if defaultLanguage-field is defined on a database, this language version will be used by default in the analysis, otherwise cypher 5 is used.
If the version is defined in-query, like `CYPHER 25 ...` this version will overwrite the default version, if it is given in an array of supported versions we store ourselves (currently 5 and 25).
