### PR TITLE
Adds experimental formatting option to codemirror playground

### DIFF
--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -4,6 +4,7 @@ export { shouldAutoCompleteYield } from './autocompletion/autocompletionHelpers'
 export type { DbSchema } from './dbSchema';
 export { _internalFeatureFlags } from './featureFlags';
 export { formatQuery } from './formatting/formatting';
+export { formatQuery as formatQueryExperimental } from './formatting/formattingv2';
 export { antlrUtils } from './helpers';
 export { CypherTokenType, lexerSymbols } from './lexerSymbols';
 export { parse, parserWrapper, parseStatementsStrs } from './parserWrapper';

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -40,6 +40,7 @@ export function App() {
   const [value, setValue] = useState<string>(demos[selectedDemoName]);
   const [showCodemirrorParse, setShowCodemirrorParse] = useState(false);
   const [showAntlrParse, setShowAntlrParse] = useState(false);
+  const [useExperimentalFormatter, setUseExperimentalFormatter] = useState(false);
   const [showConfigPanel, setShowConfigPanel] = useState(false);
   const [commandRanCount, setCommandRanCount] = useState(0);
   const [darkMode, setDarkMode] = useState(
@@ -57,7 +58,7 @@ export function App() {
       mac: 'Alt-Shift-f',
       preventDefault: true,
       run: () => {
-        editorRef.current.format();
+        editorRef.current.format(useExperimentalFormatter);
         return true;
       },
     },
@@ -141,7 +142,7 @@ export function App() {
               ariaLabel="Cypher Editor"
             />
             <p
-              onClick={() => editorRef.current.format()}
+              onClick={() => editorRef.current.format(useExperimentalFormatter)}
               className="text-blue-500 cursor-pointer hover:text-blue-700"
               title={
                 window.navigator.userAgent.includes('Mac')
@@ -184,6 +185,14 @@ export function App() {
                   onChange={() => setShowAntlrParse((s) => !s)}
                 />
                 Show antlr parse tree
+              </label>
+              <label className="flex gap-1">
+                <input
+                  type="checkbox"
+                  checked={useExperimentalFormatter}
+                  onChange={() => setUseExperimentalFormatter((s) => !s)}
+                />
+                Use experimental formatter
               </label>
               {schemaError && <div className="text-red-500">{schemaError}</div>}
               <textarea

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -302,7 +302,7 @@ export class CypherEditor extends Component<
   /**
    * Format Cypher query
    */
-  format(experimentalVersion = true) {
+  format(experimentalVersion = false) {
     format(this.editorView.current, experimentalVersion);
   }
 

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -15,6 +15,7 @@ import {
 } from '@codemirror/view';
 import {
   formatQuery,
+  formatQueryExperimental,
   _internalFeatureFlags,
   type DbSchema,
 } from '@neo4j-cypher/language-support';
@@ -180,13 +181,12 @@ export interface CypherEditorProps {
   moveFocusOnTab?: boolean;
 }
 
-const format = (view: EditorView): void => {
+const format = (view: EditorView, experimental: Boolean): void => {
   try {
     const doc = view.state.doc.toString();
-    const { formattedString, newCursorPos } = formatQuery(
-      doc,
-      view.state.selection.main.anchor,
-    );
+    const { formattedString, newCursorPos } = experimental
+     ? formatQueryExperimental(doc, view.state.selection.main.anchor)
+     : formatQuery(doc, view.state.selection.main.anchor);
     view.dispatch({
       changes: {
         from: 0,
@@ -302,8 +302,8 @@ export class CypherEditor extends Component<
   /**
    * Format Cypher query
    */
-  format() {
-    format(this.editorView.current)
+  format(experimentalVersion = true) {
+    format(this.editorView.current, experimentalVersion);
   }
 
   /**


### PR DESCRIPTION
## Description
Given that we've now introduced the code for the experimental V2 formatter, we would like some convenient way to run it. This PR adds an option in the codemirror playground to enable switching between the versions by a checkbox in the options menu.
 
### Video (let me know if you can't view this):
https://neo4j.slack.com/files/U05CXFC5V0U/F08F4STDWDQ/screen_recording_2025-02-26_at_10.03.27.mov?origin_team=T02AS3DQ7&origin_channel=C089SEWEJ8Z

## Testing
- npm run test
- Tested manually as in the video above