### PR TITLE
Fixes map projection alignment in formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -1123,17 +1123,18 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.visit(ctx.LCURLY());
     this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    const mapProjectionGrp = this.startGroup();
     const n = ctx.mapProjectionElement_list().length;
-    // Not sure if these should have groups around them?
-    // Haven't been able to find a case where it matters so far.
     for (let i = 0; i < n; i++) {
       this.visit(ctx.mapProjectionElement(i));
       if (i < n - 1) {
         this.visit(ctx.COMMA(i));
       }
     }
-    this.avoidSpaceBetween();
+    this.endGroup(mapProjectionGrp);
     this.visit(ctx.RCURLY());
+    this.concatenate();
   };
 
   visitListItemsPredicate = (ctx: ListItemsPredicateContext) => {

--- a/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
@@ -333,4 +333,26 @@ SET f.prime = "zt01uZOH"
 RETURN f`;
     verifyFormatting(query, expected);
   });
+
+  test('map projections should line up like maps 1', () => {
+    const query = `MATCH (p:Person {name: "Alice"})
+RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
+       .birthdate, .gender} AS personInfo`;
+    const expected = `MATCH (p:Person {name: "Alice"})
+RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
+          .birthdate, .gender} AS personInfo`;
+    verifyFormatting(query, expected);
+  });
+
+  test('map projections should line up like maps 1', () => {
+    const query = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
+RETURN p {.name, .age, .email, .phone, address:
+    {street: p.street, city: c.name, zip: p.zip}, .occupation, .nationality,
+    .birthdate, .gender} AS personInfo`;
+    const expected = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
+RETURN p {.name, .age, .email, .phone,
+          address: {street: p.street, city: c.name, zip: p.zip}, .occupation,
+          .nationality, .birthdate, .gender} AS personInfo`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/linebreaksv2.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaksv2.test.ts
@@ -321,9 +321,10 @@ RETURN p`;
   test('should align arguments of function invocation after opening bracket', () => {
     const query = `RETURN collect(create_this1 { datetime: apoc.date.convertFormat(toString(create_this1.datetime), "OZQvXyoU", "EhpkDy8g") }) AS data`;
     const expected = `
-RETURN collect(create_this1 {datetime:
-               apoc.date.convertFormat(toString(create_this1.datetime),
-                                       "OZQvXyoU", "EhpkDy8g")}) AS data`.trimStart();
+RETURN collect(create_this1
+               {datetime:
+                apoc.date.convertFormat(toString(create_this1.datetime),
+                                        "OZQvXyoU", "EhpkDy8g")}) AS data`.trimStart();
     verifyFormatting(query, expected);
   });
 


### PR DESCRIPTION
## Description
Map projections, unlike map literals, currently do not get a wrapping group. This means that splits wihtin them look a bit weird:

```
MATCH (p:Person {name: "Alice"})
RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
       .birthdate, .gender} AS personInfo
```
This PR adds a wrapping group within map projections, meaning they now get formatted like this:

```
MATCH (p:Person {name: "Alice"})
RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
          .birthdate, .gender} AS personInfo
```

### Testing

2 new tests added
- Note: One test fails right now due to an unrelated bug with function invocation alignment that will be resolved with #388 