### PR TITLE
Fixes arrowlines, path length, and IS X bugs in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -178,7 +178,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // (labelExpression3 etc)
   visitLabelExpression = (ctx: LabelExpressionContext) => {
     this.visitRawIfNotNull(ctx.COLON());
-    this.visitRawIfNotNull(ctx.IS());
+    this.visitIfNotNull(ctx.IS());
     this.visit(ctx.labelExpression4());
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -143,7 +143,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Visit these separately because operators want spaces around them,
   // and these are not operators (despite being minuses).
   visitArrowLine = (ctx: ArrowLineContext) => {
-    this.visitTerminalRaw(ctx.ARROW_LINE());
+    this.visitRawIfNotNull(ctx.MINUS());
+    this.visitRawIfNotNull(ctx.ARROW_LINE());
   };
 
   visitRightArrow = (ctx: RightArrowContext) => {
@@ -298,13 +299,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitRelationshipPattern = (ctx: RelationshipPatternContext) => {
     this.visitIfNotNull(ctx.leftArrow());
     const arrowLineList = ctx.arrowLine_list();
-    this.visitTerminalRaw(arrowLineList[0].MINUS());
+    this.visit(arrowLineList[0]);
     if (ctx.LBRACKET()) {
       this.visit(ctx.LBRACKET());
       this.handleInnerPatternContext(ctx);
       this.visit(ctx.RBRACKET());
     }
-    this.visitTerminalRaw(arrowLineList[1].MINUS());
+    this.visit(arrowLineList[1]);
     this.visitIfNotNull(ctx.rightArrow());
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -19,6 +19,7 @@ import {
   NodePatternContext,
   NumberLiteralContext,
   ParameterContext,
+  PathLengthContext,
   PropertyContext,
   RegularQueryContext,
   RelationshipPatternContext,
@@ -283,10 +284,26 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (ctx.labelExpression() && ctx.properties()) {
       this.addSpace();
     }
+    if (ctx instanceof RelationshipPatternContext) {
+      this.visitIfNotNull(ctx.pathLength());
+    }
     this.visitIfNotNull(ctx.properties());
     if (ctx.WHERE()) {
       this.visit(ctx.WHERE());
       this.visit(ctx.expression());
+    }
+  };
+
+  // Need to handle this separately to avoid spaces around the operators
+  visitPathLength = (ctx: PathLengthContext) => {
+    this.visitTerminalRaw(ctx.TIMES());
+    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
+    if (n === 1) {
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+    } else if (n === 2) {
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+      this.visitTerminalRaw(ctx.DOTDOT());
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(1));
     }
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -297,13 +297,18 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Need to handle this separately to avoid spaces around the operators
   visitPathLength = (ctx: PathLengthContext) => {
     this.visitTerminalRaw(ctx.TIMES());
-    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
-    if (n === 1) {
+    if (ctx._single) {
       this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
-    } else if (n === 2) {
-      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+    } else if (ctx.DOTDOT()) {
+      let idx = 0;
+      if (ctx._from_) {
+        this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
+        idx++;
+      }
       this.visitTerminalRaw(ctx.DOTDOT());
-      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(1));
+      if (ctx._to) {
+        this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
+      }
     }
   };
 

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -414,12 +414,22 @@ RETURN e`;
     verifyFormatting(query, expected);
   });
 
-  test('path length with length range', () => {
-    const query = `MATCH (p:Person)-[r:LOVES*1..10]-()
+  test('path length with different length ranges', () => {
+    const fromquery = `MATCH (p:Person)-[r:LOVES*1..]-()
 RETURN e`;
-    const expected = `MATCH (p:Person)-[r:LOVES*1..10]-()
+    const fromexpected = `MATCH (p:Person)-[r:LOVES*1..]-()
 RETURN e`;
-    verifyFormatting(query, expected);
+    const toquery = `MATCH (p:Person)-[r:LOVES*..10]-()
+RETURN e`;
+    const toexpected = `MATCH (p:Person)-[r:LOVES*..10]-()
+RETURN e`;
+    const bothquery = `MATCH (p:Person)-[r:LOVES*1..10]-()
+RETURN e`;
+    const bothexpected = `MATCH (p:Person)-[r:LOVES*1..10]-()
+RETURN e`;
+    verifyFormatting(fromquery, fromexpected);
+    verifyFormatting(toquery, toexpected);
+    verifyFormatting(bothquery, bothexpected);
   });
 });
 

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -397,6 +397,30 @@ describe('various edgecases', () => {
     const expected = `RETURN apoc.text.levenshteinSimilarity("Neo4j", "Neo4j") AS output;`;
     verifyFormatting(query, expected);
   });
+
+  test('path length in relationship pattern', () => {
+    const query = `MATCH (p:Person)-[r:LOVES*]-()
+RETURN e`;
+    const expected = `MATCH (p:Person)-[r:LOVES*]-()
+RETURN e`;
+    verifyFormatting(query, expected);
+  });
+
+  test('path length with specific length', () => {
+    const query = `MATCH (p:Person)-[r:LOVES*5]-()
+RETURN e`;
+    const expected = `MATCH (p:Person)-[r:LOVES*5]-()
+RETURN e`;
+    verifyFormatting(query, expected);
+  });
+
+  test('path length with length range', () => {
+    const query = `MATCH (p:Person)-[r:LOVES*1..10]-()
+RETURN e`;
+    const expected = `MATCH (p:Person)-[r:LOVES*1..10]-()
+RETURN e`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for correct cursor position', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -431,6 +431,22 @@ RETURN e`;
     verifyFormatting(toquery, toexpected);
     verifyFormatting(bothquery, bothexpected);
   });
+
+  test('IS FLOAT and IS INTEGER should not be broken', () => {
+    const query = `MATCH (n)
+WITH n, [k IN keys(n)] as list
+UNWIND list as listItem
+WITH n, listItem
+WHERE (n[listItem] IS FLOAT OR n[listItem] IS INTEGER)
+RETURN n`;
+    const expected = `MATCH (n)
+WITH n, [k IN keys(n)] AS list
+UNWIND list AS listItem
+WITH n, listItem
+WHERE (n[listItem] IS FLOAT OR n[listItem] IS INTEGER)
+RETURN n`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for correct cursor position', () => {


### PR DESCRIPTION
### Description
We received a large (1.5M, though could only parse 1.1M) amount of real queries from our friends at #product-analytics, and I tried running the v1 formatter on these to verify it's behavior with the verifyFormatting funciton, i.e. that it 
1. Can format anything that the parser can parse
2. Does not produce a different parse tree after formatting
3. Is idempotent

After running the formatter over all of these queries I found that 

1. in some (veeery rare) cases, the "-" characters in relationships can be parsed as MINUS ( I have no clue how, since the arrowLine rule should catch these but whatever)
2. The formatter was completely missing path lengths in relationship patterns
3. The formatter was not putting spaces around IS in some cases, e.g. IS FLOAT was becoming ISFLOAT.

This PR fixes all three issues and adds some tests for it 

### Testing
- Added unit tests for the cases above 
- Ran the formatter on 100k of the sample queries, and they all passed the three checks above.