### PR TITLE
Updates architecture overview of formatter based on recent updates

### DIFF
--- a/packages/language-support/src/formatting/architecture.md
+++ b/packages/language-support/src/formatting/architecture.md
@@ -27,9 +27,7 @@ A chunk is similar to ANTLR Tokens, but differs in the following ways
 1. A chunk can consist of multiple tokens, if those tokens should always be kept together.
 An example would be the opening parenthesis of a function call, e.g. `function()`; `function(` would become one chunk,
 since these tokens should never be separated.
-2. A chunk can represent the start or end of a group or indentation
-    - This is not ideal and will likely be moved away from in the future.
-3. A chunk embeds information about the possible splitting characters that can follow it. For instance, we never want
+2. A chunk embeds information about the possible splitting characters that can follow it. For instance, we never want
 to split a line after `WHERE`, and so we encode that in the chunk for `WHERE`.
 
 ### Group

--- a/packages/language-support/src/formatting/architecture.png
+++ b/packages/language-support/src/formatting/architecture.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64e274dd3232ae1a9373e8bdc9feb061ab69f94f966a5b7cb647f528424557ed
-size 1070421
+oid sha256:adc9d668d4ee006b39b07ca8b81857f7fba88f223dcdb8c9cb11176ef48364e8
+size 3800389


### PR DESCRIPTION
## Description
In the architecture overview of the formatter, it was assumed that groups and indentation are chunks in the chunk list. Since we've recently changed this (courtesy of PR #375), this is now outdated. 

This PR updates the architecture diagram and removes the list item describing the old behavior.

Also, it makes the diagram twice as large, as some of the text got blurry in the smaller version