### PR TITLE
Fix bug using console commands as variables labels

### DIFF
--- a/.changeset/serious-ducks-sleep.md
+++ b/.changeset/serious-ducks-sleep.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes bug using console commands as variables or labels

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -52,7 +52,7 @@ useCompletionRule: USE;
 serverCompletionRule: SERVER;
 
 // This rule overrides the identifiers adding EXPLAIN, PROFILE, etc
-unescapedLabelSymbolicNameString: 
+unescapedSymbolicNameString: 
     preparserKeyword 
     | HISTORY
     | CLEAR

--- a/packages/language-support/src/tests/syntaxColouring/preparser.test.ts
+++ b/packages/language-support/src/tests/syntaxColouring/preparser.test.ts
@@ -535,4 +535,244 @@ describe('Preparser syntax colouring', () => {
       },
     ]);
   });
+
+  test('Correctly colours console commands used as variables or labels', () => {
+    const query = `CREATE (n:clear {use: 0})
+WITH $param AS map
+RETURN map.propertyKey`;
+    expect(applySyntaxColouring(query)).toEqual([
+      {
+        bracketInfo: undefined,
+        length: 6,
+        position: {
+          line: 0,
+          startCharacter: 0,
+          startOffset: 0,
+        },
+        token: 'CREATE',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: {
+          bracketLevel: 0,
+          bracketType: 'parenthesis',
+        },
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 7,
+          startOffset: 7,
+        },
+        token: '(',
+        tokenType: 'bracket',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 8,
+          startOffset: 8,
+        },
+        token: 'n',
+        tokenType: 'variable',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 9,
+          startOffset: 9,
+        },
+        token: ':',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 5,
+        position: {
+          line: 0,
+          startCharacter: 10,
+          startOffset: 10,
+        },
+        token: 'clear',
+        tokenType: 'label',
+      },
+      {
+        bracketInfo: {
+          bracketLevel: 0,
+          bracketType: 'curly',
+        },
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 16,
+          startOffset: 16,
+        },
+        token: '{',
+        tokenType: 'bracket',
+      },
+      {
+        bracketInfo: undefined,
+        length: 3,
+        position: {
+          line: 0,
+          startCharacter: 17,
+          startOffset: 17,
+        },
+        token: 'use',
+        tokenType: 'property',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 20,
+          startOffset: 20,
+        },
+        token: ':',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 22,
+          startOffset: 22,
+        },
+        token: '0',
+        tokenType: 'numberLiteral',
+      },
+      {
+        bracketInfo: {
+          bracketLevel: 0,
+          bracketType: 'curly',
+        },
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 23,
+          startOffset: 23,
+        },
+        token: '}',
+        tokenType: 'bracket',
+      },
+      {
+        bracketInfo: {
+          bracketLevel: 0,
+          bracketType: 'parenthesis',
+        },
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 24,
+          startOffset: 24,
+        },
+        token: ')',
+        tokenType: 'bracket',
+      },
+      {
+        bracketInfo: undefined,
+        length: 4,
+        position: {
+          line: 1,
+          startCharacter: 0,
+          startOffset: 26,
+        },
+        token: 'WITH',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 1,
+          startCharacter: 5,
+          startOffset: 31,
+        },
+        token: '$',
+        tokenType: 'paramDollar',
+      },
+      {
+        bracketInfo: undefined,
+        length: 5,
+        position: {
+          line: 1,
+          startCharacter: 6,
+          startOffset: 32,
+        },
+        token: 'param',
+        tokenType: 'paramValue',
+      },
+      {
+        bracketInfo: undefined,
+        length: 2,
+        position: {
+          line: 1,
+          startCharacter: 12,
+          startOffset: 38,
+        },
+        token: 'AS',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 3,
+        position: {
+          line: 1,
+          startCharacter: 15,
+          startOffset: 41,
+        },
+        token: 'map',
+        tokenType: 'variable',
+      },
+      {
+        bracketInfo: undefined,
+        length: 6,
+        position: {
+          line: 2,
+          startCharacter: 0,
+          startOffset: 45,
+        },
+        token: 'RETURN',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 3,
+        position: {
+          line: 2,
+          startCharacter: 7,
+          startOffset: 52,
+        },
+        token: 'map',
+        tokenType: 'variable',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 2,
+          startCharacter: 10,
+          startOffset: 55,
+        },
+        token: '.',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 11,
+        position: {
+          line: 2,
+          startCharacter: 11,
+          startOffset: 56,
+        },
+        token: 'propertyKey',
+        tokenType: 'property',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
The rule we override to allow the console commands in the parser to be used as variable names, labels, etc was not the correct one, so we couldn't use `clear`, `param`, etc in some places in the query:

```
antlr4-parse ./{CypherCmdLexer.g4,CypherCmdParser.g4} statementsOrCommands


CREATE (n:clear {use: 0})
WITH $param AS map
RETURN map.propertyKey

line 1:10 mismatched input 'clear' expecting {ESCAPED_SYMBOLIC_NAME, ACCESS, ACTIVE, ADMIN, ADMINISTRATOR, ALIAS, ALIASES, ALL_SHORTEST_PATHS, ALL, ALTER, AND, ANY, ARRAY, AS, ASC, ASCENDING, ASSIGN, AT, AUTH, BINDINGS, BOOL, BOOLEAN, BOOSTED, BOTH, BREAK, BUILT, BY, CALL, CASCADE, CASE, CHANGE, CIDR, COLLECT, COMMAND, COMMANDS, COMPOSITE, CONCURRENT, CONSTRAINT, CONSTRAINTS, CONTAINS, COPY, CONTINUE, COUNT, CREATE, CSV, CURRENT, DATA, DATABASE, DATABASES, DATE, DATETIME, DBMS, DEALLOCATE, DEFAULT, DEFINED, DELETE, DENY, DESC, DESCENDING, DESTROY, DETACH, DIFFERENT, '$', DISTINCT, DRIVER, DROP, DRYRUN, DUMP, DURATION, EACH, EDGE, ENABLE, ELEMENT, ELEMENTS, ELSE, ENCRYPTED, END, ENDS, EXECUTABLE, EXECUTE, EXIST, EXISTENCE, EXISTS, ERROR, FAIL, FALSE, FIELDTERMINATOR, FINISH, FLOAT, FOR, FOREACH, FROM, FULLTEXT, FUNCTION, FUNCTIONS, GRANT, GRAPH, GRAPHS, GROUP, GROUPS, HEADERS, HOME, ID, IF, IMPERSONATE, IMMUTABLE, IN, INDEX, INDEXES, INF, INFINITY, INSERT, INT, INTEGER, IS, JOIN, KEY, LABEL, LABELS, '!', LEADING, LIMITROWS, LIST, LOAD, LOCAL, LOOKUP, '(', MANAGEMENT, MAP, MATCH, MERGE, '%', NAME, NAMES, NAN, NFC, NFD, NFKC, NFKD, NEW, NODE, NODETACH, NODES, NONE, NORMALIZE, NORMALIZED, NOT, NOTHING, NOWAIT, NULL, OF, OFFSET, ON, ONLY, OPTIONAL, OPTIONS, OPTION, OR, ORDER, PASSWORD, PASSWORDS, PATH, PATHS, PLAINTEXT, POINT, POPULATED, PRIMARY, PRIMARIES, PRIVILEGE, PRIVILEGES, PROCEDURE, PROCEDURES, PROPERTIES, PROPERTY, PROVIDER, PROVIDERS, RANGE, READ, REALLOCATE, REDUCE, RENAME, REL, RELATIONSHIP, RELATIONSHIPS, REMOVE, REPEATABLE, REPLACE, REPORT, REQUIRE, REQUIRED, RESTRICT, RETURN, REVOKE, ROLE, ROLES, ROW, ROWS, SCAN, SEC, SECOND, SECONDARY, SECONDARIES, SECONDS, SEEK, SERVER, SERVERS, SET, SETTING, SETTINGS, SHORTEST_PATH, SHORTEST, SHOW, SIGNED, SINGLE, SKIPROWS, START, STARTS, STATUS, STOP, STRING, SUPPORTED, SUSPENDED, TARGET, TERMINATE, TEXT, THEN, TIME, TIMESTAMP, TIMEZONE, TO, TOPOLOGY, TRAILING, TRANSACTION, TRANSACTIONS, TRAVERSE, TRIM, TRUE, TYPE, TYPED, TYPES, UNION, UNIQUE, UNIQUENESS, UNWIND, URL, USE, USER, USERS, USING, VALUE, VARCHAR, VECTOR, VERTEX, WAIT, WHEN, WHERE, WITH, WITHOUT, WRITE, XOR, YIELD, ZONE, ZONED, IDENTIFIER}
```