### PR TITLE
adds setting darkmode according to system pref

### DIFF
--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -42,8 +42,9 @@ export function App() {
   const [showAntlrParse, setShowAntlrParse] = useState(false);
   const [showConfigPanel, setShowConfigPanel] = useState(false);
   const [commandRanCount, setCommandRanCount] = useState(0);
-  const [darkMode, setDarkMode] = useState(false);
-
+  const [darkMode, setDarkMode] = useState(
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );  
   const [schema, setSchema] = useState<DbSchema>(testData.mockSchema);
   const [schemaText, setSchemaText] = useState<string>(
     JSON.stringify(testData.mockSchema, undefined, 2),


### PR DESCRIPTION
### Description
This PR updates react-codemirror-playground to check the system setting for darkmode. If darkmode is enabled on system, react-codemirror playground will default to darkmode. 

You might have talked about having this already and concluded you did not want to follow system settings, in that case remove this PR. 

### Tests
 - All tests passes