### PR TITLE
Fixes QPP behavior and a comment bug in V2 formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -293,14 +293,14 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
 }
 
 function determineSplits(chunk: Chunk, nextChunk: Chunk): Split[] {
+  if (nextChunk?.type === 'COMMENT' && nextChunk?.breakBefore) {
+    return [{ splitType: '\n', cost: 0 }];
+  }
   switch (chunk.type) {
     case 'COMMENT':
     case 'INDENT':
       return [{ splitType: '\n', cost: 0 }];
     case 'REGULAR':
-      if (nextChunk?.type === 'COMMENT' && nextChunk?.breakBefore) {
-        return [{ splitType: '\n', cost: 0 }];
-      }
       if (doesNotWantSpace(chunk, nextChunk)) {
         return basicNoSpaceSplits;
       }

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -85,8 +85,10 @@ import { buffersToFormattedString } from './formattingSolutionSearchv2';
 interface RawTerminalOptions {
   lowerCase?: boolean;
   upperCase?: boolean;
-  space?: boolean;
+  spacingChoice?: SpacingChoice;
 }
+
+type SpacingChoice = 'SPACE_AFTER' | 'EXTRA_SPACE';
 
 export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   buffers: Chunk[][] = [];
@@ -482,6 +484,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (options?.upperCase) {
       text = text.toUpperCase();
     }
+    if (options?.spacingChoice === 'EXTRA_SPACE') {
+      text += ' ';
+    }
+
     const chunk: RegularChunk = {
       type: 'REGULAR',
       text,
@@ -492,7 +498,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
 
     this.currentBuffer().push(chunk);
-    if (!options?.space) {
+    if (!options?.spacingChoice) {
       this.avoidSpaceBetween();
     }
     if (wantsToBeConcatenated(node)) {
@@ -512,13 +518,22 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Literals have casing rules, see
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-casing
   visitBooleanLiteral = (ctx: BooleanLiteralContext) => {
-    this.visitRawIfNotNull(ctx.TRUE(), { lowerCase: true, space: true });
-    this.visitRawIfNotNull(ctx.FALSE(), { lowerCase: true, space: true });
+    this.visitRawIfNotNull(ctx.TRUE(), {
+      lowerCase: true,
+      spacingChoice: 'SPACE_AFTER',
+    });
+    this.visitRawIfNotNull(ctx.FALSE(), {
+      lowerCase: true,
+      spacingChoice: 'SPACE_AFTER',
+    });
   };
 
   visitKeywordLiteral = (ctx: KeywordLiteralContext) => {
     if (ctx.NULL()) {
-      this.visitTerminalRaw(ctx.NULL(), { lowerCase: true, space: true });
+      this.visitTerminalRaw(ctx.NULL(), {
+        lowerCase: true,
+        spacingChoice: 'SPACE_AFTER',
+      });
     } else {
       this.visitChildren(ctx);
     }
@@ -650,13 +665,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.visit(ctx.LCURLY());
     this.concatenate();
-    const n = ctx.UNSIGNED_DECIMAL_INTEGER_list().length;
-    this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(0));
-    this.concatenate();
-    this.visit(ctx.COMMA());
-    this.concatenate();
-    if (n > 1) {
-      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(1));
+    let idx = 0;
+    if (ctx._from_) {
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
+      this.concatenate();
+      idx++;
+    }
+    if (ctx._to) {
+      this.visit(ctx.COMMA());
+      this.concatenate();
+      this.visit(ctx.UNSIGNED_DECIMAL_INTEGER(idx));
+      this.concatenate();
+    } else {
+      this.visitTerminalRaw(ctx.COMMA(), { spacingChoice: 'EXTRA_SPACE' });
       this.concatenate();
     }
     this.visit(ctx.RCURLY());

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -663,7 +663,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.avoidSpaceBetween();
       return;
     }
-    this.visit(ctx.LCURLY());
+    if (!ctx._from_) {
+      this.visitTerminalRaw(ctx.LCURLY(), { spacingChoice: 'EXTRA_SPACE' });
+    } else {
+      this.visit(ctx.LCURLY());
+    }
     this.concatenate();
     let idx = 0;
     if (ctx._from_) {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -645,6 +645,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (ctx.PLUS() || ctx.TIMES()) {
       this.visitChildren(ctx);
       this.concatenate();
+      this.avoidSpaceBetween();
       return;
     }
     this.visit(ctx.LCURLY());
@@ -660,6 +661,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.visit(ctx.RCURLY());
     this.concatenate();
+    this.avoidSpaceBetween();
   };
 
   // Handled separately because the dots aren't operators

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -686,11 +686,39 @@ RETURN m`;
     verifyFormatting(query, expected);
   });
 
+  // Example 1 by Finbar
+  test('QPP spacing with star', () => {
+    const query = `
+MATCH (p:Person)-[:ACTED_IN | DIRECTED]->   * (q)
+RETURN q`;
+    const expected = `MATCH (p:Person)-[:ACTED_IN|DIRECTED]->*(q)
+RETURN q`;
+    verifyFormatting(query, expected);
+  });
+
+  // Example 2 by Finbar
+  test('QPP spacing with unspecified start', () => {
+    const query = `MATCH SHORTEST 1(p:Person)-->{, 3}(q)
+RETURN q;`;
+    const expected = `MATCH SHORTEST 1 (p:Person)-->{,3}(q)
+RETURN q;`;
+    verifyFormatting(query, expected);
+  });
+
+  // Example 3 by Finbar
+  test('QPP spacing with unspecified end', () => {
+    const query = `MATCH (p:(!  Movie | !(Director & ! Actor)))-->{1, }(q)
+RETURN *`;
+    const expected = `MATCH (p:(!Movie|!(Director&!Actor)))-->{1, }(q)
+RETURN *;`;
+    verifyFormatting(query, expected);
+  });
+
   test('all should not get capitalized here', () => {
     const query = `MATCH path=(:Station&Western)(()-[:NEXT]->()){1,}(:Station&Western)
 WHERE all(x IN nodes(path) WHERE x:Station&Western)
 RETURN path`;
-    const expected = `MATCH path = (:Station&Western) (()-[:NEXT]->()){1,} (:Station&Western)
+    const expected = `MATCH path = (:Station&Western) (()-[:NEXT]->()){1, }(:Station&Western)
 WHERE all(x IN nodes(path) WHERE x:Station&Western)
 RETURN path`;
     verifyFormatting(query, expected);
@@ -1153,8 +1181,8 @@ MATCH (dmk:Station {name: 'Denmark Hill'})<-[:CALLS_AT]-(l1a:CallingPoint)-[:NEX
 RETURN dmk`;
     const expected = `
 MATCH (dmk:Station {name: 'Denmark Hill'})<-[:CALLS_AT]-(l1a:CallingPoint)-
-      [:NEXT]->+ (l1b)-[:CALLS_AT]->(x:Station)<-[:CALLS_AT]-(l2a:CallingPoint)-
-      [:NEXT]->* (l2b)-[:CALLS_AT]->(gtw:Station {name: 'Gatwick Airport'})
+      [:NEXT]->+(l1b)-[:CALLS_AT]->(x:Station)<-[:CALLS_AT]-(l2a:CallingPoint)-
+      [:NEXT]->*(l2b)-[:CALLS_AT]->(gtw:Station {name: 'Gatwick Airport'})
 RETURN dmk`.trim();
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -708,7 +708,7 @@ RETURN q;`;
   // Example 3 by Finbar
   test('QPP spacing with unspecified end', () => {
     const query = `MATCH (p:(!  Movie | !(Director & ! Actor)))-->{1, }(q)
-RETURN *`;
+RETURN *;`;
     const expected = `MATCH (p:(!Movie|!(Director&!Actor)))-->{1, }(q)
 RETURN *;`;
     verifyFormatting(query, expected);

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -700,7 +700,7 @@ RETURN q`;
   test('QPP spacing with unspecified start', () => {
     const query = `MATCH SHORTEST 1(p:Person)-->{, 3}(q)
 RETURN q;`;
-    const expected = `MATCH SHORTEST 1 (p:Person)-->{,3}(q)
+    const expected = `MATCH SHORTEST 1 (p:Person)-->{ ,3}(q)
 RETURN q;`;
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -232,6 +232,22 @@ MERGE (a:A)-[:T]->(b:B)
 RETURN a.prop // Output the result`;
     verifyFormatting(inlineandmultiline, expected);
   });
+
+  test('should not put the second comment on the previous line', () => {
+    const query = `
+RETURN 1,
+// Comment
+       2,
+// Second comment
+       3`;
+    const expected = `
+RETURN 1,
+// Comment
+       2,
+// Second comment
+       3`.trim();
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('other styleguide recommendations', () => {


### PR DESCRIPTION
## Description
We discussed the formatter briefly with Finbar Good, who provided us with some examples that were getting formatted incorrectly. These were mostly related to QPPs, as well as one case where a comment was getting hoisted to the previous line for no reason.

In short, the changes are
1. If either the start or end is missing from a QPP like this {start,end}, it gets replaced by a space. e.g. `{1,}` becomes `{1, }`
    - It also turns out we were accidentally putting the end as the start before, i.e. `{,3}` was becoming  `{3,}`. This is also fixed with this PR
1. No space after a + or * QPP, e.g. `(a)-[]->+ (b)` becomes  `(a)-[]->+(b)` 
1. The determineSplits function will always return only a \n as an option if the nextChunk is a comment that was explicitly newlined, regardless of what the current chunk is

### Testing 
- 4 new tests taken directly from the examples Finbar gave us.
- Ran the verification test on ~30k queries (not the idempotency check though)