### PR TITLE
Fixes function invocation alignment in formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearchv2.ts
@@ -188,7 +188,9 @@ function reconstructBestPath(state: State): Result {
 }
 
 function getStateKey(state: State): string {
-  return `${state.column}-${state.choiceIndex}`;
+  return `${state.column}-${state.choiceIndex}-${
+    state.activeGroups.at(-1)?.align
+  }`;
 }
 
 function bestFirstSolnSearch(

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -926,9 +926,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.endGroup(functionNameGrp);
     this.avoidSpaceBetween();
     this.avoidBreakBetween();
-    const invocationGrp = this.startGroup();
     this.visit(ctx.LPAREN());
     this.avoidBreakBetween();
+    const invocationGrp = this.startGroup();
     if (ctx.DISTINCT() || ctx.ALL()) {
       this.avoidSpaceBetween();
     }

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -1129,8 +1129,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.visit(ctx.LCURLY());
     this.avoidSpaceBetween();
-    this.avoidBreakBetween();
-    const mapProjectionGrp = this.startGroup();
     const n = ctx.mapProjectionElement_list().length;
     // Not sure if these should have groups around them?
     // Haven't been able to find a case where it matters so far.
@@ -1141,7 +1139,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       }
     }
     this.avoidSpaceBetween();
-    this.endGroup(mapProjectionGrp);
     this.visit(ctx.RCURLY());
   };
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -921,9 +921,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitFunctionInvocation = (ctx: FunctionInvocationContext) => {
+    const functionNameGrp = this.startGroup();
     this.visit(ctx.functionName());
+    this.endGroup(functionNameGrp);
+    this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    const invocationGrp = this.startGroup();
     this.visit(ctx.LPAREN());
-    this.concatenate(); // Don't separate the function name and the (
     if (ctx.DISTINCT() || ctx.ALL()) {
       this.avoidSpaceBetween();
     }
@@ -945,6 +949,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.visit(ctx.RPAREN());
     this.endGroup(allFunctionArgsGrp);
+    this.endGroup(invocationGrp);
   };
 
   // Handled separately because we want ON CREATE before ON MATCH
@@ -1013,6 +1018,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.visit(ctx.LCURLY());
     this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    const mapProjectionGrp = this.startGroup();
     const n = ctx.mapProjectionElement_list().length;
     // Not sure if these should have groups around them?
     // Haven't been able to find a case where it matters so far.
@@ -1023,6 +1030,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       }
     }
     this.avoidSpaceBetween();
+    this.endGroup(mapProjectionGrp);
     this.visit(ctx.RCURLY());
   };
 

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -928,6 +928,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.avoidBreakBetween();
     const invocationGrp = this.startGroup();
     this.visit(ctx.LPAREN());
+    this.avoidBreakBetween();
     if (ctx.DISTINCT() || ctx.ALL()) {
       this.avoidSpaceBetween();
     }

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -753,7 +753,7 @@ RETURN n`;
     verifyFormatting(query, expected);
   });
 
-  test('aligns and breaks long namespaced functions well', () => {
+  test('aligns and breaks long namespaced functions well 1', () => {
     const query = `MATCH (u:User)
 WITH u, apoc.util.validate(u.status <> 'active', 'User ' + u.username + ' does not have an active status which is required for processing the requested operation. ' + 'Please check the user account settings for further details.', [u.id, u.username]) AS validation
 RETURN u;`;
@@ -766,6 +766,43 @@ WITH u,
               + 'Please check the user account settings for further details.',
               [u.id, u.username]) AS validation
 RETURN u;`;
+    verifyFormatting(query, expected);
+  });
+
+  test('aligns and breaks long namespaced functions well 2', () => {
+    const query = `MATCH (userAccountInfo:UserAccountInformation)
+WITH userAccountInfo,
+     apoc.util.
+     validate(NOT userAccountInfo.isVerified,
+              'Verification Error: The user account with unique identifier ' +
+              userAccountInfo.accountUniqueIdentifier +
+              ' has not completed the mandatory ' +
+              'verification process required for accessing premium features. ' +
+              'Please review your verification email and follow the provided instructions to secure your account.',
+              [userAccountInfo.accountUniqueIdentifier,
+               userAccountInfo.emailAddress]) AS verificationStatus
+RETURN userAccountInfo;`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+
+  test('aligns and breaks long namespaced functions well 3', () => {
+    const query = `MATCH (inventoryRecord:ProductInventoryTrackingInformation)
+WITH inventoryRecord,
+     apoc.util.
+     validate(inventoryRecord.currentStock
+              < inventoryRecord.criticalThresholdStock,
+              'Alert: The inventory record for product SKU '
+              + inventoryRecord.productSKU
+              + ' indicates a current stock level of '
+              + toString(inventoryRecord.currentStock)
+              + ', which is below the critical threshold of ' +
+              toString(inventoryRecord.criticalThresholdStock) +
+              '. Immediate replenishment is required to avoid stockouts and maintain supply chain stability.',
+              [inventoryRecord.productSKU, inventoryRecord.currentStock])
+     AS stockValidation
+RETURN inventoryRecord;`;
+    const expected = query;
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -847,40 +847,6 @@ RETURN inventoryRecord;`;
     verifyFormatting(query, expected);
   });
 
-  test('comments should not start replicating themselves', () => {
-    const query = `CALL gds.graph.project(
-    "qk5jpmGl",           // Name of the projected graph
-    ["TB4Tvv6q", "2iCI1Rll", "kaLEqBxX"], // Node labels to include
-    {
-        connection: {
-            type: "R3e8WLkh",            // Include all relationships
-            orientation: "weFW44Gy" // Treat relationships as undirected
-        }
-    }
-)
-YIELD graphName, nodeCount, relationshipCount, createMillis
-RETURN graphName, nodeCount, relationshipCount, createMillis;`;
-    const expected = `CALL gds.graph.project("qk5jpmGl", // Name of the projected graph
-                       ["TB4Tvv6q", "2iCI1Rll", "kaLEqBxX"], // Node labels to include
-                       {connection: {type: "R3e8WLkh", // Include all relationships
-                                     orientation: "weFW44Gy"}}) // Treat relationships as undirected
-YIELD graphName, nodeCount, relationshipCount, createMillis
-RETURN graphName, nodeCount, relationshipCount, createMillis;`;
-    verifyFormatting(query, expected);
-  });
-
-  test('comment should not disappear in this query', () => {
-    const query = `MATCH (n)
-WITH *, n.prop, // This comment should not disappear
-     n.otherprop
-RETURN n`;
-    const expected = `MATCH (n)
-WITH *, n.prop, // This comment should not disappear
-     n.otherprop
-RETURN n`;
-    verifyFormatting(query, expected);
-  });
-
   test('should not find the wrong comma here', () => {
     const query = `CALL gds.nodeSimilarity.filtered.stream(
     "N5j8G3h2",

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -847,20 +847,6 @@ RETURN inventoryRecord;`;
     verifyFormatting(query, expected);
   });
 
-  test('should not find the wrong comma here', () => {
-    const query = `CALL gds.nodeSimilarity.filtered.stream(
-    "N5j8G3h2",
-    {
-        A3f7R: "Z2w8Q",
-        L9t4P: "Y3s1D"
-    }
-) YIELD *`;
-    const expected = `CALL gds.nodeSimilarity.filtered.stream("N5j8G3h2",
-                                        {A3f7R: "Z2w8Q", L9t4P: "Y3s1D"})
-YIELD *`;
-    verifyFormatting(query, expected);
-  });
-
   test('should not leave dangling bracket', () => {
     const query = `CREATE (company:Company
        {name: "mrUJWq6A", krs: "Yuu9Wl7d", registration_date: date("FrA1uHGX")

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -1254,10 +1254,10 @@ RETURN p`;
   });
   test('should align arguments of function invocation after opening bracket', () => {
     const query = `RETURN collect(create_this1 { datetime: apoc.date.convertFormat(toString(create_this1.datetime), "OZQvXyoU", "EhpkDy8g") }) AS data`;
-    const expected = `RETURN collect(create_this1
-               {datetime:
-                apoc.date.convertFormat(toString(create_this1.datetime),
-                                        "OZQvXyoU", "EhpkDy8g")}) AS data`;
+    const expected = `
+RETURN collect(create_this1 {datetime:
+               apoc.date.convertFormat(toString(create_this1.datetime),
+                                       "OZQvXyoU", "EhpkDy8g")}) AS data`.trimStart();
     verifyFormatting(query, expected);
   });
 

--- a/packages/language-support/src/tests/formatting/formattingv2.test.ts
+++ b/packages/language-support/src/tests/formatting/formattingv2.test.ts
@@ -752,6 +752,22 @@ RETURN n`;
 RETURN n`;
     verifyFormatting(query, expected);
   });
+
+  test('aligns and breaks long namespaced functions well', () => {
+    const query = `MATCH (u:User)
+WITH u, apoc.util.validate(u.status <> 'active', 'User ' + u.username + ' does not have an active status which is required for processing the requested operation. ' + 'Please check the user account settings for further details.', [u.id, u.username]) AS validation
+RETURN u;`;
+    const expected = `MATCH (u:User)
+WITH u,
+     apoc.util.
+     validate(u.status <> 'active',
+              'User ' + u.username +
+              ' does not have an active status which is required for processing the requested operation. '
+              + 'Please check the user account settings for further details.',
+              [u.id, u.username]) AS validation
+RETURN u;`;
+    verifyFormatting(query, expected);
+  });
 });
 
 // The @ represents the position of the cursor
@@ -1102,10 +1118,10 @@ WHERE p.price > 1000 AND p.stock > 50 AND
 RETURN p`;
     const expected = `MATCH (p:Product)
 WHERE p.price > 1000 AND p.stock > 50 AND
-      p.category IN ['Electronics', 'Home Appliances', 'Garden Tools',
-                     'Sports Equipment', 'Automotive Parts',
-                     'Fashion Accessories', 'Books', 'Toys', 'Jewelry',
-                     'Musical Instruments', 'Art Supplies', 'Office Supplies']
+      p.category IN
+      ['Electronics', 'Home Appliances', 'Garden Tools', 'Sports Equipment',
+       'Automotive Parts', 'Fashion Accessories', 'Books', 'Toys', 'Jewelry',
+       'Musical Instruments', 'Art Supplies', 'Office Supplies']
 RETURN p`;
     verifyFormatting(query, expected);
   });
@@ -1128,9 +1144,10 @@ RETURN p`;
   });
   test('should align arguments of function invocation after opening bracket', () => {
     const query = `RETURN collect(create_this1 { datetime: apoc.date.convertFormat(toString(create_this1.datetime), "OZQvXyoU", "EhpkDy8g") }) AS data`;
-    const expected = `RETURN collect(create_this1 {datetime: apoc.date.convertFormat(
-               toString(create_this1.datetime), "OZQvXyoU", "EhpkDy8g")})
-       AS data`;
+    const expected = `RETURN collect(create_this1
+               {datetime:
+                apoc.date.convertFormat(toString(create_this1.datetime),
+                                        "OZQvXyoU", "EhpkDy8g")}) AS data`;
     verifyFormatting(query, expected);
   });
 


### PR DESCRIPTION
## Description
As mentioned in PR #384, there is a bug with function invocation alignment where function arguments do not align with the opening `(`, and instead align with the namespace or the function name. This PR fixes the issue described, meaning that for instance this query goes from being formatted like this:
```
RETURN collect(create_this1 {datetime: apoc.date.convertFormat(
               toString(create_this1.datetime), "OZQvXyoU", "EhpkDy8g")})
       AS data
```
to being formatted like this:

```
RETURN collect(create_this1 {datetime:
               apoc.date.convertFormat(toString(create_this1.datetime),
                                       "OZQvXyoU", "EhpkDy8g")}) AS data
```
which is more consistent with how we usually format things.

### Testing
- Three new tests which ensure that the best solution for very tricky namespaced functions is found.
- Fixes the test described above