### PR TITLE
Adds property checks to formatter

### DIFF
--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -6,11 +6,15 @@ function verifyFormatting(query: string, expected: string): void {
   expect(formatted).toEqual(expected);
   const queryStandardized = standardizeQuery(query);
   const formattedStandardized = standardizeQuery(formatted);
+  // AST integrity check
   if (formattedStandardized !== queryStandardized) {
     throw new Error(
       `Standardized query does not match standardized formatted query`,
     );
   }
+  // Idempotency check
+  const formattedTwice = formatQuery(formatted);
+  expect(formattedTwice).toEqual(formatted);
 }
 
 describe('styleguide examples', () => {
@@ -371,6 +375,13 @@ describe('various edgecases', () => {
     const query = 'RETURN $param';
     const expected = 'RETURN $param';
     verifyFormatting(query, expected);
+  });
+
+  test('syntax error', () => {
+    const query = 'MATCH (n) RETRUN n.prop,';
+    expect(() => formatQuery(query)).toThrowError(
+      `Could not format due to syntax error at line 1:10 near "RETRUN"`,
+    );
   });
 
   test('apoc call, namespaced function', () => {

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -181,7 +181,8 @@ export interface CypherEditorProps {
 }
 
 const format = (view: EditorView): void => {
-  const doc = view.state.doc.toString();
+  try {
+    const doc = view.state.doc.toString();
     const { formattedString, newCursorPos } = formatQuery(
       doc,
       view.state.selection.main.anchor,
@@ -194,7 +195,10 @@ const format = (view: EditorView): void => {
       },
       selection: { anchor: newCursorPos },
     });
-}
+  } catch (error) {
+    // Formatting failed, likely because of a syntax error
+  }
+};
 
 const executeKeybinding = (
   onExecute?: (cmd: string) => void,


### PR DESCRIPTION
### Description

I was reading through the [scalafmt thesis](https://geirsson.com/assets/olafur.geirsson-scalafmt-thesis.pdf) and came across section 4.2 which outlined some property based testing they used during development. They describe these as having "played a vital role in the development of scalafmt and gave us confidence that the [formatting algorithms] behave well against real world input". The three checks they relied on were

1. Can-format: If the scala compiler can parse the code, the formatter should be able to format it
2. AST-integrity: the AST should stay identical after formatting
3. Idempotency: Formatting twice should give the same output

Given that scalafmt is hugely successful, I figured we want to follow their advice. I already added nr 2 in a previous PR, but this PR introduces an error handler to ensure that if the input cannot be parsed, it throws, and otherwise it should succeed. For 3, I added another check in to all tests that verify idempotency.

PS
Throwing when trying to format a syntax error might not be the best approach. I'm happy to amend that part.

### Testing
- npm run test
- 1 new unit test
- tried formatting a syntactically incorrect query in the codemirror playground and the error from the formatter was caught silently