### PR TITLE
Ports bug fixes from v2 formatter to v1

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -385,11 +385,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       return;
     }
     this.visit(ctx.LCURLY());
-    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
-    this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+    let idx = 0;
+    if (ctx._from_) {
+      this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
+      idx++;
+    }
     this.visitTerminalRaw(ctx.COMMA());
-    if (n > 1) {
-      this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(1));
+    if (ctx._to) {
+      this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
     }
     this.visit(ctx.RCURLY());
   };

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -11,6 +11,9 @@ import {
   ForeachClauseContext,
   FunctionInvocationContext,
   KeywordLiteralContext,
+  LabelExpression2Context,
+  LabelExpression3Context,
+  LabelExpression4Context,
   LabelExpressionContext,
   LeftArrowContext,
   LimitContext,
@@ -189,6 +192,40 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visitRawIfNotNull(ctx.COLON());
     this.visitIfNotNull(ctx.IS());
     this.visit(ctx.labelExpression4());
+  };
+
+  visitLabelExpression4 = (ctx: LabelExpression4Context) => {
+    // There is no great way to know which labels have colons before them,
+    // so we have to resort to manually checking the types of the children.
+    const n = ctx.getChildCount();
+    for (let i = 0; i < n; i++) {
+      const child = ctx.getChild(i);
+      if (child instanceof LabelExpression3Context) {
+        this.visit(child);
+      } else if (child instanceof TerminalNode) {
+        this.visitTerminalRaw(child);
+      }
+    }
+  };
+
+  visitLabelExpression3 = (ctx: LabelExpression3Context) => {
+    const n = ctx.getChildCount();
+    for (let i = 0; i < n; i++) {
+      const child = ctx.getChild(i);
+      if (child instanceof LabelExpression2Context) {
+        this.visit(child);
+      } else if (child instanceof TerminalNode) {
+        this.visitTerminalRaw(child);
+      }
+    }
+  };
+
+  visitLabelExpression2 = (ctx: LabelExpression2Context) => {
+    const n = ctx.EXCLAMATION_MARK_list().length;
+    for (let i = 0; i < n; i++) {
+      this.visitTerminalRaw(ctx.EXCLAMATION_MARK(i));
+    }
+    this.visit(ctx.labelExpression1());
   };
 
   visitTerminal = (node: TerminalNode) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -26,6 +26,7 @@ import {
   ParameterContext,
   PathLengthContext,
   PropertyContext,
+  QuantifierContext,
   RegularQueryContext,
   RelationshipPatternContext,
   RightArrowContext,
@@ -375,6 +376,22 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.visit(arrowLineList[1]);
     this.visitIfNotNull(ctx.rightArrow());
+  };
+
+  visitQuantifier = (ctx: QuantifierContext) => {
+    if (ctx.PLUS() || ctx.TIMES()) {
+      this.visitRawIfNotNull(ctx.PLUS());
+      this.visitRawIfNotNull(ctx.TIMES());
+      return;
+    }
+    this.visit(ctx.LCURLY());
+    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
+    this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(0));
+    this.visitTerminalRaw(ctx.COMMA());
+    if (n > 1) {
+      this.visitTerminalRaw(ctx.UNSIGNED_DECIMAL_INTEGER(1));
+    }
+    this.visit(ctx.RCURLY());
   };
 
   // Handled separately because the dots aren't operators

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -111,13 +111,20 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const commentTokens = (hiddenTokens || []).filter((token) =>
       isComment(token),
     );
+    const nodeLine = node.symbol.line;
     for (const commentToken of commentTokens) {
+      const commentLine = commentToken.line;
+      const shouldBreak = nodeLine !== commentLine;
       if (
+        !shouldBreak &&
         this.buffer.length > 0 &&
         this.buffer[this.buffer.length - 1] !== ' ' &&
         this.buffer[this.buffer.length - 1] !== '\n'
       ) {
         this.addSpace();
+      }
+      if (shouldBreak) {
+        this.breakLine();
       }
       this.buffer.push(commentToken.text.trim());
       this.breakLine();

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -545,6 +545,19 @@ RETURN n`;
     verifyFormatting(query, expected);
   });
 
+  test('quantified path pattern spacing with +/*', () => {
+    const starquery = `MATCH (p:Person)-[:ACTED_IN | DIRECTED]->   * (q)
+RETURN q;`;
+    const plusquery = `MATCH (p:Person)-[:ACTED_IN | DIRECTED]->   + (q)
+RETURN q;`;
+    const starexpected = `MATCH (p:Person)-[:ACTED_IN|DIRECTED]->*(q)
+RETURN q;`;
+    const plusexpected = `MATCH (p:Person)-[:ACTED_IN|DIRECTED]->+(q)
+RETURN q;`;
+    verifyFormatting(starquery, starexpected);
+    verifyFormatting(plusquery, plusexpected);
+  });
+
   test('graph pattern matching spacing', () => {
     const query = `MATCH (m:(Adventure&Children) & ! (War&Crime))
 RETURN m`;

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -197,6 +197,20 @@ MATCH (n)
 RETURN n;`.trim();
     verifyFormatting(query, expected);
   });
+
+  test('multiple comments should not be moved to the previous line', () => {
+    const query = `
+MATCH (n)
+// One comment about the return
+// Another comment about the return
+return n;`;
+    const expected = `
+MATCH (n)
+// One comment about the return
+// Another comment about the return
+RETURN n;`.trim();
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('other styleguide recommendations', () => {

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -102,6 +102,14 @@ RETURN count('*')`;
 }`;
     verifyFormatting(query, expected);
   });
+
+  test('no space in label predicates', () => {
+    const query = `MATCH (person    : Person  :  Owner  )
+RETURN person.name`;
+    const expected = `MATCH (person:Person:Owner)
+RETURN person.name`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('should not forget to include all comments', () => {
@@ -186,15 +194,15 @@ RETURN a.prop // Output the result`;
     verifyFormatting(inlineandmultiline, expected);
   });
 
-  test('comments should not be moved to the previous line', () => {
-    const query = `
-MATCH (n)
-// Comment about the return
-RETURN n;`;
-    const expected = `
-MATCH (n)
-// Comment about the return
-RETURN n;`.trim();
+  test('does not move explicitly newlined comments to the line before', () => {
+    const query = `MATCH (n)
+// filter out to only the right name
+WHERE n.name = 'Tomas'
+RETURN n`;
+    const expected = `MATCH (n)
+// filter out to only the right name
+WHERE n.name = 'Tomas'
+RETURN n`;
     verifyFormatting(query, expected);
   });
 
@@ -520,6 +528,28 @@ FOREACH (item IN items |
   CREATE (n)-[:CONTAINS]->(p)
 )
 RETURN n`;
+    verifyFormatting(query, expected);
+  });
+
+  test('weird label expression', () => {
+    const query = `MATCH (n)-[:ACTED_IN|AMPLIFIES|:SCREAMS|OBSERVES|:ANALYZES]-(m)
+RETURN n`;
+    const expected = `MATCH (n)-[:ACTED_IN|AMPLIFIES|:SCREAMS|OBSERVES|:ANALYZES]-(m)
+RETURN n`;
+    verifyFormatting(query, expected);
+  });
+
+  test('quantified path pattern spacing', () => {
+    const query = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){ 1 , 4 }`;
+    const expected = `MATCH ((:Station {name: 'Denmark Hill'})-[l:LINK]-(s:Station)){1,4}`;
+    verifyFormatting(query, expected);
+  });
+
+  test('graph pattern matching spacing', () => {
+    const query = `MATCH (m:(Adventure&Children) & ! (War&Crime))
+RETURN m`;
+    const expected = `MATCH (m:(Adventure&Children)&!(War&Crime))
+RETURN m`;
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/formatting.test.ts
+++ b/packages/language-support/src/tests/formatting/formatting.test.ts
@@ -185,6 +185,18 @@ MERGE (a:A)-[:T]->(b:B)
 RETURN a.prop // Output the result`;
     verifyFormatting(inlineandmultiline, expected);
   });
+
+  test('comments should not be moved to the previous line', () => {
+    const query = `
+MATCH (n)
+// Comment about the return
+RETURN n;`;
+    const expected = `
+MATCH (n)
+// Comment about the return
+RETURN n;`.trim();
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('other styleguide recommendations', () => {


### PR DESCRIPTION
## Description

There are a few bugs that we have fixed in the v2 version of the formatter but have not fixed in v1. In general, we don't necessarily care about porting fixes for all bugs, as we instead want to prioritize getting v2 out ASAP. But these bugs got extra attention and seem to be particularly painful, and were also pointed out in the #team-browser slack channel where we asked for feedback. I've ported the following fixes to v1 (from v2)

1. Newlined comments should not get moved to the end of the previous line
2. Label expressions should have correct spacing
3. QPP's should not have spaces around them.

## Testing
- Ran the AST integrity + idempotency check on 100k queries, and all passed.
- npm run test
- 7 new tests for the cases above