### PR TITLE
fixes so nested FOREACH gets newline and indent

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -8,6 +8,7 @@ import {
   CountStarContext,
   ExistsExpressionContext,
   ExtendedCaseExpressionContext,
+  ForeachClauseContext,
   KeywordLiteralContext,
   LabelExpressionContext,
   LeftArrowContext,
@@ -488,6 +489,23 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       }
     }
     this.visit(ctx.RCURLY());
+  };
+  visitForeachClause = (ctx: ForeachClauseContext) => {
+    this.visit(ctx.FOREACH());
+    this.visit(ctx.LPAREN());
+    this.visit(ctx.variable());
+    this.visit(ctx.IN());
+    this.visit(ctx.expression());
+    if (ctx.BAR()) {
+      this.visit(ctx.BAR());
+      this.addIndentation();
+      this.visit(ctx.clause(0));
+      this.removeIndentation();
+      this.breakLine();
+      this.visit(ctx.RPAREN());
+    } else {
+      this.visit(ctx.RPAREN());
+    }
   };
 }
 

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -447,6 +447,28 @@ WHERE (n[listItem] IS FLOAT OR n[listItem] IS INTEGER)
 RETURN n`;
     verifyFormatting(query, expected);
   });
+  test('should put nested FOREACH on newline', () => {
+    const query = `MATCH (u:User)
+MATCH (u)-[:USER_EVENT]->(e:Event)
+WITH u, e ORDER BY e ASC
+WITH u, collect(e) AS eventChain
+FOREACH (i IN range(0, size(eventChain) - 2) |
+FOREACH (node1 IN [eventChain [i]] |
+FOREACH (node2 IN [eventChain [i + 1]] |
+MERGE (node1)-[:NEXT_EVENT]->(node2))))`;
+    const expected = `MATCH (u:User)
+MATCH (u)-[:USER_EVENT]->(e:Event)
+WITH u, e ORDER BY e ASC
+WITH u, collect(e) AS eventChain
+FOREACH (i IN range(0, size(eventChain) - 2) |
+  FOREACH (node1 IN [eventChain[i]] |
+    FOREACH (node2 IN [eventChain[i + 1]] |
+      MERGE (node1)-[:NEXT_EVENT]->(node2)
+    )
+  )
+)`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for correct cursor position', () => {


### PR DESCRIPTION
### Description
This PR fixes so that nested FOREACH clauses gets on a new line with indentation.
**Before**
```
FOREACH (i IN range(0, size(eventChain) - 2) |
FOREACH (node1 IN [eventChain[i]] |
FOREACH (node2 IN [eventChain[i + 1]] |
MERGE (node1)-[:NEXT_EVENT]->(node2))))
```
**After**
```
FOREACH (i IN range(0, size(eventChain) - 2) |
  FOREACH (node1 IN [eventChain[i]] |
    FOREACH (node2 IN [eventChain[i + 1]] |
      MERGE (node1)-[:NEXT_EVENT]->(node2)
    )
  )
)
```

### Test
 - One test added 
 - All test passes