### PR TITLE
Fixes comments breaking clause alignment in formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -220,6 +220,17 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     return this.groupID - 1;
   };
 
+  startGroupAlsoOnComment = (): number => {
+    const last = this.currentBuffer().at(-1);
+    if (last.type === 'COMMENT') {
+      last.groupsStarting = 1;
+      this.groupStack.push(this.groupID);
+      this.groupID++;
+      return this.groupID - 1;
+    }
+    return this.startGroup();
+  };
+
   addIndentation = () => {
     this.currentBuffer().at(-1).modifyIndentation += 1;
   };
@@ -396,7 +407,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visitIfNotNull(ctx.OPTIONAL());
     this.visit(ctx.MATCH());
     this.avoidBreakBetween();
-    const matchClauseGrp = this.startGroup();
+    const matchClauseGrp = this.startGroupAlsoOnComment();
     this.visitIfNotNull(ctx.matchMode());
     this.visit(ctx.patternList());
     this.endGroup(matchClauseGrp);

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -1171,18 +1171,17 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.visit(ctx.LCURLY());
     this.avoidSpaceBetween();
-    this.avoidBreakBetween();
-    const mapProjectionGrp = this.startGroup();
     const n = ctx.mapProjectionElement_list().length;
+    // Not sure if these should have groups around them?
+    // Haven't been able to find a case where it matters so far.
     for (let i = 0; i < n; i++) {
       this.visit(ctx.mapProjectionElement(i));
       if (i < n - 1) {
         this.visit(ctx.COMMA(i));
       }
     }
-    this.endGroup(mapProjectionGrp);
+    this.avoidSpaceBetween();
     this.visit(ctx.RCURLY());
-    this.concatenate();
   };
 
   visitListItemsPredicate = (ctx: ListItemsPredicateContext) => {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -15,6 +15,7 @@ import {
   ClauseContext,
   CountStarContext,
   CreateClauseContext,
+  DeleteClauseContext,
   ExistsExpressionContext,
   Expression10Context,
   Expression2Context,
@@ -22,6 +23,7 @@ import {
   ExtendedCaseExpressionContext,
   ForeachClauseContext,
   FunctionInvocationContext,
+  InsertClauseContext,
   KeywordLiteralContext,
   LabelExpression2Context,
   LabelExpression3Context,
@@ -58,6 +60,7 @@ import {
   StatementsOrCommandsContext,
   SubqueryClauseContext,
   UnwindClauseContext,
+  UseClauseContext,
   WhereClauseContext,
   WithClauseContext,
 } from '../generated-parser/CypherCmdParser';
@@ -394,6 +397,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.preserveExplicitNewlineAfter(ctx);
   };
 
+  visitUseClause = (ctx: UseClauseContext) => {
+    this.visit(ctx.USE());
+    const useGrp = this.startGroupAlsoOnComment();
+    this.visitIfNotNull(ctx.GRAPH());
+    this.visit(ctx.graphReference());
+    this.endGroup(useGrp);
+  };
+
   visitWithClause = (ctx: WithClauseContext) => {
     this.visit(ctx.WITH());
     this.avoidBreakBetween();
@@ -421,9 +432,35 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitCreateClause = (ctx: CreateClauseContext) => {
     this.visit(ctx.CREATE());
     this.avoidBreakBetween();
-    const createClauseGrp = this.startGroup();
+    const createClauseGrp = this.startGroupAlsoOnComment();
     this.visit(ctx.patternList());
     this.endGroup(createClauseGrp);
+  };
+
+  visitInsertClause = (ctx: InsertClauseContext) => {
+    this.visit(ctx.INSERT());
+    this.avoidBreakBetween();
+    const insertClauseGrp = this.startGroupAlsoOnComment();
+    this.visit(ctx.insertPatternList());
+    this.endGroup(insertClauseGrp);
+  };
+
+  visitDeleteClause = (ctx: DeleteClauseContext) => {
+    if (ctx.DETACH() || ctx.NODETACH()) {
+      this.visitIfNotNull(ctx.DETACH());
+      this.visitIfNotNull(ctx.NODETACH());
+      this.avoidBreakBetween();
+    }
+    this.visit(ctx.DELETE());
+    const deleteClauseGrp = this.startGroupAlsoOnComment();
+    const n = ctx.expression_list().length;
+    for (let i = 0; i < n; i++) {
+      this.visit(ctx.expression(i));
+      if (i < n - 1) {
+        this.visit(ctx.COMMA(i));
+      }
+    }
+    this.endGroup(deleteClauseGrp);
   };
 
   visitReturnClause = (ctx: ReturnClauseContext) => {
@@ -1073,7 +1110,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     handleMergeClause(
       ctx,
       (node) => this.visit(node),
-      () => this.startGroup(),
+      () => this.startGroupAlsoOnComment(),
       (id) => this.endGroup(id),
       () => this.avoidBreakBetween(),
     );

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -342,11 +342,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         type: 'COMMENT',
         breakBefore: nodeLine !== commentLine,
         text,
-        groupsStarting: this.startGroupCounter,
+        groupsStarting: 0,
         groupsEnding: 0,
         modifyIndentation: 0,
       };
-      this.startGroupCounter = 0;
       // If we have a "hard-break" comment, i.e. one that has a newline before it,
       // we end all currently active groups. Otherwise, that comment becomes part of the group,
       // which makes it very hard for the search to find a good solution.

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -1123,17 +1123,18 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.variable());
     this.visit(ctx.LCURLY());
     this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    const mapProjectionGrp = this.startGroup();
     const n = ctx.mapProjectionElement_list().length;
-    // Not sure if these should have groups around them?
-    // Haven't been able to find a case where it matters so far.
     for (let i = 0; i < n; i++) {
       this.visit(ctx.mapProjectionElement(i));
       if (i < n - 1) {
         this.visit(ctx.COMMA(i));
       }
     }
-    this.avoidSpaceBetween();
+    this.endGroup(mapProjectionGrp);
     this.visit(ctx.RCURLY());
+    this.concatenate();
   };
 
   visitListItemsPredicate = (ctx: ListItemsPredicateContext) => {

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -408,7 +408,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitWithClause = (ctx: WithClauseContext) => {
     this.visit(ctx.WITH());
     this.avoidBreakBetween();
-    const withClauseGrp = this.startGroup();
+    const withClauseGrp = this.startGroupAlsoOnComment();
     this.visit(ctx.returnBody());
     this.visitIfNotNull(ctx.whereClause());
     this.endGroup(withClauseGrp);
@@ -486,7 +486,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitUnwindClause = (ctx: UnwindClauseContext) => {
     this.visit(ctx.UNWIND());
     this.avoidBreakBetween();
-    const unwindClauseGrp = this.startGroup();
+    const unwindClauseGrp = this.startGroupAlsoOnComment();
     this.visit(ctx.expression());
     const asGrp = this.startGroup();
     this.visit(ctx.AS());

--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -224,9 +224,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   startGroupAlsoOnComment = (): number => {
-    const last = this.currentBuffer().at(-1);
-    if (last.type === 'COMMENT') {
-      last.groupsStarting = 1;
+    if (this.currentBuffer().at(-1).type === 'COMMENT') {
+      const idx = this.getFirstNonCommentIdx();
+      this.currentBuffer().at(idx + 1).groupsStarting = 1;
       this.groupStack.push(this.groupID);
       this.groupID++;
       return this.groupID - 1;

--- a/packages/language-support/src/tests/formatting/commentsv2.test.ts
+++ b/packages/language-support/src/tests/formatting/commentsv2.test.ts
@@ -482,15 +482,35 @@ LIMIT "6pkMe6Kx"`;
     verifyFormatting(query, expected);
   });
 
-  test('comment directly after outermost group should not break alignment', () => {
+  test('comment directly after outermost group should not break alignment for clauses', () => {
     const query = `
-MATCH // Who comments here???
-(m)-->(n)
-RETURN m, n;`;
-    const expected = `
-MATCH // Who comments here???
-      (m)-->(n)
-RETURN m, n;`.trimStart();
+USE // Specifies the graph or database to use
+    graph
+MATCH // Matches patterns in the graph
+      (m)-[:RELATION]->(n)
+MERGE // Ensures a pattern exists in the graph
+      (p:Person {name: "Alice"})
+CREATE // Creates new nodes or relationships
+       (q:Person {name: "Bob"})-[:KNOWS]->(p)
+INSERT // Adds data to existing structures (hypothetical)
+       (r:Person {name: "Charlie"})
+DELETE // Deletes nodes or relationships
+       r
+SET // Updates properties on nodes or relationships
+    p.age = 30
+WITH // Passes results to the next clause
+     p, q
+UNWIND // Expands lists into multiple rows
+       [1, 2, 3] AS num
+CALL // Invokes a procedure
+     dbms.procedures() YIELD name
+LOAD CSV // Loads data from CSV files
+    FROM 'file:///data.csv' AS row
+LIMIT // Limits the number of rows returned
+      10
+RETURN // Returns results
+       p, q, num;`;
+    const expected = query.trim();
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/commentsv2.test.ts
+++ b/packages/language-support/src/tests/formatting/commentsv2.test.ts
@@ -501,4 +501,14 @@ UNWIND // Expands lists into multiple rows
     const expected = query.trim();
     verifyFormatting(query, expected);
   });
+
+  test('two comments after a clause should not break alignment', () => {
+    const query = `
+MATCH // One comment.
+      // Another comment. Really?
+      (m)-[:RELATION]->(n)
+RETURN m, n`.trim();
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/commentsv2.test.ts
+++ b/packages/language-support/src/tests/formatting/commentsv2.test.ts
@@ -492,24 +492,12 @@ MERGE // Ensures a pattern exists in the graph
       (p:Person {name: "Alice"})
 CREATE // Creates new nodes or relationships
        (q:Person {name: "Bob"})-[:KNOWS]->(p)
-INSERT // Adds data to existing structures (hypothetical)
-       (r:Person {name: "Charlie"})
 DELETE // Deletes nodes or relationships
        r
-SET // Updates properties on nodes or relationships
-    p.age = 30
 WITH // Passes results to the next clause
      p, q
 UNWIND // Expands lists into multiple rows
-       [1, 2, 3] AS num
-CALL // Invokes a procedure
-     dbms.procedures() YIELD name
-LOAD CSV // Loads data from CSV files
-    FROM 'file:///data.csv' AS row
-LIMIT // Limits the number of rows returned
-      10
-RETURN // Returns results
-       p, q, num;`;
+       [1, 2, 3] AS num;`;
     const expected = query.trim();
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/commentsv2.test.ts
+++ b/packages/language-support/src/tests/formatting/commentsv2.test.ts
@@ -481,4 +481,16 @@ RETURN *
 LIMIT "6pkMe6Kx"`;
     verifyFormatting(query, expected);
   });
+
+  test('comment directly after outermost group should not break alignment', () => {
+    const query = `
+MATCH // Who comments here???
+(m)-->(n)
+RETURN m, n;`;
+    const expected = `
+MATCH // Who comments here???
+      (m)-->(n)
+RETURN m, n;`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
@@ -333,4 +333,26 @@ SET f.prime = "zt01uZOH"
 RETURN f`;
     verifyFormatting(query, expected);
   });
+
+  test('map projections should line up like maps 1', () => {
+    const query = `MATCH (p:Person {name: "Alice"})
+RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
+       .birthdate, .gender} AS personInfo`;
+    const expected = `MATCH (p:Person {name: "Alice"})
+RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
+          .birthdate, .gender} AS personInfo`;
+    verifyFormatting(query, expected);
+  });
+
+  test('map projections should line up like maps 1', () => {
+    const query = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
+RETURN p {.name, .age, .email, .phone, address:
+    {street: p.street, city: c.name, zip: p.zip}, .occupation, .nationality,
+    .birthdate, .gender} AS personInfo`;
+    const expected = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
+RETURN p {.name, .age, .email, .phone,
+          address: {street: p.street, city: c.name, zip: p.zip}, .occupation,
+          .nationality, .birthdate, .gender} AS personInfo`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
@@ -344,7 +344,7 @@ RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
     verifyFormatting(query, expected);
   });
 
-  test('map projections should line up like maps 1', () => {
+  test('map projections should line up like maps 2', () => {
     const query = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
 RETURN p {.name, .age, .email, .phone, address:
     {street: p.street, city: c.name, zip: p.zip}, .occupation, .nationality,

--- a/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecasesv2.test.ts
@@ -333,26 +333,4 @@ SET f.prime = "zt01uZOH"
 RETURN f`;
     verifyFormatting(query, expected);
   });
-
-  test('map projections should line up like maps 1', () => {
-    const query = `MATCH (p:Person {name: "Alice"})
-RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
-       .birthdate, .gender} AS personInfo`;
-    const expected = `MATCH (p:Person {name: "Alice"})
-RETURN p {.name, .age, .email, .phone, .address, .occupation, .nationality,
-          .birthdate, .gender} AS personInfo`;
-    verifyFormatting(query, expected);
-  });
-
-  test('map projections should line up like maps 2', () => {
-    const query = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
-RETURN p {.name, .age, .email, .phone, address:
-    {street: p.street, city: c.name, zip: p.zip}, .occupation, .nationality,
-    .birthdate, .gender} AS personInfo`;
-    const expected = `MATCH (p:Person {name: "Alice"})-[:LIVES_IN]->(c:City)
-RETURN p {.name, .age, .email, .phone,
-          address: {street: p.street, city: c.name, zip: p.zip}, .occupation,
-          .nationality, .birthdate, .gender} AS personInfo`;
-    verifyFormatting(query, expected);
-  });
 });


### PR DESCRIPTION
## Description
In `addCommentsAfter`, we assume that groups can get attached to comment chunks, but this never seems to happen (and doesn't really make sense). Since comments do not get groups attached to them, alignment can break if they come right after the start of a clause. For instance, we would like the node pattern to align with the match here:

```
MATCH // Who comments here??
      (m)--(n)
return n, m
```
but since the group gets attached to (m), and the comment forces a break, we get 

```
MATCH // Who comments here??
(m)--(n)
return n, m
```

This PR adds a utility function `startGroupAlsoOnComment` that works like startGroup() if the last token was not a comment, and otherwise attaches the group to the comment that came right after the previous non-comment token. Note that we can't take just the last chunk since there may be multiple comments, and we have to attach the group to the one that came right after the clause word (see the last test).

This utility function is then used in all places where we start a group right after a clause token (such as `MATCH`) to ensure that comments do not break the alignment.

## Testing
- Two new tests, one with multiple comments.