### PR TITLE
Fixes known bugs in baseline PR for v2 formatter 

### DIFF
--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -24,6 +24,7 @@ import {
   FunctionInvocationContext,
   KeywordLiteralContext,
   LabelExpressionContext,
+  LimitContext,
   ListLiteralContext,
   MapContext,
   MapProjectionContext,
@@ -296,6 +297,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.endGroup();
     this.endGroup();
+  };
+
+  visitLimit = (ctx: LimitContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
   };
 
   visitReturnItem = (ctx: ReturnItemContext) => {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -639,6 +639,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  // Handled separately because we never want to split within the quantifier.
+  // So we fully concatenate it to ensure it's part of the same chunk.
   visitQuantifier = (ctx: QuantifierContext) => {
     if (ctx.PLUS() || ctx.TIMES()) {
       this.visitChildren(ctx);

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -643,6 +643,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (ctx.PLUS() || ctx.TIMES()) {
       this.visitChildren(ctx);
       this.concatenate();
+      return;
     }
     this.visit(ctx.LCURLY());
     this.concatenate();

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -741,7 +741,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.removeIndentation();
     this.breakLine();
     this.visit(ctx.RCURLY());
-    this.breakLine();
     this.visitIfNotNull(ctx.subqueryInTransactionsParameters());
   };
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -46,6 +46,7 @@ import {
   PatternListContext,
   ProcedureNameContext,
   PropertyContext,
+  QuantifierContext,
   ReduceExpressionContext,
   RegularQueryContext,
   RelationshipPatternContext,
@@ -636,6 +637,26 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       }
       this.endGroup();
     }
+  };
+
+  visitQuantifier = (ctx: QuantifierContext) => {
+    if (ctx.PLUS() || ctx.TIMES()) {
+      this.visitChildren(ctx);
+      this.concatenate();
+    }
+    this.visit(ctx.LCURLY());
+    this.concatenate();
+    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
+    this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+    this.concatenate();
+    this.visit(ctx.COMMA());
+    this.concatenate();
+    if (n > 1) {
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(1));
+      this.concatenate();
+    }
+    this.visit(ctx.RCURLY());
+    this.concatenate();
   };
 
   // Handled separately because the dots aren't operators

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -393,6 +393,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitLabelExpression4 = (ctx: LabelExpression4Context) => {
+    // There is no great way to know which labels have colons before them,
+    // so we have to resort to manually checking the types of the children.
     const n = ctx.getChildCount();
     for (let i = 0; i < n; i++) {
       const child = ctx.getChild(i);
@@ -401,7 +403,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         if (i > 0) {
           this.concatenate();
         }
-        //console.log("Avoiding space between", this.currentBuffer().at(-1));
       } else if (child instanceof TerminalNode) {
         this.avoidSpaceBetween();
         this.visitTerminal(child);
@@ -418,7 +419,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         if (i > 0) {
           this.concatenate();
         }
-        //console.log("Avoiding space between", this.currentBuffer().at(-1));
       } else if (child instanceof TerminalNode) {
         this.avoidSpaceBetween();
         this.visitTerminal(child);

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1144,4 +1144,18 @@ WHERE (p.priiiiiiiiiiiiiiiiiiice +
 RETURN p;`;
     verifyFormatting(query, expected);
   });
+
+  test('complicated QPP', () => {
+    const query = `
+MATCH (dmk:Station {name: 'Denmark Hill'})<-[:CALLS_AT]-(l1a:CallingPoint)-[:NEXT]->+
+        (l1b)-[:CALLS_AT]->(x:Station)<-[:CALLS_AT]-(l2a:CallingPoint)-[:NEXT]->*
+        (l2b)-[:CALLS_AT]->(gtw:Station {name: 'Gatwick Airport'})
+RETURN dmk`;
+    const expected = `
+MATCH (dmk:Station {name: 'Denmark Hill'})<-[:CALLS_AT]-(l1a:CallingPoint)-
+      [:NEXT]->+ (l1b)-[:CALLS_AT]->(x:Station)<-[:CALLS_AT]-(l2a:CallingPoint)-
+      [:NEXT]->* (l2b)-[:CALLS_AT]->(gtw:Station {name: 'Gatwick Airport'})
+RETURN dmk`.trim();
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -427,6 +427,15 @@ FOREACH (i IN range(0, size(eventChain) - 2) |
 )`;
     verifyFormatting(query, expected);
   });
+
+  test('puts LIMIT on a new line', () => {
+    const query = `CREATE (n)
+RETURN n LIMIT 0`;
+    const expected = `CREATE (n)
+RETURN n
+LIMIT 0`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('various edgecases', () => {
@@ -924,7 +933,8 @@ LIMIT "ZTWWLgIq"`;
       (Kevin:Person {name: "HEZDAAhT"})
 WHERE p.name <> "nnwAPHJg"
 RETURN p.name AS Name, p.born AS BirthYear, m.title AS MovieTitle
-       ORDER BY Name ASC LIMIT "ZTWWLgIq"`;
+       ORDER BY Name ASC
+LIMIT "ZTWWLgIq"`;
     verifyFormatting(query, expected);
   });
 

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -690,7 +690,7 @@ RETURN m`;
     const query = `MATCH path=(:Station&Western)(()-[:NEXT]->()){1,}(:Station&Western)
 WHERE all(x IN nodes(path) WHERE x:Station&Western)
 RETURN path`;
-    const expected = `MATCH path = (:Station&Western) (()-[:NEXT]->()){1,}(:Station&Western)
+    const expected = `MATCH path = (:Station&Western) (()-[:NEXT]->()){1,} (:Station&Western)
 WHERE all(x IN nodes(path) WHERE x:Station&Western)
 RETURN path`;
     verifyFormatting(query, expected);

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -108,6 +108,14 @@ RETURN count('*')`;
 }`;
     verifyFormatting(query, expected);
   });
+
+  test('no space in label predicates', () => {
+    const query = `MATCH (person    : Person  :  Owner  )
+RETURN person.name`;
+    const expected = `MATCH (person:Person:Owner)
+RETURN person.name`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {
@@ -660,6 +668,38 @@ RETURN n`;
     const expected = `MATCH (n)
 // filter out to only the right name
 WHERE n.name = 'Tomas'
+RETURN n`;
+    verifyFormatting(query, expected);
+  });
+
+  test('graph pattern matching spacing', () => {
+    const query = `MATCH (m:(Adventure&Children)&!(War&Crime))
+RETURN m`;
+    const expected = `MATCH (m:(Adventure&Children)&!(War&Crime))
+RETURN m`;
+    verifyFormatting(query, expected);
+  });
+
+  test('quantified path pattern spacing', () => {
+    const query = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){1,4}`;
+    const expected = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){1,4}`;
+    verifyFormatting(query, expected);
+  });
+
+  test('all should not get capitalized here', () => {
+    const query = `MATCH path=(:Station&Western)(()-[:NEXT]->()){1,}(:Station&Western)
+WHERE all(x IN nodes(path) WHERE x:Station&Western)
+RETURN path`;
+    const expected = `MATCH path = (:Station&Western) (()-[:NEXT]->()){1,}(:Station&Western)
+WHERE all(x IN nodes(path) WHERE x:Station&Western)
+RETURN path`;
+    verifyFormatting(query, expected);
+  });
+
+  test('weird label expression', () => {
+    const query = `MATCH (n)-[:ACTED_IN|AMPLIFIES|:SCREAMS|OBSERVES|:ANALYZES]-(m)
+RETURN n`;
+    const expected = `MATCH (n)-[:ACTED_IN|AMPLIFIES|:SCREAMS|OBSERVES|:ANALYZES]-(m)
 RETURN n`;
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -673,7 +673,7 @@ RETURN n`;
   });
 
   test('graph pattern matching spacing', () => {
-    const query = `MATCH (m:(Adventure&Children)&!(War&Crime))
+    const query = `MATCH (m:(Adventure&Children) & ! (War&Crime))
 RETURN m`;
     const expected = `MATCH (m:(Adventure&Children)&!(War&Crime))
 RETURN m`;
@@ -681,7 +681,7 @@ RETURN m`;
   });
 
   test('quantified path pattern spacing', () => {
-    const query = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){1,4}`;
+    const query = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){ 1 , 4 }`;
     const expected = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){1,4}`;
     verifyFormatting(query, expected);
   });


### PR DESCRIPTION
## Description
The PR which added the baseline of the V2 formatter had some known bugs which we decided to tackle later on, namely:

- Patterns and quantified patterns get weird spacing
- LIMIT does not get put on a newline (we forgot to port this to V2 I think)
- functions in listItemsPredicate are handled like keywords when they shouldn't be
- IN CONCURRENT... at the end of a subquery gets put on a new line for no reason.

This PR fixes these issues.

Relevant discussions in the previous PR:

-  https://github.com/neo4j/cypher-language-support/pull/369#discussion_r1967612286
-  https://github.com/neo4j/cypher-language-support/pull/369#discussion_r1967632302

### Testing
- Unit tests added for all the cases above (roughly 8 tests)
- ran the sanity checks on 100k queries (no idempotency check because of the issues with comments though...) and they didn't break the AST 