### PR TITLE
Adds neo4j+ssc and bolt+ssc as connection options

### DIFF
--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -13,7 +13,13 @@ import { connectionTreeDataProvider } from './treeviews/connectionTreeDataProvid
 import { databaseInformationTreeDataProvider } from './treeviews/databaseInformationTreeDataProvider';
 import { displayMessageForConnectionResult } from './uiUtils';
 
-export type Scheme = 'neo4j' | 'neo4j+s' | 'bolt' | 'bolt+s';
+export type Scheme =
+  | 'neo4j'
+  | 'neo4j+s'
+  | 'neo4j+ssc'
+  | 'bolt'
+  | 'bolt+s'
+  | 'bolt+ssc';
 
 export type State = 'inactive' | 'activating' | 'active' | 'error';
 

--- a/packages/vscode-extension/src/webviews/connectionPanel.ts
+++ b/packages/vscode-extension/src/webviews/connectionPanel.ts
@@ -224,6 +224,11 @@ export class ConnectionPanel {
                             ? 'selected'
                             : ''
                         }>bolt+s://</option>
+                        <option value="bolt+ssc" ${
+                          this._connection?.scheme === 'bolt+ssc'
+                            ? 'selected'
+                            : ''
+                        }>bolt+ssc://</option>
                         <option value="neo4j" ${
                           this._connection?.scheme === 'neo4j' ||
                           !this._connection
@@ -235,6 +240,11 @@ export class ConnectionPanel {
                             ? 'selected'
                             : ''
                         }>neo4j+s://</option>
+                        <option value="neo4j+ssc" ${
+                          this._connection?.scheme === 'neo4j+ssc'
+                            ? 'selected'
+                            : ''
+                        }>neo4j+ssc://</option>
                     </select>
                   </div>
                   <div class="form--input-wrapper">

--- a/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
+++ b/packages/vscode-extension/src/webviews/controllers/connectionPanelController.ts
@@ -92,7 +92,14 @@ export function getConnection(): Connection | null {
  * @returns True if the string is a valid Scheme, false otherwise.
  */
 export function isValidScheme(scheme: string): scheme is Scheme {
-  return ['neo4j', 'neo4j+s', 'bolt', 'bolt+s'].includes(scheme);
+  return [
+    'neo4j',
+    'neo4j+s',
+    'neo4j+ssc',
+    'bolt',
+    'bolt+s',
+    'bolt+ssc',
+  ].includes(scheme);
 }
 
 /**


### PR DESCRIPTION
We got an issue from a user wanting to connect with ssc. This option adds that. For me, connecting with a ssc-supporting server with the new options worked, while connecting with a non-ssc server didnt, so looks good i suppose, but please do double check that it works for you :)

Closes #350