### PR TITLE
moves format keybinding to playground

### DIFF
--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -46,6 +46,16 @@ export function App() {
   );
   const [schemaError, setSchemaError] = useState<string | null>(null);
 
+  const extraKeybindings = [{
+      key: 'Ctrl-Shift-f',
+      mac: 'Alt-Shift-f',
+      preventDefault: true,
+      run: () => {
+        editorRef.current.format()
+        return true;
+      },
+  }]
+
   const editorRef = useRef<CypherEditor>(null);
 
   const treeData = useMemo(() => {
@@ -115,6 +125,7 @@ export function App() {
               theme={darkMode ? 'dark' : 'light'}
               history={Object.values(demos)}
               schema={schema}
+              extraKeybindings={extraKeybindings}
               featureFlags={{
                 signatureInfoOnAutoCompletions: true,
               }}

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -210,15 +210,6 @@ const executeKeybinding = (
       key: 'Enter',
       run: insertNewline,
     },
-    Format: { 
-      key: 'Ctrl-Shift-f',
-      mac: 'Alt-Shift-f',
-      preventDefault: true,
-      run: (view: EditorView) => {
-        format(view)
-        return true;
-      },
-    }
   };
   if (onExecute) {
     keybindings['Ctrl-Enter'] = {


### PR DESCRIPTION
### Code Formatting Keybinding Refactor

- Removes hardcoded formatting keybindings from `react-codemirror` package
- Allows clients to configure their own custom formatting keybindings
- Implements formatting keybinding in playground using `extraKeyBindings` parameter

### Tests
Npm run test works, no tests added