### PR TITLE
Adds preservation of explicit newlines made by user to formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingHelpersv2.ts
+++ b/packages/language-support/src/formatting/formattingHelpersv2.ts
@@ -48,6 +48,7 @@ export const MAX_COL = 80;
 
 export interface BaseChunk {
   isCursor?: boolean;
+  doubleBreak?: true;
   text: string;
   groupsStarting: number;
   groupsEnding: number;

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -73,6 +73,34 @@ interface FinalResultWithPos {
 type FinalResult = string | FinalResultWithPos;
 
 const openingCharacters = [CypherCmdLexer.LPAREN, CypherCmdLexer.LBRACKET];
+const standardSplits: Split[] = [
+  { splitType: ' ', cost: 0 },
+  { splitType: '\n', cost: 1 },
+];
+const doubleBreakStandardSplits: Split[] = [
+  { splitType: ' ', cost: 0 },
+  { splitType: '\n\n', cost: 1 },
+];
+const noSpaceSplits: Split[] = [
+  { splitType: '', cost: 0 },
+  { splitType: '\n', cost: 1 },
+];
+const noSpaceDoubleBreakSplits: Split[] = [
+  { splitType: '', cost: 0 },
+  { splitType: '\n\n', cost: 1 },
+];
+const noBreakSplit: Split[] = [{ splitType: ' ', cost: 0 }];
+const noSpaceNoBreakSplit: Split[] = [{ splitType: '', cost: 0 }];
+const onlyBreakSplit: Split[] = [{ splitType: '\n', cost: 0 }];
+const onlyDoubleBreakSplit: Split[] = [{ splitType: '\n\n', cost: 0 }];
+
+const emptyChunk: RegularChunk = {
+  type: 'REGULAR',
+  text: '',
+  groupsStarting: 0,
+  groupsEnding: 0,
+  modifyIndentation: 0,
+};
 
 export function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
   return (
@@ -356,32 +384,3 @@ export function buffersToFormattedString(
   }
   return { formattedString: formatted.trimEnd(), cursorPos: cursorPos };
 }
-
-const standardSplits: Split[] = [
-  { splitType: ' ', cost: 0 },
-  { splitType: '\n', cost: 1 },
-];
-const doubleBreakStandardSplits: Split[] = [
-  { splitType: ' ', cost: 0 },
-  { splitType: '\n\n', cost: 1 },
-];
-const noSpaceSplits: Split[] = [
-  { splitType: '', cost: 0 },
-  { splitType: '\n', cost: 1 },
-];
-const noSpaceDoubleBreakSplits: Split[] = [
-  { splitType: '', cost: 0 },
-  { splitType: '\n\n', cost: 1 },
-];
-const noBreakSplit: Split[] = [{ splitType: ' ', cost: 0 }];
-const noSpaceNoBreakSplit: Split[] = [{ splitType: '', cost: 0 }];
-const onlyBreakSplit: Split[] = [{ splitType: '\n', cost: 0 }];
-const onlyDoubleBreakSplit: Split[] = [{ splitType: '\n\n', cost: 0 }];
-
-const emptyChunk: RegularChunk = {
-  type: 'REGULAR',
-  text: '',
-  groupsStarting: 0,
-  groupsEnding: 0,
-  modifyIndentation: 0,
-};

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -281,7 +281,7 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
     buffer.push(decision.chosenSplit.splitType);
   });
   let result = buffer.join('').trimEnd();
-  if (decisions.at(-1).left.text === '\n') {
+  if (decisions.at(-1).left.doubleBreak) {
     result += '\n';
   }
   if (cursorPos === -1) {

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -291,22 +291,28 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
 }
 
 function determineSplits(chunk: Chunk, nextChunk: Chunk): Split[] {
-  const onlyBreaksSplit = chunk.doubleBreak ? onlyDoubleBreakSplit : onlyBreakSplit;
+  const onlyBreaksSplit = chunk.doubleBreak
+    ? onlyDoubleBreakSplit
+    : onlyBreakSplit;
   if (isCommentBreak(chunk, nextChunk)) {
     return onlyBreaksSplit;
   }
 
-  const noSpaceBreaksSplit = chunk.doubleBreak ? noSpaceDoubleBreakSplits : noSpaceSplits;
+  const noSpaceBreaksSplits = chunk.doubleBreak
+    ? noSpaceDoubleBreakSplits
+    : noSpaceSplits;
 
   if (chunk.type === 'REGULAR') {
     if (doesNotWantSpace(chunk, nextChunk) && chunk.noBreak)
       return noSpaceNoBreakSplit;
-    if (doesNotWantSpace(chunk, nextChunk)) return noSpaceBreaksSplit;
+    if (doesNotWantSpace(chunk, nextChunk)) return noSpaceBreaksSplits;
     if (chunk.noBreak) return noBreakSplit;
   }
 
-  const standardBreaksSplit = chunk.doubleBreak ? doubleBreakSplits : standardSplits;
-  return standardBreaksSplit;
+  const standardBreaksSplits = chunk.doubleBreak
+    ? doubleBreakStandardSplits
+    : standardSplits;
+  return standardBreaksSplits;
 }
 
 function chunkListToChoices(chunkList: Chunk[]): Choice[] {
@@ -358,7 +364,7 @@ const standardSplits: Split[] = [
   { splitType: ' ', cost: 0 },
   { splitType: '\n', cost: 1 },
 ];
-const doubleBreakSplits: Split[] = [
+const doubleBreakStandardSplits: Split[] = [
   { splitType: ' ', cost: 0 },
   { splitType: '\n\n', cost: 1 },
 ];

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -21,7 +21,7 @@ const INDENTATION = 2;
 const showGroups = false;
 
 export interface Split {
-  splitType: ' ' | '\n' | '\n\n' | '';
+  splitType: ' ' | '' | '\n' | '\n\n';
   cost: number;
 }
 

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -73,6 +73,7 @@ interface FinalResultWithPos {
 type FinalResult = string | FinalResultWithPos;
 
 const openingCharacters = [CypherCmdLexer.LPAREN, CypherCmdLexer.LBRACKET];
+
 const standardSplits: Split[] = [
   { splitType: ' ', cost: 0 },
   { splitType: '\n', cost: 1 },

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -280,7 +280,10 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
     if (showGroups) addGroupEnd(buffer, decision);
     buffer.push(decision.chosenSplit.splitType);
   });
-  const result = buffer.join('').trimEnd();
+  let result = buffer.join('').trimEnd();
+  if (decisions.at(-1).left.text === '\n') {
+    result += '\n';
+  }
   if (cursorPos === -1) {
     return result;
   }

--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -291,28 +291,25 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
 }
 
 function determineSplits(chunk: Chunk, nextChunk: Chunk): Split[] {
-  const onlyBreaksSplit = chunk.doubleBreak
-    ? onlyDoubleBreakSplit
-    : onlyBreakSplit;
   if (isCommentBreak(chunk, nextChunk)) {
-    return onlyBreaksSplit;
+    return chunk.doubleBreak ? onlyDoubleBreakSplit : onlyBreakSplit;
   }
-
-  const noSpaceBreaksSplits = chunk.doubleBreak
-    ? noSpaceDoubleBreakSplits
-    : noSpaceSplits;
 
   if (chunk.type === 'REGULAR') {
-    if (doesNotWantSpace(chunk, nextChunk) && chunk.noBreak)
-      return noSpaceNoBreakSplit;
-    if (doesNotWantSpace(chunk, nextChunk)) return noSpaceBreaksSplits;
-    if (chunk.noBreak) return noBreakSplit;
+    const noSpace = doesNotWantSpace(chunk, nextChunk);
+
+    if (noSpace) {
+      if (chunk.noBreak) {
+        return noSpaceNoBreakSplit;
+      }
+      return chunk.doubleBreak ? noSpaceDoubleBreakSplits : noSpaceSplits;
+    }
+    if (chunk.noBreak) {
+      return noBreakSplit;
+    }
   }
 
-  const standardBreaksSplits = chunk.doubleBreak
-    ? doubleBreakStandardSplits
-    : standardSplits;
-  return standardBreaksSplits;
+  return chunk.doubleBreak ? doubleBreakStandardSplits : standardSplits;
 }
 
 function chunkListToChoices(chunkList: Chunk[]): Choice[] {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -187,6 +187,15 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  doubleBreakBetweenNonComment = (): void => {
+    if (
+      this.currentBuffer().length > 0 &&
+      this.currentBuffer().at(-1).type !== 'COMMENT'
+    ) {
+      this.currentBuffer().at(-1).doubleBreak = true;
+    }
+  };
+
   getFirstNonCommentIdx = (): number => {
     let idx = this.currentBuffer().length - 1;
     while (idx >= 0 && this.currentBuffer()[idx].type === 'COMMENT') {
@@ -249,7 +258,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     ).length;
     // If there are comments, they take responsibility of the explicit newlines.
     if (hiddenNewlines > 1 && commentCount === 0) {
-      this.doubleBreakBetween();
+      this.doubleBreakBetweenNonComment();
     }
   };
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -235,14 +235,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const commentCount = hiddenTokens?.filter(token => isComment(token)).length;
     // If there are comments, they take responsibility of the explicit newlines.
     if (hiddenNewlines > 1 && commentCount === 0) {
-      this.currentBuffer().push({
-        type: 'REGULAR',
-        groupsStarting: 0,
-        groupsEnding: 0,
-        modifyIndentation: 0,
-        text: '\n',
-        node: null,
-      })
+      this.doubleBreakBetween();
     }
   }
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -141,6 +141,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const chunk: RegularChunk = {
       type: 'REGULAR',
       text: prefix.text + suffix.text,
+      doubleBreak: suffix.doubleBreak,
       groupsStarting: prefix.groupsStarting + suffix.groupsStarting,
       groupsEnding: prefix.groupsEnding + suffix.groupsEnding,
       modifyIndentation: prefix.modifyIndentation + suffix.modifyIndentation,

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -113,6 +113,17 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  softBreakLine = () => {
+    this.currentBuffer().push({
+      type: 'REGULAR',
+      groupsStarting: 0,
+      groupsEnding: 0,
+      modifyIndentation: 0,
+      text: '\n',
+      node: null,
+    })
+  }
+
   // If two tokens should never be split, concatenate them into one chunk
   concatenate = () => {
     // Loop since we might have multiple comments or special chunks anywhere, e.g. [b, C, C, a, C]
@@ -270,11 +281,12 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const hiddenTokens = this.tokenStream.getHiddenTokensToRight(
       token.tokenIndex,
     );
-    const commentTokens = (hiddenTokens || []).filter((token) =>
-      isComment(token),
-    );
     const nodeLine = node.symbol.line;
-    for (const commentToken of commentTokens) {
+    for (const hiddenToken of hiddenTokens || []) {
+      if (!isComment(hiddenToken)) {
+        continue;
+      }
+      const commentToken = hiddenToken;
       const text = commentToken.text.trim();
       const commentLine = commentToken.line;
       const chunk: CommentChunk = {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -294,6 +294,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     );
     const nodeLine = node.symbol.line;
     let breakCount = 0;
+    let includesComment = false;
     for (const hiddenToken of hiddenTokens || []) {
       if (hiddenToken.text === '\n') {
         breakCount++;
@@ -306,6 +307,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       }
       breakCount = 0;
       const commentToken = hiddenToken;
+      includesComment = true;
       const text = commentToken.text.trim();
       const commentLine = commentToken.line;
       const chunk: CommentChunk = {
@@ -326,6 +328,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         }
       }
       this.currentBuffer().push(chunk);
+    }
+    if (breakCount > 1 && includesComment) {
+      this.doubleBreakBetween();
     }
   };
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -310,6 +310,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  visitStatementsOrCommands = (ctx: StatementsOrCommandsContext) => {
+    const n = ctx.statementOrCommand_list().length;
+    for (let i = 0; i < n; i++) {
+      this.visit(ctx.statementOrCommand(i));
+      if (i < n - 1 || ctx.SEMICOLON(i)) {
+        if (this.currentBuffer().at(-1).text === '\n') {
+          this.currentBuffer().pop();
+        }
+        this.visit(ctx.SEMICOLON(i));
+      }
+    }
+  }
+
   // Handled separately because clauses should start on new lines, see
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
   visitClause = (ctx: ClauseContext) => {

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1237,6 +1237,7 @@ CREATE (qwer_tyuiopa_zxcvbnmasdfg)-[:abcdefgh]->(qwertyu),
        (mnbvcxzasdfghj_poiuytrewq)-[:GHIJKLMN]->(zxcvbnmlkjhgfd_asdfjkl),
        (zxcvbnmlkjhgfd_asdfjkl)-[:OPQRS_TU]->(qwertyu),
        (qwert_yuiopasdfg)-[:OPQRS_TU]->(qwertyu),
+
        // this is a loooooooooooooooooooong comment
        (hjklmno)-[:OPQRS_TU]->(zxcvbn_mnb_lkjhgfdsa),
        (zxcvbn_mnb_lkjhgfdsa)-[:OPQRS_TU]->(poiuzxcv),
@@ -1244,9 +1245,11 @@ CREATE (qwer_tyuiopa_zxcvbnmasdfg)-[:abcdefgh]->(qwertyu),
        (asdfghjk_qwe)-[:OPQRS_TU]->(zxcvbnmop),
        (zxcvbnmop)-[:OPQRS_TU]->(qwertyu),
        (zxcvbnmop)-[:VWXYZABC]->(qwertyuiopa_sdfghjklz),
+
        // this is a loooooooooooooooooooong comment
        (mnbvcxzlkj)-[:VWXYZABC]->(asdfg_hjkltyui),
        (mnbvcxzlkj)-[:VWXYZABC]->(qwertyuiopa_sdfghjklz),
+
        // this is a loooooooooooooooooooong comment
        (mnbvcxzasdfghj_poiuytrewq)-[:YZABCDF]->(asdfghj_klzxcvbnmop),
        (mnbvcxzasdfghj_poiuytrewq)-[:DEFHIJKL]->(qazwsxedc_rfvgt),
@@ -1776,6 +1779,16 @@ RETURN n`;
 MATCH (n)
 
 RETURN n`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('this comment should leave a newline before it', () => {
+    const query = `
+MATCH (n)
+
+// Comment
+RETURN n`.trimStart();
+    const expected = query;
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1791,4 +1791,60 @@ RETURN n`.trimStart();
     const expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('another long example with clauses and comments', () => {
+    const query = `MERGE (qwerty:Abcdef {name: "ABCDEFGH"})
+// Xyzzab qwe POIUYTREWQ poiuy rty uio MNBVCXZ
+MERGE (A1B2C3D4E5:Qwert {name: "IJKLMNOP"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "abcdefgh"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "ijklmnop"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "qrstuvwx"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "yzABCDEF"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "GHIJKLMN"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "opqrstuv"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "wxyz0123"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "456789ab"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "cdefghij"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "klmnopqr"})
+MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "stuvwxyz"})
+MERGE (qwerty)-[:PLMKOIJNBHUY]->(A1B2C3D4E5)
+
+// Abcdef ghi ZxcvbnmQwertyz uiopa sdx fgh jklzxcv
+MERGE (F6G7H8J9K0L1M2:Qwert {name: "ZXCVBNML"})
+MERGE (F6G7H8J9K0L1M2)-[:QAZWSXEDCR]->(:Zxcvbn {name: "asdfghjk"})
+MERGE (F6G7H8J9K0L1M2)-[:QAZWSXEDCR]->(:Zxcvbn {name: "poiuytre"})
+MERGE (qwerty)-[:PLMKOIJNBHUY]->(F6G7H8J9K0L1M2)
+
+MERGE (ZyXwVuTsr:Qwert {name: "lkjhgfds"})
+MERGE (ZyXwVuTsr)-[:QAZWSXEDCR]->(:Zxcvbn {name: "mnbvcxza"})
+MERGE (ZyXwVuTsr)-[:QAZWSXEDCR]->(:Zxcvbn {name: "qwertyui"})
+MERGE (qwerty)-[:PLMKOIJNBHUY]->(ZyXwVuTsr)
+
+// Fghijk lmn QWERTYUIOPASDFGHJ KJIHG QAZ WSX EDCRFVT
+MERGE (QWERTYUIOPASDFGHJ:Qwert {name: "1234abcd"})
+MERGE (QWERTYUIOPASDFGHJ)-[:QAZWSXEDCR]->(:Zxcvbn {name: "efghijkl"})
+MERGE (QWERTYUIOPASDFGHJ)-[:QAZWSXEDCR]->(:Zxcvbn {name: "mnopqrst"})
+MERGE (QWERTYUIOPASDFGHJ)-[:QAZWSXEDCR]->(:Zxcvbn {name: "uvwxYZ12"})
+MERGE (QWERTYUIOPASDFGHJ)-[:QAZWSXEDCR]->(:Zxcvbn {name: "34567890"})
+MERGE (qwerty)-[:PLMKOIJNBHUY]->(QWERTYUIOPASDFGHJ)
+
+// Lmnopq rst UVWXYZABCDEFG NOPQR STU VWX YZABCDF
+MERGE (LMNOPQRSTUVWX:Qwert {name: "zxvbnmlk"})
+MERGE (LMNOPQRSTUVWX)-[:QAZWSXEDCR]->(:Zxcvbn {name: "opaslkdj"})
+MERGE (LMNOPQRSTUVWX)-[:QAZWSXEDCR]->(:Zxcvbn {name: "qwerty12"})
+MERGE (qwerty)-[:PLMKOIJNBHUY]->(LMNOPQRSTUVWX)
+
+// uvwxyz efg lmno pqrstuvwxyzab
+MERGE (pqr45:Qwer {name: "asdf1234", type: "zxcv5678"})
+MERGE (LMNOPQRSTUVWX)-[:ZXCVB]->(pqr45)-[:ZXCVB]->(A1B2C3D4E5)
+MERGE (qwerty)-[:ASDFGHJKL]->(pqr45)
+MERGE (stu78:Qwer {name: "poiuy987", type: "lkjh6543"})
+MERGE (A1B2C3D4E5)-[:ZXCVB]->(stu78)-[:ZXCVB]->(F6G7H8J9K0L1M2)
+MERGE (qwerty)-[:ASDFGHJKL]->(stu78)
+MERGE (vwx90:Qwer {name: "mnbv3210", type: "zazxswed"})
+MERGE (A1B2C3D4E5)-[:ZXCVB]->(vwx90)-[:ZXCVB]->(ZyXwVuTsr)
+MERGE (qwerty)-[:ASDFGHJKL]->(vwx90)`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1810,6 +1810,7 @@ MERGE (A1B2C3D4E5)-[:QAZWSXEDCR]->(:Zxcvbn {name: "stuvwxyz"})
 MERGE (qwerty)-[:PLMKOIJNBHUY]->(A1B2C3D4E5)
 
 // Abcdef ghi ZxcvbnmQwertyz uiopa sdx fgh jklzxcv
+
 MERGE (F6G7H8J9K0L1M2:Qwert {name: "ZXCVBNML"})
 MERGE (F6G7H8J9K0L1M2)-[:QAZWSXEDCR]->(:Zxcvbn {name: "asdfghjk"})
 MERGE (F6G7H8J9K0L1M2)-[:QAZWSXEDCR]->(:Zxcvbn {name: "poiuytre"})
@@ -1829,12 +1830,14 @@ MERGE (QWERTYUIOPASDFGHJ)-[:QAZWSXEDCR]->(:Zxcvbn {name: "34567890"})
 MERGE (qwerty)-[:PLMKOIJNBHUY]->(QWERTYUIOPASDFGHJ)
 
 // Lmnopq rst UVWXYZABCDEFG NOPQR STU VWX YZABCDF
+
 MERGE (LMNOPQRSTUVWX:Qwert {name: "zxvbnmlk"})
 MERGE (LMNOPQRSTUVWX)-[:QAZWSXEDCR]->(:Zxcvbn {name: "opaslkdj"})
 MERGE (LMNOPQRSTUVWX)-[:QAZWSXEDCR]->(:Zxcvbn {name: "qwerty12"})
 MERGE (qwerty)-[:PLMKOIJNBHUY]->(LMNOPQRSTUVWX)
 
 // uvwxyz efg lmno pqrstuvwxyzab
+
 MERGE (pqr45:Qwer {name: "asdf1234", type: "zxcv5678"})
 MERGE (LMNOPQRSTUVWX)-[:ZXCVB]->(pqr45)-[:ZXCVB]->(A1B2C3D4E5)
 MERGE (qwerty)-[:ASDFGHJKL]->(pqr45)
@@ -1993,6 +1996,16 @@ WHERE (
           b.AbCdEfGhIjKlMn > "QwErTyUi"))
 // AND b.LmNo_PqRsTuV = e1.LmNo_PqRsTuV
 RETURN a, b, d, e1, zYxWvUtSrqP`;
+    verifyFormatting(query, expected);
+  });
+
+  test('should preserve newlines also after a comment', () => {
+    const query = `
+MATCH (n)
+// Comment, please preserve the line below
+
+RETURN n`.trimStart();
+    const expected = query;
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1921,4 +1921,22 @@ MATCH (a)
 RETURN a`.trimStart();
     verifyFormatting(query, expected);
   });
+
+  test('should remove the first but not the second newline, and keep indentation', () => {
+    const query = `
+MERGE (a:Person {name: "Alice"})
+
+ON CREATE SET a.created = timestamp()
+ON MATCH SET a.lastSeen = timestamp()
+
+RETURN a
+`.trimStart();
+    const expected = `
+MERGE (a:Person {name: "Alice"})
+  ON CREATE SET a.created = timestamp()
+  ON MATCH SET a.lastSeen = timestamp()
+
+RETURN a`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -467,19 +467,12 @@ LIMIT 0`;
 
   test('call with IN CONCURRENT... at the end', () => {
     const query = `MATCH (c:Cuenta)-[:REALIZA]->(m:Movimiento)-[:HACIA]->(c2:Cuenta)
-
 WHERE NOT EXISTS {MATCH (c)-[:TRANSFIERE]->(c2)}
-
 WITH c, c2, count(m) as trxs, avg(m.monto) as avgTrx, sum(m.monto) as totalSum LIMIT 1000
-
 CALL (c, c2, trxs, avgTrx, totalSum) {
-
     MERGE (c)-[r:TRANSFIERE]->(c2)
-
     ON CREATE SET r.totalTrx = trxs, r.avgTrx = avgTrx, r.total = totalSum
-
     ON MATCH SET r.totalTrx = trxs, r.avgTrx = avgTrx, r.total = totalSum
-
 } IN 10 CONCURRENT TRANSACTIONS OF 25 ROWS
 
 ;`;

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1939,4 +1939,60 @@ MERGE (a:Person {name: "Alice"})
 RETURN a`.trimStart();
     verifyFormatting(query, expected);
   });
+
+  test('this query should not lose idempotency because of double break and concatenate', () => {
+    const query = `MATCH (a:AbCdEf {XyZ012345: "ABCDEFGH"})
+
+MATCH (a)-[b:ZxCvBnMq]->(d:GhIjKlM)<-[e1:ZxCvBnMq]-(zYxWvUtSrqP:AbCdEf)
+WHERE (
+  // abcdefghijklmnopqrstuvwxy
+  (b.AbCdEfGhIjKlMn <= "1A2b3C4d")
+
+  // Qwertyuiopasdfghjklzxcvbnm1234567890AB
+  OR (
+      e1.OpQrStUvW >= "Z9y8X7w6"
+      AND b.AbCdEfGhIjKlMn in ["aBcDeFgH","IjKlMnOp"]
+  )
+
+  // QazwsxedcrfvtgbyhnujmikolpASDFGHJKLQWERTYUIOPZXCVBNM1234567abcdefghij
+  OR (
+      b.OpQrStUvW <= e1.OpQrStUvW
+      AND e1.OpQrStUvW >= "QrStUvWx"
+      AND b.AbCdEfGhIjKlMn in ["YzXwVuTs","LmNoPqRs"]
+      // AND b.LmNo_PqRsTuV = e1.LmNo_PqRsTuV
+  )
+
+  // 0123456789abcdefghijKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVW
+  OR (
+      b.OpQrStUvW = e1.OpQrStUvW
+      AND e1.OpQrStUvW >= "StUvWxYz"
+      AND b.AbCdEfGhIjKlMn > "QwErTyUi"
+      // AND b.LmNo_PqRsTuV = e1.LmNo_PqRsTuV
+  )
+)
+
+RETURN a, b, d, e1, zYxWvUtSrqP`;
+    const expected = `MATCH (a:AbCdEf {XyZ012345: "ABCDEFGH"})
+
+MATCH (a)-[b:ZxCvBnMq]->(d:GhIjKlM)<-[e1:ZxCvBnMq]-(zYxWvUtSrqP:AbCdEf)
+WHERE (
+      // abcdefghijklmnopqrstuvwxy
+      (b.AbCdEfGhIjKlMn <= "1A2b3C4d")
+
+      // Qwertyuiopasdfghjklzxcvbnm1234567890AB
+      OR (e1.OpQrStUvW >= "Z9y8X7w6" AND
+          b.AbCdEfGhIjKlMn IN ["aBcDeFgH", "IjKlMnOp"])
+
+      // QazwsxedcrfvtgbyhnujmikolpASDFGHJKLQWERTYUIOPZXCVBNM1234567abcdefghij
+      OR (b.OpQrStUvW <= e1.OpQrStUvW AND e1.OpQrStUvW >= "QrStUvWx" AND
+          b.AbCdEfGhIjKlMn IN ["YzXwVuTs", "LmNoPqRs"])
+      // AND b.LmNo_PqRsTuV = e1.LmNo_PqRsTuV
+
+      // 0123456789abcdefghijKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVW
+      OR (b.OpQrStUvW = e1.OpQrStUvW AND e1.OpQrStUvW >= "StUvWxYz" AND
+          b.AbCdEfGhIjKlMn > "QwErTyUi"))
+// AND b.LmNo_PqRsTuV = e1.LmNo_PqRsTuV
+RETURN a, b, d, e1, zYxWvUtSrqP`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1847,4 +1847,78 @@ MERGE (qwerty)-[:ASDFGHJKL]->(vwx90)`;
     const expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('double newline before block comment', () => {
+    const query = `
+MATCH (a)
+
+
+/* block comment */
+RETURN a`;
+    const expected = `
+MATCH (a)
+
+/* block comment */
+RETURN a`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('inline block comment with internal newlines', () => {
+    const query = `
+MATCH (a)
+RETURN a; /* comment line 1
+
+comment line 2 */
+MATCH (b)
+RETURN b;`;
+    const expected = `
+MATCH (a)
+RETURN a; /* comment line 1
+
+comment line 2 */
+MATCH (b)
+RETURN b;`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('multiline block comment with line before it', () => {
+    const query = `
+MATCH (a)
+RETURN a;
+
+/* comment line 1
+
+
+comment line 3 */
+MATCH (b)
+RETURN b;`;
+    const expected = `
+MATCH (a)
+RETURN a;
+
+/* comment line 1
+
+
+comment line 3 */
+MATCH (b)
+RETURN b;`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('mixed comments with explicit newline', () => {
+    const query = `
+MATCH (a)
+// single line comment
+
+
+/* block comment */
+RETURN a`.trimStart();
+    const expected = `
+MATCH (a)
+// single line comment
+
+/* block comment */
+RETURN a`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -2008,4 +2008,15 @@ RETURN n`.trimStart();
     const expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('should keep the logical delimiter the user has made intact', () => {
+    const query = `
+MATCH (n)
+
+// === THIS IS THE START OF THE RETURN STATEMENT ===
+
+RETURN n`.trimStart();
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
## Description

Multiple people who have tried out the V1 formatter commented on the fact that it does not preserve the explicit newlines they have placed in their queries. So, for instance, this query
```
MATCH (n)

// Return the node
RETURN n
```
would get formatted to this:

```
MATCH (n)
// Return the node
RETURN n
```
Which can be quite annoying if you've tried to separate some things logically by inserting that newline. Prettier also preserves these explicit newlines, e.g. if you have this 

```
 const traillingCharacters = [
  CypherCmdLexer.SEMICOLON,

  CypherCmdLexer.COMMA,
  CypherCmdLexer.COLON,
  CypherCmdLexer.RPAREN,
  CypherCmdLexer.RBRACKET,
];
```
it will not remove the newline after the first list item. If there are two or more newlines however, they are reduced to just one.

This PR adds support for preserving these explicit newlines, by checking for more than one \n in these three places

1. After the end of a clause
2. Before a comment
3. After a comment

If two or more are found, we set the chunk to "double break", meaning its split choices will now contain \n\n instead of \n.

### Testing 

- ~13 new tests for these cases, had to fix some old tests as well
- Ran the verify check on 100k queries and all but two passed, which is the same result as on main. There does seem to be a bug with comments where they get duplicated or disappear however. We are tracking that on trello and will fix it in a separate PR since it's not related to this.