### PR TITLE
Allows generating VSCode artifacts in branches

### DIFF
--- a/.github/workflows/archive-vscode-artifacts.yaml
+++ b/.github/workflows/archive-vscode-artifacts.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What
This PR allows us to trigger the workflow to archive VSCode artifacts in branches (PRs for example).

Up until now those artifacts were generated automatically but only on merging to main.

## Why
So we can collaborate with the product department better on something getting merged to `main`