### PR TITLE
Adds subquery and parameter handling to formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -22,6 +22,7 @@ import CypherCmdParser, {
   MergeClauseContext,
   NodePatternContext,
   NumberLiteralContext,
+  ParameterContext,
   PropertyContext,
   RelationshipPatternContext,
   RightArrowContext,
@@ -230,6 +231,12 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.buffer.push(result);
     this.addCommentsAfter(node);
+  };
+
+  // Handled separately because the dollar should not
+  visitParameter = (ctx: ParameterContext) => {
+    this.visitTerminalRaw(ctx.DOLLAR());
+    this.visit(ctx.parameterName());
   };
 
   // Literals have casing rules, see

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -26,6 +26,7 @@ import CypherCmdParser, {
   RelationshipPatternContext,
   RightArrowContext,
   StatementsOrCommandsContext,
+  SubqueryClauseContext,
   WhereClauseContext,
 } from '../generated-parser/CypherCmdParser';
 import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
@@ -311,6 +312,22 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.addSpace();
     }
     this.visit(ctx.RCURLY());
+  };
+
+  visitSubqueryClause = (ctx: SubqueryClauseContext) => {
+    this.visitIfNotNull(ctx.OPTIONAL());
+    this.visit(ctx.CALL());
+    this.visitIfNotNull(ctx.subqueryScope());
+    this.addSpace();
+    this.visit(ctx.LCURLY());
+    this.addIndentation();
+    this.breakLine();
+    this.visit(ctx.regularQuery());
+    this.breakLine();
+    this.removeIndentation();
+    this.visit(ctx.RCURLY());
+    this.breakLine();
+    this.visitIfNotNull(ctx.subqueryInTransactionsParameters());
   };
 
   // Handled separately because we want ON CREATE before ON MATCH

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -233,7 +233,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.addCommentsAfter(node);
   };
 
-  // Handled separately because the dollar should not
+  // Handled separately because the dollar should not be treated
+  // as an operator
   visitParameter = (ctx: ParameterContext) => {
     this.visitTerminalRaw(ctx.DOLLAR());
     this.visit(ctx.parameterName());

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -322,6 +322,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.RCURLY());
   };
 
+  // Handled separately because it wants indentation and line breaks
   visitSubqueryClause = (ctx: SubqueryClauseContext) => {
     this.visitIfNotNull(ctx.OPTIONAL());
     this.visit(ctx.CALL());

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -240,6 +240,15 @@ RETURN emptyList`;
     const expected = 'RETURN -1, -2, -3';
     expect(formatQuery(query)).toEqual(expected);
   });
+
+  test('param example', () => {
+    const query = `CREATE (N:Label {Prop: 0}) WITH N, RAND()
+AS Rand, $pArAm AS MAP RETURN Rand, MAP.property_key, count(N)`;
+    const expected = `CREATE (N:Label {Prop: 0})
+WITH N, RAND() AS Rand, $pArAm AS MAP
+RETURN Rand, MAP.property_key, count(N)`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
 });
 
 describe('various edgecases', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -64,6 +64,19 @@ RETURN map`;
     const expected = `RETURN split('original', 'i')`;
     expect(formatQuery(query)).toEqual(expected);
   });
+
+  test('should format call subqueries', () => {
+    const query = `UNWIND range(1,100) as _ CALL { MATCH (source:object)
+  MATCH (target:object) RETURN source, target } RETURN count('*')`;
+    const expected = `UNWIND range(1, 100) AS _
+CALL {
+  MATCH (source:object)
+  MATCH (target:object)
+  RETURN source, target
+}
+RETURN count('*')`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -75,7 +75,7 @@ RETURN map`;
   test('no padding space within function call parentheses', () => {
     const query = `RETURN split( 'original', 'i' )`;
     const expected = `RETURN split('original', 'i')`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('should format call subqueries', () => {
@@ -88,7 +88,7 @@ CALL {
   RETURN source, target
 }
 RETURN count('*')`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 
   test('should format call subqueries with ()', () => {
@@ -96,7 +96,7 @@ RETURN count('*')`;
     const expected = `CALL () {
   RETURN 'hello' AS innerReturn
 }`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -260,7 +260,7 @@ AS Rand, $pArAm AS MAP RETURN Rand, MAP.property_key, count(N)`;
     const expected = `CREATE (N:Label {Prop: 0})
 WITH N, RAND() AS Rand, $pArAm AS MAP
 RETURN Rand, MAP.property_key, count(N)`;
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });
 
@@ -274,6 +274,6 @@ describe('various edgecases', () => {
   test('should not add space for parameter access', () => {
     const query = 'RETURN $param';
     const expected = 'RETURN $param';
-    expect(formatQuery(query)).toEqual(expected);
+    verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -254,7 +254,7 @@ RETURN emptyList`;
     verifyFormatting(query, expected);
   });
 
-  test('param example', () => {
+  test('parameter casing example', () => {
     const query = `CREATE (N:Label {Prop: 0}) WITH N, RAND()
 AS Rand, $pArAm AS MAP RETURN Rand, MAP.property_key, count(N)`;
     const expected = `CREATE (N:Label {Prop: 0})

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -58,6 +58,12 @@ RETURN length(p)`;
 RETURN map`;
     expect(formatQuery(query)).toEqual(expected);
   });
+
+  test('no padding space within function call parentheses', () => {
+    const query = `RETURN split( 'original', 'i' )`;
+    const expected = `RETURN split('original', 'i')`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -257,4 +257,10 @@ describe('various edgecases', () => {
     const expectedMultiquery = 'RETURN 1;\nRETURN 2;\nRETURN 3;';
     expect(formatQuery(multiquery)).toEqual(expectedMultiquery);
   });
+
+  test('should not add space for parameter access', () => {
+    const query = 'RETURN $param';
+    const expected = 'RETURN $param';
+    expect(formatQuery(query)).toEqual(expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -77,6 +77,14 @@ CALL {
 RETURN count('*')`;
     expect(formatQuery(query)).toEqual(expected);
   });
+
+  test('should format call subqueries with ()', () => {
+    const query = `CALL () { RETURN 'hello' AS innerReturn }`;
+    const expected = `CALL () {
+  RETURN 'hello' AS innerReturn
+}`;
+    expect(formatQuery(query)).toEqual(expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {


### PR DESCRIPTION
### Description
Adds two things missing from the styleguide recommendations:
1. (bugfix) - no space between dollar sign and parameter name
2. Subquery clauses shuold get indentation like the exists clauses, e.g. this query

```
CALL () { RETURN 'hello' AS innerReturn }
```
should be formatted into

```
CALL () {
  RETURN 'hello' AS innerReturn
}
```

I've also added a couple of examples from the styleguide into the tests, such as the "no padding space within function call parentheses" one.

### Testing
- npm run test 
- unit tests included in this PR for the new features
