### PR TITLE
Fixes GH actions deploy of codemirror playground

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -3,7 +3,7 @@ name: Deploy Codemirror Demo to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'fix-codemirror-playground']
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -3,7 +3,7 @@ name: Deploy Codemirror Demo to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main']
+    branches: ['main', 'fix-codemirror-playground']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/packages/react-codemirror-playground/vite.config.ts
+++ b/packages/react-codemirror-playground/vite.config.ts
@@ -3,5 +3,5 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
-  base: './cypher-language-support',
+  base: './',
 });


### PR DESCRIPTION
Reverts https://github.com/neo4j/cypher-language-support/pull/315 because GitHub does not seem to be able to properly deploy it to GitHub Pages:

<img width="1174"  src="https://github.com/user-attachments/assets/215d8a3e-433a-4386-8c73-b4f1563f2115" />

It's better to live with us not being able to use the codemirror playground in Firefox locally than with a globally broken GitHub deploy.

I deployed the branch temporarily to https://neo4j.github.io/cypher-language-support in this commit [35fc692](https://github.com/neo4j/cypher-language-support/pull/337/commits/35fc692cb989f51034997440ba0f61f806c34923) to check that the fix works