### PR TITLE
Adds baseline formatter implementation

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1,0 +1,380 @@
+import {
+  CharStreams,
+  CommonTokenStream,
+  ParserRuleContext,
+  TerminalNode,
+} from 'antlr4';
+import {
+  default as CypherCmdLexer,
+  default as CypherLexer,
+} from '../generated-parser/CypherCmdLexer';
+import CypherCmdParser, {
+  ArrowLineContext,
+  BooleanLiteralContext,
+  ClauseContext,
+  CountStarContext,
+  ExistsExpressionContext,
+  KeywordLiteralContext,
+  LabelExpressionContext,
+  LeftArrowContext,
+  MapContext,
+  MergeActionContext,
+  MergeClauseContext,
+  NodePatternContext,
+  NumberLiteralContext,
+  PropertyContext,
+  RelationshipPatternContext,
+  RightArrowContext,
+  StatementsOrCommandsContext,
+  WhereClauseContext,
+} from '../generated-parser/CypherCmdParser';
+import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
+import {
+  isComment,
+  wantsSpaceAfter,
+  wantsSpaceBefore,
+  wantsToBeUpperCase,
+} from './formattingHelpers';
+
+interface RawTerminalOptions {
+  lowerCase?: boolean;
+  upperCase?: boolean;
+}
+
+export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
+  buffer: string[] = [];
+  indentation = 0;
+  indentationSpaces = 2;
+
+  constructor(private tokenStream: CommonTokenStream) {
+    super();
+  }
+
+  format = (root: StatementsOrCommandsContext) => {
+    this.visit(root);
+    return this.buffer.join('').trim();
+  };
+
+  breakLine = () => {
+    if (
+      this.buffer.length > 0 &&
+      this.buffer[this.buffer.length - 1] !== '\n'
+    ) {
+      this.buffer.push('\n');
+    }
+  };
+
+  addSpace = () => {
+    if (this.buffer.at(-1) !== ' ') {
+      this.buffer.push(' ');
+    }
+  };
+
+  addIndentation = () => this.indentation++;
+
+  removeIndentation = () => this.indentation--;
+
+  applyIndentation = () => {
+    for (let i = 0; i < this.indentation * this.indentationSpaces; i++) {
+      this.buffer.push(' ');
+    }
+  };
+
+  // Comments are in the hidden channel, so grab them manually
+  addCommentsBefore = (node: TerminalNode) => {
+    const token = node.symbol;
+    const hiddenTokens = this.tokenStream.getHiddenTokensToLeft(
+      token.tokenIndex,
+    );
+    const commentTokens = (hiddenTokens || []).filter((token) =>
+      isComment(token),
+    );
+    for (const commentToken of commentTokens) {
+      this.buffer.push(commentToken.text.trim());
+      this.breakLine();
+    }
+  };
+
+  addCommentsAfter = (node: TerminalNode) => {
+    const token = node.symbol;
+    const hiddenTokens = this.tokenStream.getHiddenTokensToRight(
+      token.tokenIndex,
+    );
+    const commentTokens = (hiddenTokens || []).filter((token) =>
+      isComment(token),
+    );
+    for (const commentToken of commentTokens) {
+      if (
+        this.buffer.length > 0 &&
+        this.buffer[this.buffer.length - 1] !== ' ' &&
+        this.buffer[this.buffer.length - 1] !== '\n'
+      ) {
+        this.addSpace();
+      }
+      this.buffer.push(commentToken.text.trim());
+      this.breakLine();
+    }
+  };
+
+  visitIfNotNull = (ctx: ParserRuleContext | TerminalNode) => {
+    if (ctx) {
+      this.visit(ctx);
+    }
+  };
+
+  visitRawIfNotNull = (ctx: TerminalNode, options?: RawTerminalOptions) => {
+    if (ctx) {
+      this.visitTerminalRaw(ctx, options);
+    }
+  };
+
+  // Handled separately because clauses should start on new lines, see
+  // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
+  visitClause = (ctx: ClauseContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
+  // Visit these separately because operators want spaces around them,
+  // and these are not operators (despite being minuses).
+  visitArrowLine = (ctx: ArrowLineContext) => {
+    this.visitTerminalRaw(ctx.ARROW_LINE());
+  };
+
+  visitRightArrow = (ctx: RightArrowContext) => {
+    this.visitTerminalRaw(ctx.GT());
+  };
+
+  visitLeftArrow = (ctx: LeftArrowContext) => {
+    this.visitTerminalRaw(ctx.LT());
+  };
+
+  // Handled separately because count star is its own thing
+  visitCountStar = (ctx: CountStarContext) => {
+    this.visitTerminalRaw(ctx.COUNT());
+    this.visit(ctx.LPAREN());
+    this.visitTerminalRaw(ctx.TIMES());
+    this.visit(ctx.RPAREN());
+  };
+
+  // Handled separately to avoid spaces between a minus and a number
+  visitNumberLiteral = (ctx: NumberLiteralContext) => {
+    this.visitRawIfNotNull(ctx.MINUS());
+    this.visitIfNotNull(ctx.DECIMAL_DOUBLE());
+    this.visitIfNotNull(ctx.UNSIGNED_DECIMAL_INTEGER());
+    this.visitIfNotNull(ctx.UNSIGNED_HEX_INTEGER());
+    this.visitIfNotNull(ctx.UNSIGNED_OCTAL_INTEGER());
+  };
+
+  // Handled separately since otherwise they will get weird spacing
+  // TODO: doesn't handle the special label expressions yet
+  // (labelExpression3 etc)
+  visitLabelExpression = (ctx: LabelExpressionContext) => {
+    this.visitRawIfNotNull(ctx.COLON());
+    this.visitRawIfNotNull(ctx.IS());
+    this.visit(ctx.labelExpression4());
+  };
+
+  visitTerminal = (node: TerminalNode) => {
+    if (this.buffer.length === 0) {
+      this.addCommentsBefore(node);
+    }
+    if (
+      this.buffer.length > 0 &&
+      this.buffer[this.buffer.length - 1] === '\n'
+    ) {
+      this.applyIndentation();
+    }
+
+    if (
+      this.buffer.length > 0 &&
+      this.buffer[this.buffer.length - 1] !== '\n' &&
+      this.buffer[this.buffer.length - 1] !== ' '
+    ) {
+      if (wantsSpaceBefore(node)) {
+        this.addSpace();
+      }
+    }
+    if (node.symbol.type === CypherCmdLexer.EOF) {
+      return;
+    }
+    if (wantsToBeUpperCase(node)) {
+      this.buffer.push(node.getText().toUpperCase());
+    } else {
+      this.buffer.push(node.getText());
+    }
+    if (wantsSpaceAfter(node)) {
+      this.addSpace();
+    }
+    this.addCommentsAfter(node);
+  };
+
+  // Some terminals don't want to have the regular rules applied to them,
+  // for instance the . in properties should be handled in a "raw" manner to
+  // avoid getting spaces around it (since it is an operator and operators want spaces)
+  // But we still need to get the comments, to ensure that in e.g. the query
+  // node. // comment
+  // prop
+  // the comment doesn't disappear
+  visitTerminalRaw = (node: TerminalNode, options?: RawTerminalOptions) => {
+    if (this.buffer.length === 0) {
+      this.addCommentsBefore(node);
+    }
+    let result = node.getText();
+    if (options?.lowerCase) {
+      result = result.toLowerCase();
+    }
+    if (options?.upperCase) {
+      result = result.toUpperCase();
+    }
+    this.buffer.push(result);
+    this.addCommentsAfter(node);
+  };
+
+  // Literals have casing rules, see
+  // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-casing
+  visitBooleanLiteral = (ctx: BooleanLiteralContext) => {
+    this.visitRawIfNotNull(ctx.TRUE(), { lowerCase: true });
+    this.visitRawIfNotNull(ctx.FALSE(), { lowerCase: true });
+  };
+
+  visitKeywordLiteral = (ctx: KeywordLiteralContext) => {
+    if (ctx.NULL()) {
+      this.visitTerminalRaw(ctx.NULL(), { lowerCase: true });
+    } else {
+      this.visitChildren(ctx);
+    }
+  };
+
+  // The patterns are handled separately because we need spaces
+  // between labels and property predicates in patterns
+  handleInnerPatternContext = (
+    ctx: NodePatternContext | RelationshipPatternContext,
+  ) => {
+    this.visitIfNotNull(ctx.variable());
+    this.visitIfNotNull(ctx.labelExpression());
+    if (ctx.labelExpression() && ctx.properties()) {
+      this.addSpace();
+    }
+    this.visitIfNotNull(ctx.properties());
+    if (ctx.WHERE()) {
+      this.visit(ctx.WHERE());
+      this.visit(ctx.expression());
+    }
+  };
+
+  visitNodePattern = (ctx: NodePatternContext) => {
+    this.visit(ctx.LPAREN());
+    this.handleInnerPatternContext(ctx);
+    this.visit(ctx.RPAREN());
+  };
+
+  visitRelationshipPattern = (ctx: RelationshipPatternContext) => {
+    this.visitIfNotNull(ctx.leftArrow());
+    const arrowLineList = ctx.arrowLine_list();
+    this.visitTerminalRaw(arrowLineList[0].MINUS());
+    if (ctx.LBRACKET()) {
+      this.visit(ctx.LBRACKET());
+      this.handleInnerPatternContext(ctx);
+      this.visit(ctx.RBRACKET());
+    }
+    this.visitTerminalRaw(arrowLineList[1].MINUS());
+    this.visitIfNotNull(ctx.rightArrow());
+  };
+
+  // Handled separately because the dot is not an operator
+  visitProperty = (ctx: PropertyContext) => {
+    this.visitTerminalRaw(ctx.DOT());
+    this.visit(ctx.propertyKeyName());
+  };
+
+  // Handled separately because where is not a clause (it is a subclause)
+  visitWhereClause = (ctx: WhereClauseContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
+  // Handled separately because it contains subclauses (and thus indentation rules)
+  visitExistsExpression = (ctx: ExistsExpressionContext) => {
+    this.visit(ctx.EXISTS());
+    this.visit(ctx.LCURLY());
+    if (ctx.regularQuery()) {
+      this.addIndentation();
+      this.visit(ctx.regularQuery());
+      this.breakLine();
+      this.removeIndentation();
+    } else {
+      this.addSpace();
+      this.visitIfNotNull(ctx.matchMode());
+      this.visit(ctx.patternList());
+      this.visitIfNotNull(ctx.whereClause());
+      this.addSpace();
+    }
+    this.visit(ctx.RCURLY());
+  };
+
+  // Handled separately because we want ON CREATE before ON MATCH
+  visitMergeClause = (ctx: MergeClauseContext) => {
+    this.visit(ctx.MERGE());
+    this.visit(ctx.pattern());
+    const mergeActions = ctx
+      .mergeAction_list()
+      .map((action, index) => ({ action, index }))
+      .sort((a, b) => {
+        if (a.action.CREATE() && b.action.MATCH()) {
+          return -1;
+        } else if (a.action.MATCH() && b.action.CREATE()) {
+          return 1;
+        }
+        return a.index - b.index;
+      })
+      .map(({ action }) => action);
+    mergeActions.forEach((action) => {
+      this.visit(action);
+    });
+  };
+
+  // Handled separately because it wants indentation
+  // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
+  visitMergeAction = (ctx: MergeActionContext) => {
+    if (this.buffer.length > 0) {
+      this.breakLine();
+      this.addIndentation();
+      this.applyIndentation();
+    }
+    this.visitChildren(ctx);
+    this.removeIndentation();
+  };
+
+  // Map has its own formatting rules, see:
+  // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-spacing
+  visitMap = (ctx: MapContext) => {
+    this.visit(ctx.LCURLY());
+
+    const propertyKeyNames = ctx.propertyKeyName_list();
+    const expressions = ctx.expression_list();
+    const commaList = ctx.COMMA_list();
+    const colonList = ctx.COLON_list();
+    for (let i = 0; i < expressions.length; i++) {
+      this.visit(propertyKeyNames[i]);
+      this.visitTerminalRaw(colonList[i]);
+      this.addSpace();
+      this.visit(expressions[i]);
+      if (i < expressions.length - 1) {
+        this.visit(commaList[i]);
+      }
+    }
+    this.visit(ctx.RCURLY());
+  };
+}
+
+export function formatQuery(query: string) {
+  const inputStream = CharStreams.fromString(query);
+  const lexer = new CypherLexer(inputStream);
+  const tokens = new CommonTokenStream(lexer);
+  const parser = new CypherCmdParser(tokens);
+  parser.buildParseTrees = true;
+  const tree = parser.statementsOrCommands();
+  const visitor = new TreePrintVisitor(tokens);
+  return visitor.format(tree);
+}

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -1,0 +1,43 @@
+import { TerminalNode, Token } from 'antlr4';
+import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
+import {
+  EscapedSymbolicNameStringContext,
+  UnescapedSymbolicNameString_Context,
+} from '../generated-parser/CypherCmdParser';
+import { lexerKeywords, lexerOperators } from '../lexerSymbols';
+
+export function wantsToBeUpperCase(node: TerminalNode): boolean {
+  return isKeywordTerminal(node);
+}
+
+export function wantsSpaceBefore(node: TerminalNode): boolean {
+  return isKeywordTerminal(node) || lexerOperators.includes(node.symbol.type);
+}
+
+export function wantsSpaceAfter(node: TerminalNode): boolean {
+  return (
+    isKeywordTerminal(node) ||
+    lexerOperators.includes(node.symbol.type) ||
+    node.symbol.type === CypherCmdLexer.COMMA
+  );
+}
+
+function isKeywordTerminal(node: TerminalNode): boolean {
+  return lexerKeywords.includes(node.symbol.type) && !isSymbolicName(node);
+}
+
+export function isComment(token: Token) {
+  return (
+    token.type === CypherCmdLexer.MULTI_LINE_COMMENT ||
+    token.type === CypherCmdLexer.SINGLE_LINE_COMMENT
+  );
+}
+
+// Variables or property names that have the same name as a keyword should not be
+// treated as keywords
+function isSymbolicName(node: TerminalNode): boolean {
+  return (
+    node.parentCtx instanceof UnescapedSymbolicNameString_Context ||
+    node.parentCtx instanceof EscapedSymbolicNameStringContext
+  );
+}

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -1,0 +1,224 @@
+import { formatQuery } from '../formatting/../../formatting/formatting';
+
+describe('styleguide examples', () => {
+  test('on match indentation example', () => {
+    const query = `MERGE (n) ON CREATE SET n.prop = 0
+MERGE (a:A)-[:T]->(b:B)
+ON MATCH SET b.name = 'you'
+ON CREATE SET a.name = 'me'
+RETURN a.prop`;
+    const expected = `MERGE (n)
+  ON CREATE SET n.prop = 0
+MERGE (a:A)-[:T]->(b:B)
+  ON CREATE SET a.name = 'me'
+  ON MATCH SET b.name = 'you'
+RETURN a.prop`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('on where exists regular subquery', () => {
+    const query = `MATCH (a:A) WHERE EXISTS {MATCH (a)-->(b:B) WHERE b.prop = 'yellow'} RETURN a.foo`;
+
+    const expected = `MATCH (a:A)
+WHERE EXISTS {
+  MATCH (a)-->(b:B)
+  WHERE b.prop = 'yellow'
+}
+RETURN a.foo`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('on where exists regular simplified subquery', () => {
+    const query = `MATCH (a:A)
+WHERE EXISTS {
+  (a)-->(b:B)
+}
+RETURN a.prop`;
+
+    const expected = `MATCH (a:A)
+WHERE EXISTS { (a)-->(b:B) }
+RETURN a.prop`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('Using wrapper space around operators', () => {
+    const query = `MATCH p=(s)-->(e)
+WHERE s.name<>e.name
+RETURN length(p)`;
+
+    const expected = `MATCH p = (s)-->(e)
+WHERE s.name <> e.name
+RETURN length(p)`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('formats maps properly', () => {
+    const query = `WITH { key1 :'value' ,key2  :  42 } AS map RETURN map`;
+    const expected = `WITH {key1: 'value', key2: 42} AS map
+RETURN map`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+});
+
+describe('should not forget to include all comments', () => {
+  test('property comments', () => {
+    const propertycomments = `match (n)
+return n. // comment
+prop`;
+    const expected = `MATCH (n)
+RETURN n. // comment
+prop`;
+    expect(formatQuery(propertycomments)).toEqual(expected);
+  });
+
+  test('basic inline comments', () => {
+    // Whitespace after the comment lines is intentional. It should be removed
+    const inlinecomments = `
+MERGE (n) ON CREATE SET n.prop = 0 // Ensure 'n' exists and initialize 'prop' to 0 if created   
+MERGE (a:A)-[:T]->(b:B)           // Create or match a relationship from 'a:A' to 'b:B'     
+ON MATCH SET b.name = 'you'       // If 'b' already exists, set its 'name' to 'you'       
+ON CREATE SET a.name = 'me'       // If 'a' is created, set its 'name' to 'me'       
+RETURN a.prop                     // Return the 'prop' of 'a'       
+`;
+    const expected = `MERGE (n)
+  ON CREATE SET n.prop = 0 // Ensure 'n' exists and initialize 'prop' to 0 if created
+MERGE (a:A)-[:T]->(b:B) // Create or match a relationship from 'a:A' to 'b:B'
+  ON CREATE SET a.name = 'me' // If 'a' is created, set its 'name' to 'me'
+  ON MATCH SET b.name = 'you' // If 'b' already exists, set its 'name' to 'you'
+RETURN a.prop // Return the 'prop' of 'a'`;
+    expect(formatQuery(inlinecomments)).toEqual(expected);
+  });
+
+  test('comments before the query', () => {
+    const inlinecommentbefore = `// This is a comment before everything
+MATCH (n) return n`;
+    const expected = `// This is a comment before everything
+MATCH (n)
+RETURN n`;
+    expect(formatQuery(inlinecommentbefore)).toEqual(expected);
+
+    const multilinecommentbefore = `/* This is a comment before everything
+And it spans multiple lines */
+MATCH (n) return n`;
+    const expected2 = `/* This is a comment before everything
+And it spans multiple lines */
+MATCH (n)
+RETURN n`;
+    expect(formatQuery(multilinecommentbefore)).toEqual(expected2);
+  });
+
+  test('weird inline comments', () => {
+    const inlinemultiline = `MERGE (n) /* Ensuring the node exists */ 
+  ON CREATE SET n.prop = 0 /* Set default property */
+MERGE (a:A) /* Create or match 'a:A' */ 
+  -[:T]-> (b:B) /* Link 'a' to 'b' */
+RETURN a.prop /* Return the property of 'a' */
+`;
+    const expected = `MERGE (n) /* Ensuring the node exists */
+  ON CREATE SET n.prop = 0 /* Set default property */
+MERGE (a:A) /* Create or match 'a:A' */
+-[:T]->(b:B) /* Link 'a' to 'b' */
+RETURN a.prop /* Return the property of 'a' */`;
+    expect(formatQuery(inlinemultiline)).toEqual(expected);
+  });
+
+  test('weird inline and multiline comments', () => {
+    const inlineandmultiline = `MERGE (n) // Ensure node exists
+ON CREATE SET n.prop = 0 /* Default value */
+/* Match or create a relationship
+   and update properties as needed */    
+MERGE (a:A) -[:T]-> (b:B)
+ON CREATE SET a.name='me'// Name set during creation
+ON MATCH SET b.name='you' /* Update name if matched */
+RETURN a.prop// Output the result`;
+    const expected = `MERGE (n) // Ensure node exists
+  ON CREATE SET n.prop = 0 /* Default value */
+/* Match or create a relationship
+   and update properties as needed */
+MERGE (a:A)-[:T]->(b:B)
+  ON CREATE SET a.name = 'me' // Name set during creation
+  ON MATCH SET b.name = 'you' /* Update name if matched */
+RETURN a.prop // Output the result`;
+    expect(formatQuery(inlineandmultiline)).toEqual(expected);
+  });
+});
+
+describe('other styleguide recommendations', () => {
+  test('order by', () => {
+    const query = `RETURN user.id ORDER BY potential_reach, like_count;`;
+    const expected = `RETURN user.id ORDER BY potential_reach, like_count;`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('escaped names', () => {
+    const query =
+      'CREATE (`complex name with special@chars`) RETURN `complex name with special@chars`';
+    const expected =
+      'CREATE (`complex name with special@chars`)\nRETURN `complex name with special@chars`';
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('cases null and booleans properly', () => {
+    const query = `WITH NULL as n1, Null as n2, False as f1, True as t1 RETURN NULL, TRUE, FALSE`;
+    const expected = `WITH null AS n1, null AS n2, false AS f1, true AS t1
+RETURN null, true, false`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('can handle using keyword literal names in weird ways', () => {
+    const query1 = 'MATCH (NULL) RETURN NULL';
+    const expected1 = 'MATCH (NULL)\nRETURN null';
+    expect(formatQuery(query1)).toEqual(expected1);
+
+    const query2 = 'MATCH (NAN) RETURN NAN';
+    const expected2 = 'MATCH (NAN)\nRETURN NAN';
+    expect(formatQuery(query2)).toEqual(expected2);
+
+    const query3 = 'MATCH (INF) RETURN INF';
+    const expected3 = 'MATCH (INF)\nRETURN INF';
+    expect(formatQuery(query3)).toEqual(expected3);
+  });
+
+  test('puts one space between label/type predicates and property predicates in patterns', () => {
+    const query = `MATCH (p:Person{property:-1})-[:KNOWS{since: 2016}]->() RETURN p.name`;
+    const expected = `MATCH (p:Person {property: -1})-[:KNOWS {since: 2016}]->()\nRETURN p.name`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('no space in patterns', () => {
+    const query = 'MATCH (:Person) --> (:Vehicle) RETURN count(*)';
+    const expected = 'MATCH (:Person)-->(:Vehicle)\nRETURN count(*)';
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('space after each comma in lists and enumerations', () => {
+    const query = `MATCH (),()
+WITH ['a','b',3.14] AS list
+RETURN list,2,3,4`;
+    const expected = `MATCH (), ()
+WITH ['a', 'b', 3.14] AS list
+RETURN list, 2, 3, 4`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('handles empty list literals', () => {
+    const query = `WITH [] AS emptyList RETURN emptyList`;
+    const expected = `WITH [] AS emptyList
+RETURN emptyList`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
+
+  test('should not add space for negating minuses', () => {
+    const query = 'RETURN -1, -2, -3';
+    const expected = 'RETURN -1, -2, -3';
+    expect(formatQuery(query)).toEqual(expected);
+  });
+});
+
+describe('various edgecases', () => {
+  test('multiple queries', () => {
+    const multiquery = 'RETURN 1; RETURN 2; RETURN 3;';
+    const expectedMultiquery = 'RETURN 1;\nRETURN 2;\nRETURN 3;';
+    expect(formatQuery(multiquery)).toEqual(expectedMultiquery);
+  });
+});


### PR DESCRIPTION
### Description
Initial implementation of our cypher formatter. Note that the code does nothing beyond running its own tests at this stage.

The reason I am opening a PR despite it not actually doing anything is that we're already up to several hundred LOC, and reviewing huge PRs is not fun. So this is an attempt at introducing a PR early to avoid too much code in once PR, but still making it big enough to actually introduce meaningful code. It's still huge though, sorry 😅 .

I've been (very) generous with the amounts of comments, and it might be a bit verbose. The reasoning is that methods should have a compelling reason to exist, or they should not exist at all, and instead be handled by the general cases. So to keep track of why something is needed, and to be able to evaluate if it still is after new changes, I added lots of "handled separately because..." comments.

### Testing
- 19 Unit tests included in this PR 
- `npm run test` (in root dir)