### PR TITLE
Add formatting keybind button

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -46,8 +46,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   buffer: string[] = [];
   indentation = 0;
   indentationSpaces = 2;
-  targetToken = -1;
-  cursorPos = -1;
+  targetToken?: number;
+  cursorPos?: number;
 
   constructor(private tokenStream: CommonTokenStream) {
     super();
@@ -239,7 +239,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.cursorPos = this.buffer.join('').length;
     }
     this.buffer.push(result);
-
     this.addCommentsAfter(node);
   };
 
@@ -403,10 +402,8 @@ export function formatQuery(
   const tree = parser.statementsOrCommands();
   const visitor = new TreePrintVisitor(tokens);
 
-  if (cursorPosition === undefined) {
-    const result = visitor.format(tree);
-    return result;
-  }
+  if (cursorPosition === undefined) return visitor.format(tree);
+
   if (cursorPosition >= query.length || cursorPosition === 0) {
     const result = visitor.format(tree);
     return {
@@ -416,12 +413,11 @@ export function formatQuery(
   }
 
   const targetToken = findTargetToken(tokens.tokens, cursorPosition);
-
   const relativePosition = cursorPosition - targetToken.start;
   visitor.targetToken = targetToken.tokenIndex;
-  const result = visitor.format(tree);
+
   return {
-    formattedString: result,
+    formattedString: visitor.format(tree),
     newCursorPos: visitor.cursorPos + relativePosition,
   };
 }

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -364,7 +364,7 @@ interface FormattingResultWithCursor {
 
 export function formatQuery(query: string): string;
 export function formatQuery(
-  query: string,
+  quer: string,
   cursorPosition: number,
 ): FormattingResultWithCursor;
 export function formatQuery(

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1,14 +1,6 @@
+import { CommonTokenStream, ParserRuleContext, TerminalNode } from 'antlr4';
+import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import {
-  CharStreams,
-  CommonTokenStream,
-  ParserRuleContext,
-  TerminalNode,
-} from 'antlr4';
-import {
-  default as CypherCmdLexer,
-  default as CypherLexer,
-} from '../generated-parser/CypherCmdLexer';
-import CypherCmdParser, {
   ArrowLineContext,
   BooleanLiteralContext,
   ClauseContext,
@@ -31,6 +23,8 @@ import CypherCmdParser, {
 import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
 import {
   findTargetToken,
+  getParseTreeAndTokens,
+  handleMergeClause,
   isComment,
   wantsSpaceAfter,
   wantsSpaceBefore,
@@ -326,23 +320,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   // Handled separately because we want ON CREATE before ON MATCH
   visitMergeClause = (ctx: MergeClauseContext) => {
-    this.visit(ctx.MERGE());
-    this.visit(ctx.pattern());
-    const mergeActions = ctx
-      .mergeAction_list()
-      .map((action, index) => ({ action, index }))
-      .sort((a, b) => {
-        if (a.action.CREATE() && b.action.MATCH()) {
-          return -1;
-        } else if (a.action.MATCH() && b.action.CREATE()) {
-          return 1;
-        }
-        return a.index - b.index;
-      })
-      .map(({ action }) => action);
-    mergeActions.forEach((action) => {
-      this.visit(action);
-    });
+    handleMergeClause(ctx, (node) => this.visit(node));
   };
 
   // Handled separately because it wants indentation
@@ -393,13 +371,9 @@ export function formatQuery(
   query: string,
   cursorPosition?: number,
 ): string | FormattingResultWithCursor {
-  const inputStream = CharStreams.fromString(query);
-  const lexer = new CypherLexer(inputStream);
-  const tokens = new CommonTokenStream(lexer);
+  const { tree, tokens } = getParseTreeAndTokens(query);
   tokens.fill();
-  const parser = new CypherCmdParser(tokens);
-  parser.buildParseTrees = true;
-  const tree = parser.statementsOrCommands();
+
   const visitor = new TreePrintVisitor(tokens);
 
   if (cursorPosition === undefined) return visitor.format(tree);

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -364,7 +364,7 @@ interface FormattingResultWithCursor {
 
 export function formatQuery(query: string): string;
 export function formatQuery(
-  quer: string,
+  query: string,
   cursorPosition: number,
 ): FormattingResultWithCursor;
 export function formatQuery(

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -53,14 +53,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     super();
   }
 
-  getTargetToken = (): number => {
-    return this.targetToken;
-  };
-
-  setTargetToken = (targetToken: number): void => {
-    this.targetToken = targetToken;
-  };
-
   format = (root: StatementsOrCommandsContext) => {
     this.visit(root);
     return this.buffer.join('').trim();
@@ -402,7 +394,6 @@ export function formatQuery(
   query: string,
   cursorPosition?: number,
 ): string | FormattingResultWithCursor {
-
   const inputStream = CharStreams.fromString(query);
   const lexer = new CypherLexer(inputStream);
   const tokens = new CommonTokenStream(lexer);
@@ -424,10 +415,10 @@ export function formatQuery(
     };
   }
 
-  const targetToken = findTargetToken(tokens.tokens, cursorPosition)
-  
+  const targetToken = findTargetToken(tokens.tokens, cursorPosition);
+
   const relativePosition = cursorPosition - targetToken.start;
-  visitor.setTargetToken(targetToken.tokenIndex);
+  visitor.targetToken = targetToken.tokenIndex;
   const result = visitor.format(tree);
   return {
     formattedString: result,

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -14,10 +14,12 @@ import {
   MergeClauseContext,
   NodePatternContext,
   NumberLiteralContext,
+  ParameterContext,
   PropertyContext,
   RelationshipPatternContext,
   RightArrowContext,
   StatementsOrCommandsContext,
+  SubqueryClauseContext,
   WhereClauseContext,
 } from '../generated-parser/CypherCmdParser';
 import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
@@ -236,6 +238,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.addCommentsAfter(node);
   };
 
+  // Handled separately because the dollar should not be treated
+  // as an operator
+  visitParameter = (ctx: ParameterContext) => {
+    this.visitTerminalRaw(ctx.DOLLAR());
+    this.visit(ctx.parameterName());
+  };
+
   // Literals have casing rules, see
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-casing
   visitBooleanLiteral = (ctx: BooleanLiteralContext) => {
@@ -316,6 +325,23 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.addSpace();
     }
     this.visit(ctx.RCURLY());
+  };
+
+  // Handled separately because it wants indentation and line breaks
+  visitSubqueryClause = (ctx: SubqueryClauseContext) => {
+    this.visitIfNotNull(ctx.OPTIONAL());
+    this.visit(ctx.CALL());
+    this.visitIfNotNull(ctx.subqueryScope());
+    this.addSpace();
+    this.visit(ctx.LCURLY());
+    this.addIndentation();
+    this.breakLine();
+    this.visit(ctx.regularQuery());
+    this.breakLine();
+    this.removeIndentation();
+    this.visit(ctx.RCURLY());
+    this.breakLine();
+    this.visitIfNotNull(ctx.subqueryInTransactionsParameters());
   };
 
   // Handled separately because we want ON CREATE before ON MATCH

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -378,7 +378,7 @@ export function formatQuery(
 
   if (cursorPosition === undefined) return visitor.format(tree);
 
-  if (cursorPosition >= query.length || cursorPosition === 0) {
+  if (cursorPosition >= query.length || cursorPosition <= 0) {
     const result = visitor.format(tree);
     return {
       formattedString: result,
@@ -387,6 +387,12 @@ export function formatQuery(
   }
 
   const targetToken = findTargetToken(tokens.tokens, cursorPosition);
+  if (!targetToken) {
+    return {
+      formattedString: visitor.format(tree),
+      newCursorPos: 0,
+    };
+  }
   const relativePosition = cursorPosition - targetToken.start;
   visitor.targetToken = targetToken.tokenIndex;
 

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -41,3 +41,16 @@ function isSymbolicName(node: TerminalNode): boolean {
     node.parentCtx instanceof EscapedSymbolicNameStringContext
   );
 }
+
+export function findTargetToken(tokens: Token[], cursorPosition: number) {
+  let targetToken = tokens[0]
+  for (const token of tokens) {
+    if (token.channel === 0) {
+      targetToken = token;
+    }
+    if (cursorPosition >= token.start && cursorPosition <= token.stop) {
+      break;
+    }
+  }
+  return targetToken
+}

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -80,15 +80,18 @@ export function getParseTreeAndTokens(query: string) {
   return { tree, tokens };
 }
 
-export function findTargetToken(tokens: Token[], cursorPosition: number) {
+export function findTargetToken(
+  tokens: Token[],
+  cursorPosition: number,
+): Token | false {
   let targetToken: Token;
   for (const token of tokens) {
     if (token.channel === 0) {
       targetToken = token;
     }
     if (cursorPosition >= token.start && cursorPosition <= token.stop) {
-      break;
+      return targetToken;
     }
   }
-  return targetToken
+  return false;
 }

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -81,7 +81,7 @@ export function getParseTreeAndTokens(query: string) {
 }
 
 export function findTargetToken(tokens: Token[], cursorPosition: number) {
-  let targetToken = tokens[0]
+  let targetToken: Token;
   for (const token of tokens) {
     if (token.channel === 0) {
       targetToken = token;

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -1,10 +1,39 @@
-import { TerminalNode, Token } from 'antlr4';
-import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import {
+  CharStreams,
+  CommonTokenStream,
+  ParseTree,
+  TerminalNode,
+  Token,
+} from 'antlr4';
+import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
+import CypherCmdParser, {
   EscapedSymbolicNameStringContext,
+  MergeClauseContext,
   UnescapedSymbolicNameString_Context,
 } from '../generated-parser/CypherCmdParser';
 import { lexerKeywords, lexerOperators } from '../lexerSymbols';
+
+export function handleMergeClause(
+  ctx: MergeClauseContext,
+  visit: (node: ParseTree) => void,
+) {
+  visit(ctx.MERGE());
+  visit(ctx.pattern());
+  const mergeActions = ctx
+    .mergeAction_list()
+    .map((action, index) => ({ action, index }));
+  mergeActions.sort((a, b) => {
+    if (a.action.CREATE() && b.action.MATCH()) {
+      return -1;
+    } else if (a.action.MATCH() && b.action.CREATE()) {
+      return 1;
+    }
+    return a.index - b.index;
+  });
+  mergeActions.forEach(({ action }) => {
+    visit(action);
+  });
+}
 
 export function wantsToBeUpperCase(node: TerminalNode): boolean {
   return isKeywordTerminal(node);
@@ -40,6 +69,15 @@ function isSymbolicName(node: TerminalNode): boolean {
     node.parentCtx instanceof UnescapedSymbolicNameString_Context ||
     node.parentCtx instanceof EscapedSymbolicNameStringContext
   );
+}
+export function getParseTreeAndTokens(query: string) {
+  const inputStream = CharStreams.fromString(query);
+  const lexer = new CypherCmdLexer(inputStream);
+  const tokens = new CommonTokenStream(lexer);
+  const parser = new CypherCmdParser(tokens);
+  parser.buildParseTrees = true;
+  const tree = parser.statementsOrCommands();
+  return { tree, tokens };
 }
 
 export function findTargetToken(tokens: Token[], cursorPosition: number) {

--- a/packages/language-support/src/formatting/standardizer.ts
+++ b/packages/language-support/src/formatting/standardizer.ts
@@ -1,0 +1,31 @@
+import { TerminalNode } from 'antlr4';
+import {
+  MergeClauseContext,
+  StatementsOrCommandsContext,
+} from '../generated-parser/CypherCmdParser';
+import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
+import { getParseTreeAndTokens, handleMergeClause } from './formattingHelpers';
+
+class StandardizingVisitor extends CypherCmdParserVisitor<void> {
+  buffer = [];
+
+  format = (root: StatementsOrCommandsContext) => {
+    this.visit(root);
+    return this.buffer.join('');
+  };
+
+  visitMergeClause = (ctx: MergeClauseContext) => {
+    handleMergeClause(ctx, (node) => this.visit(node));
+  };
+
+  visitTerminal = (node: TerminalNode) => {
+    this.buffer.push(node.getText().toLowerCase());
+    this.buffer.push(' ');
+  };
+}
+
+export function standardizeQuery(query: string): string {
+  const { tree } = getParseTreeAndTokens(query);
+  const visitor = new StandardizingVisitor();
+  return visitor.format(tree);
+}

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -21,3 +21,4 @@ export type { CompletionItem, Neo4jFunction, Neo4jProcedure } from './types';
 export { CypherLexer, CypherParser };
 import CypherLexer from './generated-parser/CypherCmdLexer';
 import CypherParser from './generated-parser/CypherCmdParser';
+export { formatQuery } from './formatting/formatting'

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -71,6 +71,33 @@ RETURN length(p)`;
 RETURN map`;
     verifyFormatting(query, expected);
   });
+
+  test('no padding space within function call parentheses', () => {
+    const query = `RETURN split( 'original', 'i' )`;
+    const expected = `RETURN split('original', 'i')`;
+    verifyFormatting(query, expected);
+  });
+
+  test('should format call subqueries', () => {
+    const query = `UNWIND range(1,100) as _ CALL { MATCH (source:object)
+  MATCH (target:object) RETURN source, target } RETURN count('*')`;
+    const expected = `UNWIND range(1, 100) AS _
+CALL {
+  MATCH (source:object)
+  MATCH (target:object)
+  RETURN source, target
+}
+RETURN count('*')`;
+    verifyFormatting(query, expected);
+  });
+
+  test('should format call subqueries with ()', () => {
+    const query = `CALL () { RETURN 'hello' AS innerReturn }`;
+    const expected = `CALL () {
+  RETURN 'hello' AS innerReturn
+}`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {
@@ -226,6 +253,15 @@ RETURN emptyList`;
     const expected = 'RETURN -1, -2, -3';
     verifyFormatting(query, expected);
   });
+
+  test('parameter casing example', () => {
+    const query = `CREATE (N:Label {Prop: 0}) WITH N, RAND()
+AS Rand, $pArAm AS MAP RETURN Rand, MAP.property_key, count(N)`;
+    const expected = `CREATE (N:Label {Prop: 0})
+WITH N, RAND() AS Rand, $pArAm AS MAP
+RETURN Rand, MAP.property_key, count(N)`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('various edgecases', () => {
@@ -233,6 +269,12 @@ describe('various edgecases', () => {
     const multiquery = 'RETURN 1; RETURN 2; RETURN 3;';
     const expectedMultiquery = 'RETURN 1;\nRETURN 2;\nRETURN 3;';
     verifyFormatting(multiquery, expectedMultiquery);
+  });
+
+  test('should not add space for parameter access', () => {
+    const query = 'RETURN $param';
+    const expected = 'RETURN $param';
+    verifyFormatting(query, expected);
   });
 });
 

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -1,4 +1,17 @@
-import { formatQuery } from '../formatting/../../formatting/formatting';
+import { formatQuery } from '../../formatting/formatting';
+import { standardizeQuery } from '../../formatting/standardizer';
+
+function verifyFormatting(query: string, expected: string): void {
+  const formatted = formatQuery(query);
+  expect(formatted).toEqual(expected);
+  const queryStandardized = standardizeQuery(query);
+  const formattedStandardized = standardizeQuery(formatted);
+  if (formattedStandardized !== queryStandardized) {
+    throw new Error(
+      `Standardized query does not match standardized formatted query`,
+    );
+  }
+}
 
 describe('styleguide examples', () => {
   test('on match indentation example', () => {
@@ -13,7 +26,7 @@ MERGE (a:A)-[:T]->(b:B)
   ON CREATE SET a.name = 'me'
   ON MATCH SET b.name = 'you'
 RETURN a.prop`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('on where exists regular subquery', () => {
@@ -25,7 +38,7 @@ WHERE EXISTS {
   WHERE b.prop = 'yellow'
 }
 RETURN a.foo`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('on where exists regular simplified subquery', () => {
@@ -38,7 +51,7 @@ RETURN a.prop`;
     const expected = `MATCH (a:A)
 WHERE EXISTS { (a)-->(b:B) }
 RETURN a.prop`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('Using wrapper space around operators', () => {
@@ -49,14 +62,14 @@ RETURN length(p)`;
     const expected = `MATCH p = (s)-->(e)
 WHERE s.name <> e.name
 RETURN length(p)`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('formats maps properly', () => {
     const query = `WITH { key1 :'value' ,key2  :  42 } AS map RETURN map`;
     const expected = `WITH {key1: 'value', key2: 42} AS map
 RETURN map`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -68,7 +81,7 @@ prop`;
     const expected = `MATCH (n)
 RETURN n. // comment
 prop`;
-    expect(formatQuery(propertycomments)).toEqual(expected);
+    verifyFormatting(propertycomments, expected);
   });
 
   test('basic inline comments', () => {
@@ -86,7 +99,7 @@ MERGE (a:A)-[:T]->(b:B) // Create or match a relationship from 'a:A' to 'b:B'
   ON CREATE SET a.name = 'me' // If 'a' is created, set its 'name' to 'me'
   ON MATCH SET b.name = 'you' // If 'b' already exists, set its 'name' to 'you'
 RETURN a.prop // Return the 'prop' of 'a'`;
-    expect(formatQuery(inlinecomments)).toEqual(expected);
+    verifyFormatting(inlinecomments, expected);
   });
 
   test('comments before the query', () => {
@@ -95,7 +108,7 @@ MATCH (n) return n`;
     const expected = `// This is a comment before everything
 MATCH (n)
 RETURN n`;
-    expect(formatQuery(inlinecommentbefore)).toEqual(expected);
+    verifyFormatting(inlinecommentbefore, expected);
 
     const multilinecommentbefore = `/* This is a comment before everything
 And it spans multiple lines */
@@ -104,7 +117,7 @@ MATCH (n) return n`;
 And it spans multiple lines */
 MATCH (n)
 RETURN n`;
-    expect(formatQuery(multilinecommentbefore)).toEqual(expected2);
+    verifyFormatting(multilinecommentbefore, expected2);
   });
 
   test('weird inline comments', () => {
@@ -119,7 +132,7 @@ RETURN a.prop /* Return the property of 'a' */
 MERGE (a:A) /* Create or match 'a:A' */
 -[:T]->(b:B) /* Link 'a' to 'b' */
 RETURN a.prop /* Return the property of 'a' */`;
-    expect(formatQuery(inlinemultiline)).toEqual(expected);
+    verifyFormatting(inlinemultiline, expected);
   });
 
   test('weird inline and multiline comments', () => {
@@ -139,7 +152,7 @@ MERGE (a:A)-[:T]->(b:B)
   ON CREATE SET a.name = 'me' // Name set during creation
   ON MATCH SET b.name = 'you' /* Update name if matched */
 RETURN a.prop // Output the result`;
-    expect(formatQuery(inlineandmultiline)).toEqual(expected);
+    verifyFormatting(inlineandmultiline, expected);
   });
 });
 
@@ -147,7 +160,7 @@ describe('other styleguide recommendations', () => {
   test('order by', () => {
     const query = `RETURN user.id ORDER BY potential_reach, like_count;`;
     const expected = `RETURN user.id ORDER BY potential_reach, like_count;`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('escaped names', () => {
@@ -155,40 +168,40 @@ describe('other styleguide recommendations', () => {
       'CREATE (`complex name with special@chars`) RETURN `complex name with special@chars`';
     const expected =
       'CREATE (`complex name with special@chars`)\nRETURN `complex name with special@chars`';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('cases null and booleans properly', () => {
     const query = `WITH NULL as n1, Null as n2, False as f1, True as t1 RETURN NULL, TRUE, FALSE`;
     const expected = `WITH null AS n1, null AS n2, false AS f1, true AS t1
 RETURN null, true, false`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('can handle using keyword literal names in weird ways', () => {
     const query1 = 'MATCH (NULL) RETURN NULL';
     const expected1 = 'MATCH (NULL)\nRETURN null';
-    expect(formatQuery(query1)).toEqual(expected1);
+    verifyFormatting(query1, expected1);
 
     const query2 = 'MATCH (NAN) RETURN NAN';
     const expected2 = 'MATCH (NAN)\nRETURN NAN';
-    expect(formatQuery(query2)).toEqual(expected2);
+    verifyFormatting(query2, expected2);
 
     const query3 = 'MATCH (INF) RETURN INF';
     const expected3 = 'MATCH (INF)\nRETURN INF';
-    expect(formatQuery(query3)).toEqual(expected3);
+    verifyFormatting(query3, expected3);
   });
 
   test('puts one space between label/type predicates and property predicates in patterns', () => {
     const query = `MATCH (p:Person{property:-1})-[:KNOWS{since: 2016}]->() RETURN p.name`;
     const expected = `MATCH (p:Person {property: -1})-[:KNOWS {since: 2016}]->()\nRETURN p.name`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('no space in patterns', () => {
     const query = 'MATCH (:Person) --> (:Vehicle) RETURN count(*)';
     const expected = 'MATCH (:Person)-->(:Vehicle)\nRETURN count(*)';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('space after each comma in lists and enumerations', () => {
@@ -198,20 +211,20 @@ RETURN list,2,3,4`;
     const expected = `MATCH (), ()
 WITH ['a', 'b', 3.14] AS list
 RETURN list, 2, 3, 4`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('handles empty list literals', () => {
     const query = `WITH [] AS emptyList RETURN emptyList`;
     const expected = `WITH [] AS emptyList
 RETURN emptyList`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('should not add space for negating minuses', () => {
     const query = 'RETURN -1, -2, -3';
     const expected = 'RETURN -1, -2, -3';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -219,6 +232,6 @@ describe('various edgecases', () => {
   test('multiple queries', () => {
     const multiquery = 'RETURN 1; RETURN 2; RETURN 3;';
     const expectedMultiquery = 'RETURN 1;\nRETURN 2;\nRETURN 3;';
-    expect(formatQuery(multiquery)).toEqual(expectedMultiquery);
+    verifyFormatting(multiquery, expectedMultiquery);
   });
 });

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -310,7 +310,7 @@ CALL {
 } 
 RETURN count(*)`;
     const result = formatQuery(query, 124);
-    expect(result.newCursorPos).toEqual(125);
+    expect(result.newCursorPos).toEqual(131);
   });
 
   test('cursor start of line without spaces', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -235,3 +235,50 @@ describe('various edgecases', () => {
     verifyFormatting(multiquery, expectedMultiquery);
   });
 });
+
+describe('tests for correct cursor position', () => {
+  test('cursor at beginning', () => {
+    const query = 'RETURN -1, -2, -3';
+    const result = formatQuery(query, 0);
+    expect(result.newCursorPos).toEqual(0);
+  });
+  test('cursor at end', () => {
+    const query = 'RETURN -1, -2, -3';
+    const result = formatQuery(query, query.length - 1);
+    expect(result.newCursorPos).toEqual(result.formattedString.length - 1);
+  });
+  test('cursor at newline', () => {
+    const query = `MATCH (n:Person)
+WHERE n.name = "Steve" 
+RETURN n 
+LIMIT 12;`;
+    const result = formatQuery(query, 56);
+    expect(result.newCursorPos).toEqual(54);
+  });
+
+  test('cursor start of line with spaces newline', () => {
+    const query = `UNWIND range(1,100) as _
+CALL {
+  MATCH (source:object) WHERE source.id= $id1
+  MATCH (target:object) WHERE target.id= $id2
+  MATCH path = (source)-[*1..10]->(target)
+  WITH path, reduce(weight = 0, r IN relationships(path) | weight + r.weight) as Weight
+  ORDER BY Weight LIMIT 3
+  RETURN length(path) as l, Weight 
+} 
+RETURN count(*)`;
+    const result = formatQuery(query, 124);
+    expect(result.newCursorPos).toEqual(125);
+  });
+
+  test('cursor start of line without spaces', () => {
+    const query = `MATCH (variable :Label)-[:REL_TYPE]->() 
+WHERE variable.property = "String" 
+    OR namespaced.function() = false
+    // comment
+    OR $parameter > 2 
+RETURN variable;`;
+    const result = formatQuery(query, 133);
+    expect(result.newCursorPos).toEqual(120);
+  });
+});

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -1,6 +1,6 @@
 import { DbSchema, testData } from '@neo4j-cypher/language-support';
 import { CypherEditor } from '@neo4j-cypher/react-codemirror';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Tree } from 'react-d3-tree';
 import { TokenTable } from './TokenTable';
 import { getDebugTree } from './treeUtil';
@@ -32,6 +32,7 @@ RETURN count(*)`,
 type DemoName = keyof typeof demos;
 
 export function App() {
+  const formatFlag = false;
   const [selectedDemoName, setSelectedDemoName] = useState<DemoName>('basic');
   const [value, setValue] = useState<string>(demos[selectedDemoName]);
   const [showCodemirrorParse, setShowCodemirrorParse] = useState(false);
@@ -45,6 +46,8 @@ export function App() {
     JSON.stringify(testData.mockSchema, undefined, 2),
   );
   const [schemaError, setSchemaError] = useState<string | null>(null);
+
+  const editorRef = useRef<CypherEditor>(null);
 
   const treeData = useMemo(() => {
     return getDebugTree(value);
@@ -103,6 +106,7 @@ export function App() {
             <CypherEditor
               className="border-2 border-gray-100 dark:border-gray-400 text-sm"
               value={value}
+              ref={editorRef}
               onChange={setValue}
               prompt="neo4j$"
               onExecute={() => {
@@ -112,10 +116,20 @@ export function App() {
               theme={darkMode ? 'dark' : 'light'}
               history={Object.values(demos)}
               schema={schema}
-              featureFlags={{ signatureInfoOnAutoCompletions: true }}
+              featureFlags={{
+                signatureInfoOnAutoCompletions: true,
+                format: formatFlag,
+              }}
               ariaLabel="Cypher Editor"
             />
-
+            {formatFlag && 
+            <p
+              onClick={() => editorRef.current.format()}
+              className="text-blue-500 cursor-pointer hover:text-blue-700"
+            >
+              Format Query
+            </p>
+            }
             {commandRanCount > 0 && (
               <span className="text-gray-400">
                 "commands" ran so far: {commandRanCount}

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -117,7 +117,6 @@ export function App() {
               schema={schema}
               featureFlags={{
                 signatureInfoOnAutoCompletions: true,
-                format: true,
               }}
               ariaLabel="Cypher Editor"
             />

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -32,7 +32,6 @@ RETURN count(*)`,
 type DemoName = keyof typeof demos;
 
 export function App() {
-  const formatFlag = false;
   const [selectedDemoName, setSelectedDemoName] = useState<DemoName>('basic');
   const [value, setValue] = useState<string>(demos[selectedDemoName]);
   const [showCodemirrorParse, setShowCodemirrorParse] = useState(false);
@@ -118,18 +117,16 @@ export function App() {
               schema={schema}
               featureFlags={{
                 signatureInfoOnAutoCompletions: true,
-                format: formatFlag,
+                format: true,
               }}
               ariaLabel="Cypher Editor"
             />
-            {formatFlag && 
             <p
               onClick={() => editorRef.current.format()}
               className="text-blue-500 cursor-pointer hover:text-blue-700"
             >
               Format Query
             </p>
-            }
             {commandRanCount > 0 && (
               <span className="text-gray-400">
                 "commands" ran so far: {commandRanCount}

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -124,6 +124,7 @@ export function App() {
             <p
               onClick={() => editorRef.current.format()}
               className="text-blue-500 cursor-pointer hover:text-blue-700"
+              title={window.navigator.userAgent.includes("Mac") ? "Shift-Option-F" : "Ctrl-Shift-I"}
             >
               Format Query
             </p>

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -277,7 +277,7 @@ export class CypherEditor extends Component<
   private schemaRef: React.MutableRefObject<CypherConfig> = createRef();
 
   /**
-   * Format query code
+   * Format Cypher query
    */
   format() {
     if (this.props.featureFlags.format) {

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -100,7 +100,6 @@ export interface CypherEditorProps {
   featureFlags?: {
     consoleCommands?: boolean;
     signatureInfoOnAutoCompletions?: boolean;
-    format?: boolean;
   };
   /**
    * The schema to use for autocompletion and linting.
@@ -280,22 +279,20 @@ export class CypherEditor extends Component<
    * Format Cypher query
    */
   format() {
-    if (this.props.featureFlags.format) {
-      const currentView = this.editorView.current;
-      const doc = currentView.state.doc.toString();
-      const { formattedString, newCursorPos } = formatQuery(
-        doc,
-        currentView.state.selection.main.anchor,
-      );
-      currentView.dispatch({
-        changes: {
-          from: 0,
-          to: doc.length,
-          insert: formattedString,
-        },
-        selection: { anchor: newCursorPos },
-      });
-    }
+    const currentView = this.editorView.current;
+    const doc = currentView.state.doc.toString();
+    const { formattedString, newCursorPos } = formatQuery(
+      doc,
+      currentView.state.selection.main.anchor,
+    );
+    currentView.dispatch({
+      changes: {
+        from: 0,
+        to: doc.length,
+        insert: formattedString,
+      },
+      selection: { anchor: newCursorPos },
+    });
   }
 
   /**
@@ -404,17 +401,15 @@ export class CypherEditor extends Component<
           }),
         ]
       : [];
-    if (this.props.featureFlags && this.props.featureFlags.format) {
-      extraKeybindings.push({
-        key: 'Ctrl-Shift-f',
-        mac: 'Alt-Shift-f',
-        preventDefault: true,
-        run: () => {
-          this.format()
-          return true;
-        },
-      })
-    }
+    extraKeybindings.push({
+      key: 'Ctrl-Shift-f',
+      mac: 'Alt-Shift-f',
+      preventDefault: true,
+      run: () => {
+        this.format();
+        return true;
+      },
+    });
 
     this.editorState.current = EditorState.create({
       extensions: [

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -374,7 +374,6 @@ export class CypherEditor extends Component<
       showSignatureTooltipBelow,
       featureFlags: {
         consoleCommands: true,
-        format: true,
         ...featureFlags,
       },
       useLightVersion: false,


### PR DESCRIPTION
# Description

This pull request has the intent to connect the formatter with the Query Editor part of the repo. The Query Editor imports the formatter and then exposes the formatting functionality by a function but also allows the formatter to be ran by key-binding. The package react-codemirror-playground adds a button (see picture) which also runs the formatter. 

The functionality of the formatter is hidden behind a feature flag in react-codemirror-playground/src/App.tsx. Change the constant formatFlag to true in order to test. 

## Testing
Tested by running `npm run test` in root directory. All tests passed. 

![Skärmavbild 2025-01-28 kl  16 37 12](https://github.com/user-attachments/assets/9d5727d8-ff07-4b0b-9258-41505dbd6e19)
