### PR TITLE
Fixes bug with syntax highlighting of preparser options

### DIFF
--- a/.changeset/nervous-taxis-admire.md
+++ b/.changeset/nervous-taxis-admire.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Solves highlighting bug with multiline constructs embedded in the preparser

--- a/packages/language-support/src/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouring.ts
@@ -40,13 +40,13 @@ import { CypherTokenType } from '../lexerSymbols';
 import { parserWrapper } from '../parserWrapper';
 import {
   BracketType,
+  computeTokenKey,
   getCypherTokenType,
   getTokenPosition,
   ParsedCypherToken,
   removeOverlappingTokens,
   shouldAssignTokenType,
   sortTokens,
-  tokenPositionToString as computeTokenKey,
   toParsedTokens,
 } from './syntaxColouringHelpers';
 

--- a/packages/language-support/src/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouring.ts
@@ -46,7 +46,7 @@ import {
   removeOverlappingTokens,
   shouldAssignTokenType,
   sortTokens,
-  tokenPositionToString,
+  tokenPositionToString as computeTokenKey,
   toParsedTokens,
 } from './syntaxColouringHelpers';
 
@@ -107,7 +107,7 @@ class SyntaxHighlighter extends CypherParserListener {
 
       toParsedTokens(tokenPosition, tokenType, tokenStr, token).forEach(
         (token) => {
-          const tokenPos = tokenPositionToString(token.position);
+          const tokenPos = computeTokenKey(token.position, token.token.length);
           this.colouredTokens.set(tokenPos, token);
         },
       );
@@ -330,9 +330,8 @@ function colourLexerTokens(tokens: Token[]) {
         token,
         bracketsLevel,
       ).forEach((t) => {
-        const tokenPos = tokenPositionToString(t.position);
-
-        result.set(tokenPos, t);
+        const tokenKey = computeTokenKey(t.position, t.length);
+        result.set(tokenKey, t);
       });
     }
     ++i;

--- a/packages/language-support/src/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouring.ts
@@ -107,8 +107,8 @@ class SyntaxHighlighter extends CypherParserListener {
 
       toParsedTokens(tokenPosition, tokenType, tokenStr, token).forEach(
         (token) => {
-          const tokenPos = computeTokenKey(token.position, token.token.length);
-          this.colouredTokens.set(tokenPos, token);
+          const tokenKey = computeTokenKey(token.position, token.token.length);
+          this.colouredTokens.set(tokenKey, token);
         },
       );
     }

--- a/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
@@ -13,8 +13,11 @@ export interface TokenPosition {
   startOffset: number;
 }
 
-export function tokenPositionToString(tokenPosition: TokenPosition): string {
-  return `${tokenPosition.line},${tokenPosition.startCharacter}`;
+export function tokenPositionToString(
+  tokenPosition: TokenPosition,
+  tokenLength: number,
+): string {
+  return `${tokenPosition.line},${tokenPosition.startCharacter},${tokenLength}`;
 }
 
 export interface ParsedCypherToken {
@@ -191,14 +194,20 @@ export function sortTokens(tokens: ParsedCypherToken[]) {
     const lineDiff = a.position.line - b.position.line;
     if (lineDiff !== 0) return lineDiff;
 
-    return a.position.startCharacter - b.position.startCharacter;
+    const colDiff = a.position.startCharacter - b.position.startCharacter;
+    if (colDiff !== 0) return colDiff;
+    else return b.length - a.length;
   });
 }
 
 // Assumes the tokens are already sorted
 export function removeOverlappingTokens(tokens: ParsedCypherToken[]) {
   const result: ParsedCypherToken[] = [];
-  let prev: TokenPosition = { line: -1, startCharacter: -1, startOffset: -1 };
+  let prev: TokenPosition = {
+    line: -1,
+    startCharacter: -1,
+    startOffset: -1,
+  };
   let prevEndCharacter = 0;
 
   tokens.forEach((token) => {

--- a/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
@@ -13,7 +13,7 @@ export interface TokenPosition {
   startOffset: number;
 }
 
-export function tokenPositionToString(
+export function computeTokenKey(
   tokenPosition: TokenPosition,
   tokenLength: number,
 ): string {

--- a/packages/language-support/src/tests/syntaxColouring/preparser.test.ts
+++ b/packages/language-support/src/tests/syntaxColouring/preparser.test.ts
@@ -775,4 +775,303 @@ RETURN map.propertyKey`;
       },
     ]);
   });
+
+  test('Correctly colours preparser options including unfinished comments', () => {
+    const query = `CYPHER runtime = /*some unfinished comment
+    slotted`;
+    expect(applySyntaxColouring(query)).toEqual([
+      {
+        bracketInfo: undefined,
+        length: 6,
+        position: {
+          line: 0,
+          startCharacter: 0,
+          startOffset: 0,
+        },
+        token: 'CYPHER',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 7,
+        position: {
+          line: 0,
+          startCharacter: 7,
+          startOffset: 7,
+        },
+        token: 'runtime',
+        tokenType: 'setting',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 15,
+          startOffset: 15,
+        },
+        token: '=',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 25,
+        position: {
+          line: 0,
+          startCharacter: 17,
+          startOffset: 17,
+        },
+        token: '/*some unfinished comment',
+        tokenType: 'comment',
+      },
+      {
+        bracketInfo: undefined,
+        length: 11,
+        position: {
+          line: 1,
+          startCharacter: 0,
+          startOffset: 43,
+        },
+        token: '    slotted',
+        tokenType: 'comment',
+      },
+    ]);
+  });
+
+  test('Correctly colours preparser options including unfinished backticked elements', () => {
+    const query = `CYPHER runtime = \`some unfinished 
+    backticked element
+    `;
+    expect(applySyntaxColouring(query)).toEqual([
+      {
+        bracketInfo: undefined,
+        length: 6,
+        position: {
+          line: 0,
+          startCharacter: 0,
+          startOffset: 0,
+        },
+        token: 'CYPHER',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 7,
+        position: {
+          line: 0,
+          startCharacter: 7,
+          startOffset: 7,
+        },
+        token: 'runtime',
+        tokenType: 'setting',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 15,
+          startOffset: 15,
+        },
+        token: '=',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 17,
+        position: {
+          line: 0,
+          startCharacter: 17,
+          startOffset: 17,
+        },
+        token: '`some unfinished ',
+        tokenType: 'symbolicName',
+      },
+      {
+        bracketInfo: undefined,
+        length: 22,
+        position: {
+          line: 1,
+          startCharacter: 0,
+          startOffset: 35,
+        },
+        token: '    backticked element',
+        tokenType: 'symbolicName',
+      },
+      {
+        bracketInfo: undefined,
+        length: 4,
+        position: {
+          line: 2,
+          startCharacter: 0,
+          startOffset: 58,
+        },
+        token: '    ',
+        tokenType: 'symbolicName',
+      },
+    ]);
+  });
+
+  test('Correctly colours preparser options including unfinished strings', () => {
+    const query = `CYPHER runtime = "some unfinished 
+    string
+    `;
+    expect(applySyntaxColouring(query)).toEqual([
+      {
+        bracketInfo: undefined,
+        length: 6,
+        position: {
+          line: 0,
+          startCharacter: 0,
+          startOffset: 0,
+        },
+        token: 'CYPHER',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: undefined,
+        length: 7,
+        position: {
+          line: 0,
+          startCharacter: 7,
+          startOffset: 7,
+        },
+        token: 'runtime',
+        tokenType: 'setting',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 15,
+          startOffset: 15,
+        },
+        token: '=',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 17,
+        position: {
+          line: 0,
+          startCharacter: 17,
+          startOffset: 17,
+        },
+        token: `"some unfinished `,
+        tokenType: 'stringLiteral',
+      },
+      {
+        bracketInfo: undefined,
+        length: 10,
+        position: {
+          line: 1,
+          startCharacter: 0,
+          startOffset: 35,
+        },
+        token: '    string',
+        tokenType: 'stringLiteral',
+      },
+      {
+        bracketInfo: undefined,
+        length: 4,
+        position: {
+          line: 2,
+          startCharacter: 0,
+          startOffset: 46,
+        },
+        token: '    ',
+        tokenType: 'stringLiteral',
+      },
+    ]);
+  });
+
+  test('Correctly colours strings in wrong places', () => {
+    const query = `MATCH (n: "foo bar 
+
+      adfsa
+      asfds`;
+    expect(applySyntaxColouring(query)).toEqual([
+      {
+        bracketInfo: undefined,
+        length: 5,
+        position: {
+          line: 0,
+          startCharacter: 0,
+          startOffset: 0,
+        },
+        token: 'MATCH',
+        tokenType: 'keyword',
+      },
+      {
+        bracketInfo: {
+          bracketLevel: 0,
+          bracketType: 'parenthesis',
+        },
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 6,
+          startOffset: 6,
+        },
+        token: '(',
+        tokenType: 'bracket',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 7,
+          startOffset: 7,
+        },
+        token: 'n',
+        tokenType: 'variable',
+      },
+      {
+        bracketInfo: undefined,
+        length: 1,
+        position: {
+          line: 0,
+          startCharacter: 8,
+          startOffset: 8,
+        },
+        token: ':',
+        tokenType: 'operator',
+      },
+      {
+        bracketInfo: undefined,
+        length: 9,
+        position: {
+          line: 0,
+          startCharacter: 10,
+          startOffset: 10,
+        },
+        token: `"foo bar `,
+        tokenType: 'stringLiteral',
+      },
+      {
+        bracketInfo: undefined,
+        length: 11,
+        position: {
+          line: 2,
+          startCharacter: 0,
+          startOffset: 21,
+        },
+        token: '      adfsa',
+        tokenType: 'stringLiteral',
+      },
+      {
+        bracketInfo: undefined,
+        length: 11,
+        position: {
+          line: 3,
+          startCharacter: 0,
+          startOffset: 33,
+        },
+        token: '      asfds',
+        tokenType: 'stringLiteral',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## What
To highlight the tokens we were:

1. Doing a first pass using the lexer
2. Fixing the highlighting with the parsing tree

The problem is we were storing the colouring in a map with key `line,column`, but we were not taking into account how many characters that highlighting affected. So for cases like:

```
CYPHER runtime = "some unfinished 
    string
```

we would not colour the string correctly.

This PR adds the length of the colouring as a third coordinate in that map key, so we can solve those edge cases.

## Why

We were getting the highlighting of multiline constructs in the preparser incorrectly

<img width="413"  src="https://github.com/user-attachments/assets/c4e54eca-3b99-4567-80f5-0418b926aad0" />

