### PR TITLE
Fixes built-in function case sensitivity

### DIFF
--- a/.changeset/neat-panthers-whisper.md
+++ b/.changeset/neat-panthers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Bugfix for case-insensitivity of built-in functions

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -109,16 +109,14 @@ function functionExists(
   const functionExistsWithExactName = Boolean(
     functionsSchema[functionCandidate.name],
   );
-  const lowercaseFunctionName = functionCandidate.name.toLowerCase();
-  const caseInsensitiveFunctionInDatabase =
-    functionsSchema[lowercaseFunctionName];
-
-  // Built-in functions are case-insensitive in the database
-  return (
-    functionExistsWithExactName ||
-    (caseInsensitiveFunctionInDatabase &&
-      caseInsensitiveFunctionInDatabase.isBuiltIn)
+  const lowerCaseFunctionName = functionCandidate.name.toLowerCase();
+  const caseInsensitiveBuiltInFunctionExists = Boolean(
+    Object.values(functionsSchema).find(
+      (fn) => fn.isBuiltIn && fn.name.toLowerCase() === lowerCaseFunctionName,
+    ),
   );
+  // Built-in functions are case-insensitive in the database
+  return caseInsensitiveBuiltInFunctionExists || functionExistsWithExactName;
 }
 
 function generateFunctionUsedAsProcedureError(

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -1,3 +1,4 @@
+import { testData } from '../testData';
 import { getDiagnosticsForQuery } from './helpers';
 
 describe('Syntactic validation spec', () => {
@@ -736,6 +737,68 @@ describe('Syntactic validation spec', () => {
           },
           start: {
             character: 24,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Syntax validation does not error on case-insensitive use of built-in functions', () => {
+    const query = `RETURN randomUuId()`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          functions: {
+            'CYPHER 5': {
+              randomUUID: {
+                ...testData.emptyFunction,
+                name: 'randomUUID',
+                isBuiltIn: true,
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  test('Syntax validation returns error on case-insensitive use of non-built-in functions', () => {
+    const query = `RETURN apoc.madeup()`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          functions: {
+            'CYPHER 5': {
+              'apoc.madeUp': {
+                ...testData.emptyFunction,
+                name: 'apoc.madeUp',
+                isBuiltIn: false,
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        message:
+          "Function apoc.madeup is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 18,
+          start: 7,
+        },
+        range: {
+          end: {
+            character: 18,
+            line: 0,
+          },
+          start: {
+            character: 7,
             line: 0,
           },
         },


### PR DESCRIPTION
Before calls to built-in functions (example: randomUUID()) would get errors in language-support (but not when running query)
pre-fix: `RETURN randomUuid()` -> ~"Function randomUuid is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application"
          
now: `RETURN randomUuid()` -> no error
     but still for non-built in:
         `RETURN apoc.math.cosH(5)` -> "Function apoc.math.cosH is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application"