### PR TITLE
Increases cache key granularity in formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -188,7 +188,9 @@ function reconstructBestPath(state: State): Result {
 }
 
 function getStateKey(state: State): string {
-  return `${state.column}-${state.choiceIndex}`;
+  return `${state.column}-${state.choiceIndex}-${
+    state.activeGroups.at(-1)?.align
+  }`;
 }
 
 function bestFirstSolnSearch(

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1102,10 +1102,10 @@ WHERE p.price > 1000 AND p.stock > 50 AND
 RETURN p`;
     const expected = `MATCH (p:Product)
 WHERE p.price > 1000 AND p.stock > 50 AND
-      p.category IN ['Electronics', 'Home Appliances', 'Garden Tools',
-                     'Sports Equipment', 'Automotive Parts',
-                     'Fashion Accessories', 'Books', 'Toys', 'Jewelry',
-                     'Musical Instruments', 'Art Supplies', 'Office Supplies']
+      p.category IN
+      ['Electronics', 'Home Appliances', 'Garden Tools', 'Sports Equipment',
+       'Automotive Parts', 'Fashion Accessories', 'Books', 'Toys', 'Jewelry',
+       'Musical Instruments', 'Art Supplies', 'Office Supplies']
 RETURN p`;
     verifyFormatting(query, expected);
   });


### PR DESCRIPTION
## Description
As mentioned in the original V2 PR (#369), our caching of states is not perfect. One manifestation of this is the fact that function invocations with long namespaces rarely find their best solution. As an example, consider this query, which has been formatted with the current caching/memoization:

```
MATCH (userAccountInfo:UserAccountInformation)
WITH userAccountInfo, apoc.util.validate(NOT userAccountInfo.isVerified,
                                         'Verification Error: The user account with unique identifier '
                                         +
                                         userAccountInfo.accountUniqueIdentifier
                                         + ' has not completed the mandatory ' +
                                         'verification process required for accessing premium features. '
                                         +
                                         // The line below goes all the way to 142 (!!!)
                                         'Please review your verification email and follow the provided instructions to secure your account.',
                                         [userAccountInfo.accountUniqueIdentifier,
                                          userAccountInfo.emailAddress])
                      AS verificationStatus
RETURN userAccountInfo;
```
Clearly, the formatter should find a solution which splits after `userAccountInfo`, and then again after `validate(`. But it doesn't, because the memoization is an approximation rather than an exact representation of the state. This PR adds the alignment of the last active group to the state/cache key, which greatly reduces the risk of the best-first search skipping an optimal state. This increases the granularity of the cache key, which increases the theoretical time complexity from `O(n*MAX_COL)` to `O(n*MAX_COL^2)`, so in theory 80 times slower. But consider the same query, now formatted with this new caching:


```
MATCH (userAccountInfo:UserAccountInformation)
WITH userAccountInfo,
     apoc.util.validate(
     NOT userAccountInfo.isVerified,
     'Verification Error: The user account with unique identifier '
     + userAccountInfo.accountUniqueIdentifier +
     ' has not completed the mandatory ' +
     'verification process required for accessing premium features. ' +
     'Please review your verification email and follow the provided instructions to secure your account.',
     [userAccountInfo.accountUniqueIdentifier, userAccountInfo.emailAddress])
     AS verificationStatus
RETURN userAccountInfo;
```
_Note: There is also a bug where the function arguments should align with the opening `(`, that will be fixed in an upcoming PR. Making that work required increasing the cache granularity, and I wanted to make this it's own PR since baking that change in at the same time doesn't feel right._


This is clearly the solution you would expect it to find, as it leaves far fewer characters out of bounds.

## Performance
Of course, there is no such thing as a free lunch. The increased granularity comes at the cost of some performance. But I would like to argue that the performance cost is not significant enough in comparison to the improvement in quality. I measured the time it took to format the first 10000 sample queries we have, and these were the results:

```
// With the increased granularity
~/.../src/formatting (fixprocedurecalls) $ time ts-node verify.ts
Successfully formatted 9507 queries out of 9507

real    0m50.385s
user    1m1.759s
sys     0m1.418s


// Current state / baseline
~/.../src/formatting (fixprocedurecalls) $ time ts-node verify.ts
Successfully formatted 9507 queries out of 9507

real    0m37.028s
user    0m45.489s
sys     0m0.921s
```
It's an increase of about `35%` which, while not great, certainly beats having the abomination shown above. This would bring our average formatting time for queries (based on the numbers above) from `3.7ms` to `5ms`. That's still far below any painful thresholds for the use case we're currently serving (the button in Query), and we still haven't done any thorough performance optimizations whatsoever.

## Testing
- Fixed one test which now finds a better (read: "lower cost") solution.
   - I have an upcoming PR which introduces some more namespaced function call tests which will depend on this PR.