### PR TITLE
Adds .cy, .cyp and .cql extensions to the VSCode extension

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds autocompletions for Cypher version
 - Adds support for CYPHER preparser options (runtime, planner, etc)
 - Adds support for multiple Neo4j connections
+- Makes .cy, .cyp and .cql file extensions work with the plugin
 
 ## 1.6.1
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -197,7 +197,10 @@
       {
         "id": "cypher",
         "extensions": [
-          ".cypher"
+          ".cypher",
+          ".cql",
+          ".cy",
+          ".cyp"
         ],
         "aliases": [
           "Cypher"


### PR DESCRIPTION
Adds `.cql, .cy, .cyp` as possible extensions for Cypher files in the VSCode plugin.

Closes #367