### PR TITLE
Adds standardization check to formatter tests

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1,14 +1,6 @@
+import { CommonTokenStream, ParserRuleContext, TerminalNode } from 'antlr4';
+import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import {
-  CharStreams,
-  CommonTokenStream,
-  ParserRuleContext,
-  TerminalNode,
-} from 'antlr4';
-import {
-  default as CypherCmdLexer,
-  default as CypherLexer,
-} from '../generated-parser/CypherCmdLexer';
-import CypherCmdParser, {
   ArrowLineContext,
   BooleanLiteralContext,
   ClauseContext,
@@ -30,6 +22,8 @@ import CypherCmdParser, {
 } from '../generated-parser/CypherCmdParser';
 import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
 import {
+  getParseTreeAndTokens,
+  handleMergeClause,
   isComment,
   wantsSpaceAfter,
   wantsSpaceBefore,
@@ -315,23 +309,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   // Handled separately because we want ON CREATE before ON MATCH
   visitMergeClause = (ctx: MergeClauseContext) => {
-    this.visit(ctx.MERGE());
-    this.visit(ctx.pattern());
-    const mergeActions = ctx
-      .mergeAction_list()
-      .map((action, index) => ({ action, index }))
-      .sort((a, b) => {
-        if (a.action.CREATE() && b.action.MATCH()) {
-          return -1;
-        } else if (a.action.MATCH() && b.action.CREATE()) {
-          return 1;
-        }
-        return a.index - b.index;
-      })
-      .map(({ action }) => action);
-    mergeActions.forEach((action) => {
-      this.visit(action);
-    });
+    handleMergeClause(ctx, (node) => this.visit(node));
   };
 
   // Handled separately because it wants indentation
@@ -369,12 +347,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 }
 
 export function formatQuery(query: string) {
-  const inputStream = CharStreams.fromString(query);
-  const lexer = new CypherLexer(inputStream);
-  const tokens = new CommonTokenStream(lexer);
-  const parser = new CypherCmdParser(tokens);
-  parser.buildParseTrees = true;
-  const tree = parser.statementsOrCommands();
+  const { tree, tokens } = getParseTreeAndTokens(query);
   const visitor = new TreePrintVisitor(tokens);
   return visitor.format(tree);
 }

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -1,10 +1,39 @@
-import { TerminalNode, Token } from 'antlr4';
-import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import {
+  CharStreams,
+  CommonTokenStream,
+  ParseTree,
+  TerminalNode,
+  Token,
+} from 'antlr4';
+import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
+import CypherCmdParser, {
   EscapedSymbolicNameStringContext,
+  MergeClauseContext,
   UnescapedSymbolicNameString_Context,
 } from '../generated-parser/CypherCmdParser';
 import { lexerKeywords, lexerOperators } from '../lexerSymbols';
+
+export function handleMergeClause(
+  ctx: MergeClauseContext,
+  visit: (node: ParseTree) => void,
+) {
+  visit(ctx.MERGE());
+  visit(ctx.pattern());
+  const mergeActions = ctx
+    .mergeAction_list()
+    .map((action, index) => ({ action, index }));
+  mergeActions.sort((a, b) => {
+    if (a.action.CREATE() && b.action.MATCH()) {
+      return -1;
+    } else if (a.action.MATCH() && b.action.CREATE()) {
+      return 1;
+    }
+    return a.index - b.index;
+  });
+  mergeActions.forEach(({ action }) => {
+    visit(action);
+  });
+}
 
 export function wantsToBeUpperCase(node: TerminalNode): boolean {
   return isKeywordTerminal(node);
@@ -40,4 +69,13 @@ function isSymbolicName(node: TerminalNode): boolean {
     node.parentCtx instanceof UnescapedSymbolicNameString_Context ||
     node.parentCtx instanceof EscapedSymbolicNameStringContext
   );
+}
+export function getParseTreeAndTokens(query: string) {
+  const inputStream = CharStreams.fromString(query);
+  const lexer = new CypherCmdLexer(inputStream);
+  const tokens = new CommonTokenStream(lexer);
+  const parser = new CypherCmdParser(tokens);
+  parser.buildParseTrees = true;
+  const tree = parser.statementsOrCommands();
+  return { tree, tokens };
 }

--- a/packages/language-support/src/formatting/standardizer.ts
+++ b/packages/language-support/src/formatting/standardizer.ts
@@ -1,0 +1,31 @@
+import { TerminalNode } from 'antlr4';
+import {
+  MergeClauseContext,
+  StatementsOrCommandsContext,
+} from '../generated-parser/CypherCmdParser';
+import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
+import { getParseTreeAndTokens, handleMergeClause } from './formattingHelpers';
+
+class StandardizingVisitor extends CypherCmdParserVisitor<void> {
+  buffer = [];
+
+  format = (root: StatementsOrCommandsContext) => {
+    this.visit(root);
+    return this.buffer.join('');
+  };
+
+  visitMergeClause = (ctx: MergeClauseContext) => {
+    handleMergeClause(ctx, (node) => this.visit(node));
+  };
+
+  visitTerminal = (node: TerminalNode) => {
+    this.buffer.push(node.getText().toLowerCase());
+    this.buffer.push(' ');
+  };
+}
+
+export function standardizeQuery(query: string): string {
+  const { tree } = getParseTreeAndTokens(query);
+  const visitor = new StandardizingVisitor();
+  return visitor.format(tree);
+}

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -1,4 +1,17 @@
-import { formatQuery } from '../formatting/../../formatting/formatting';
+import { formatQuery } from '../../formatting/formatting';
+import { standardizeQuery } from '../../formatting/standardizer';
+
+function verifyFormatting(query: string, expected: string): void {
+  const formatted = formatQuery(query);
+  expect(formatted).toEqual(expected);
+  const queryStandardized = standardizeQuery(query);
+  const formattedStandardized = standardizeQuery(formatted);
+  if (formattedStandardized !== queryStandardized) {
+    throw new Error(
+      `Standardized query does not match standardized formatted query`,
+    );
+  }
+}
 
 describe('styleguide examples', () => {
   test('on match indentation example', () => {
@@ -13,7 +26,7 @@ MERGE (a:A)-[:T]->(b:B)
   ON CREATE SET a.name = 'me'
   ON MATCH SET b.name = 'you'
 RETURN a.prop`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('on where exists regular subquery', () => {
@@ -25,7 +38,7 @@ WHERE EXISTS {
   WHERE b.prop = 'yellow'
 }
 RETURN a.foo`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('on where exists regular simplified subquery', () => {
@@ -38,7 +51,7 @@ RETURN a.prop`;
     const expected = `MATCH (a:A)
 WHERE EXISTS { (a)-->(b:B) }
 RETURN a.prop`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('Using wrapper space around operators', () => {
@@ -49,14 +62,14 @@ RETURN length(p)`;
     const expected = `MATCH p = (s)-->(e)
 WHERE s.name <> e.name
 RETURN length(p)`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('formats maps properly', () => {
     const query = `WITH { key1 :'value' ,key2  :  42 } AS map RETURN map`;
     const expected = `WITH {key1: 'value', key2: 42} AS map
 RETURN map`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -68,7 +81,7 @@ prop`;
     const expected = `MATCH (n)
 RETURN n. // comment
 prop`;
-    expect(formatQuery(propertycomments)).toEqual(expected);
+    verifyFormatting(propertycomments, expected);
   });
 
   test('basic inline comments', () => {
@@ -86,7 +99,7 @@ MERGE (a:A)-[:T]->(b:B) // Create or match a relationship from 'a:A' to 'b:B'
   ON CREATE SET a.name = 'me' // If 'a' is created, set its 'name' to 'me'
   ON MATCH SET b.name = 'you' // If 'b' already exists, set its 'name' to 'you'
 RETURN a.prop // Return the 'prop' of 'a'`;
-    expect(formatQuery(inlinecomments)).toEqual(expected);
+    verifyFormatting(inlinecomments, expected);
   });
 
   test('comments before the query', () => {
@@ -95,7 +108,7 @@ MATCH (n) return n`;
     const expected = `// This is a comment before everything
 MATCH (n)
 RETURN n`;
-    expect(formatQuery(inlinecommentbefore)).toEqual(expected);
+    verifyFormatting(inlinecommentbefore, expected);
 
     const multilinecommentbefore = `/* This is a comment before everything
 And it spans multiple lines */
@@ -104,7 +117,7 @@ MATCH (n) return n`;
 And it spans multiple lines */
 MATCH (n)
 RETURN n`;
-    expect(formatQuery(multilinecommentbefore)).toEqual(expected2);
+    verifyFormatting(multilinecommentbefore, expected2);
   });
 
   test('weird inline comments', () => {
@@ -119,7 +132,7 @@ RETURN a.prop /* Return the property of 'a' */
 MERGE (a:A) /* Create or match 'a:A' */
 -[:T]->(b:B) /* Link 'a' to 'b' */
 RETURN a.prop /* Return the property of 'a' */`;
-    expect(formatQuery(inlinemultiline)).toEqual(expected);
+    verifyFormatting(inlinemultiline, expected);
   });
 
   test('weird inline and multiline comments', () => {
@@ -139,7 +152,7 @@ MERGE (a:A)-[:T]->(b:B)
   ON CREATE SET a.name = 'me' // Name set during creation
   ON MATCH SET b.name = 'you' /* Update name if matched */
 RETURN a.prop // Output the result`;
-    expect(formatQuery(inlineandmultiline)).toEqual(expected);
+    verifyFormatting(inlineandmultiline, expected);
   });
 });
 
@@ -147,7 +160,7 @@ describe('other styleguide recommendations', () => {
   test('order by', () => {
     const query = `RETURN user.id ORDER BY potential_reach, like_count;`;
     const expected = `RETURN user.id ORDER BY potential_reach, like_count;`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('escaped names', () => {
@@ -155,40 +168,40 @@ describe('other styleguide recommendations', () => {
       'CREATE (`complex name with special@chars`) RETURN `complex name with special@chars`';
     const expected =
       'CREATE (`complex name with special@chars`)\nRETURN `complex name with special@chars`';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('cases null and booleans properly', () => {
     const query = `WITH NULL as n1, Null as n2, False as f1, True as t1 RETURN NULL, TRUE, FALSE`;
     const expected = `WITH null AS n1, null AS n2, false AS f1, true AS t1
 RETURN null, true, false`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('can handle using keyword literal names in weird ways', () => {
     const query1 = 'MATCH (NULL) RETURN NULL';
     const expected1 = 'MATCH (NULL)\nRETURN null';
-    expect(formatQuery(query1)).toEqual(expected1);
+    verifyFormatting(query1, expected1);
 
     const query2 = 'MATCH (NAN) RETURN NAN';
     const expected2 = 'MATCH (NAN)\nRETURN NAN';
-    expect(formatQuery(query2)).toEqual(expected2);
+    verifyFormatting(query2, expected2);
 
     const query3 = 'MATCH (INF) RETURN INF';
     const expected3 = 'MATCH (INF)\nRETURN INF';
-    expect(formatQuery(query3)).toEqual(expected3);
+    verifyFormatting(query3, expected3);
   });
 
   test('puts one space between label/type predicates and property predicates in patterns', () => {
     const query = `MATCH (p:Person{property:-1})-[:KNOWS{since: 2016}]->() RETURN p.name`;
     const expected = `MATCH (p:Person {property: -1})-[:KNOWS {since: 2016}]->()\nRETURN p.name`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('no space in patterns', () => {
     const query = 'MATCH (:Person) --> (:Vehicle) RETURN count(*)';
     const expected = 'MATCH (:Person)-->(:Vehicle)\nRETURN count(*)';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('space after each comma in lists and enumerations', () => {
@@ -198,20 +211,20 @@ RETURN list,2,3,4`;
     const expected = `MATCH (), ()
 WITH ['a', 'b', 3.14] AS list
 RETURN list, 2, 3, 4`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('handles empty list literals', () => {
     const query = `WITH [] AS emptyList RETURN emptyList`;
     const expected = `WITH [] AS emptyList
 RETURN emptyList`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('should not add space for negating minuses', () => {
     const query = 'RETURN -1, -2, -3';
     const expected = 'RETURN -1, -2, -3';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -219,6 +232,6 @@ describe('various edgecases', () => {
   test('multiple queries', () => {
     const multiquery = 'RETURN 1; RETURN 2; RETURN 3;';
     const expectedMultiquery = 'RETURN 1;\nRETURN 2;\nRETURN 3;';
-    expect(formatQuery(multiquery)).toEqual(expectedMultiquery);
+    verifyFormatting(multiquery, expectedMultiquery);
   });
 });


### PR DESCRIPTION
### Description
When formatting, we want to ensure that we do not accidentally modify the parse tree in doing so. As a way of implementing this, I propose a "standardizer" which simply walks the tree and prints it as is, in order to make sure we don't e.g. drop some terminal nodes. This PR adds such a standardizer and runs it on every test. The idea is also to use this on a larger sample of queries once we get access to these (I've asked in #product_analytics). 

Since some styleguide rules change the tree, we can't simply do a comparison between the parsetree.toStringTree() strings. One styleguide rule says that ON CREATE should come before ON MATCH for instance, and so we need to take this into account in the standardizer. 

### Testing
- npm run test