### PR TITLE
Fixes formatter bug; FOREACH with multiple clauses

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -490,22 +490,23 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.visit(ctx.RCURLY());
   };
+
   visitForeachClause = (ctx: ForeachClauseContext) => {
     this.visit(ctx.FOREACH());
     this.visit(ctx.LPAREN());
     this.visit(ctx.variable());
     this.visit(ctx.IN());
     this.visit(ctx.expression());
-    if (ctx.BAR()) {
-      this.visit(ctx.BAR());
+    this.visit(ctx.BAR());
+
+    const n = ctx.clause_list().length;
+    for (let i = 0; i < n; i++) {
       this.addIndentation();
-      this.visit(ctx.clause(0));
+      this.visit(ctx.clause(i));
       this.removeIndentation();
-      this.breakLine();
-      this.visit(ctx.RPAREN());
-    } else {
-      this.visit(ctx.RPAREN());
     }
+    this.breakLine();
+    this.visit(ctx.RPAREN());
   };
 }
 

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -469,6 +469,25 @@ FOREACH (i IN range(0, size(eventChain) - 2) |
 )`;
     verifyFormatting(query, expected);
   });
+
+  test('should remember all clauses in foreach', () => {
+    const query = `
+MATCH (n)
+UNWIND n.list as items
+FOREACH (item in items |
+  CREATE (p:Product {name: item})
+  CREATE (n)-[:CONTAINS]->(p)
+)
+RETURN n`;
+    const expected = `MATCH (n)
+UNWIND n.list AS items
+FOREACH (item IN items |
+  CREATE (p:Product {name: item})
+  CREATE (n)-[:CONTAINS]->(p)
+)
+RETURN n`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for correct cursor position', () => {


### PR DESCRIPTION
While running our v2 formatter against real queries, we noticed some clauses in FOREACH statements were missing. The current visitForeachClause only visits the first clause though there may be multiple; hence them disappearing. 

This PR fixes the bug and adds a test for that case.