### PR TITLE
Fixes RETURN DISTINCT edgecase in formatter

### DIFF
--- a/packages/language-support/src/formatting/formattingv2.ts
+++ b/packages/language-support/src/formatting/formattingv2.ts
@@ -470,6 +470,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   visitReturnBody = (ctx: ReturnBodyContext) => {
     this.visitIfNotNull(ctx.DISTINCT());
+    this.avoidBreakBetween();
     const returnItemsGrp = this.startGroup();
     this.visit(ctx.returnItems());
     if (ctx.orderBy() || ctx.skip()) {

--- a/packages/language-support/src/tests/formatting/linebreaksv2.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaksv2.test.ts
@@ -401,6 +401,24 @@ MATCH (dmk:Station {name: 'Denmark Hill'})<-[:CALLS_AT]-(l1a:CallingPoint)-
 RETURN dmk`.trim();
     verifyFormatting(query, expected);
   });
+
+  test('should not break after DISTINCT that follows RETURN', () => {
+    const query = `MATCH (abcde:wxyz)-[]->(fgh:wxyz)-[]->(ijk:wxyz)-[]->(lm:wxyz)
+WHERE abcde.zxcvbnml = "XyZpQ8Rt"
+RETURN DISTINCT
+abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml, fgh.qwertyuiopa,
+fgh.zxcvbnmasdfgh, fgh.zxcvbnml, ijk.qwertyuiopa, ijk.zxcvbnmasdfgh,
+ijk.zxcvbnml, lm.qwertyuiopa, lm.zxcvbnmasdfgh, lm.zxcvbnml, lm.lkjhgfdswert
+ORDER BY lm.lkjhgfdswert ASC`;
+    const expected = `MATCH (abcde:wxyz)-[]->(fgh:wxyz)-[]->(ijk:wxyz)-[]->(lm:wxyz)
+WHERE abcde.zxcvbnml = "XyZpQ8Rt"
+RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
+                fgh.qwertyuiopa, fgh.zxcvbnmasdfgh, fgh.zxcvbnml,
+                ijk.qwertyuiopa, ijk.zxcvbnmasdfgh, ijk.zxcvbnml,
+                lm.qwertyuiopa, lm.zxcvbnmasdfgh, lm.zxcvbnml, lm.lkjhgfdswert
+                ORDER BY lm.lkjhgfdswert ASC`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {


### PR DESCRIPTION
## Description
Since the formatter is allowed to break after `DISTINCT` on a `RETURN` clause, we can get this kind of weird formatting:

```
MATCH (abcde:wxyz)-[]->(fgh:wxyz)-[]->(ijk:wxyz)-[]->(lm:wxyz)
WHERE abcde.zxcvbnml = "XyZpQ8Rt"
RETURN DISTINCT
abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml, fgh.qwertyuiopa,
fgh.zxcvbnmasdfgh, fgh.zxcvbnml, ijk.qwertyuiopa, ijk.zxcvbnmasdfgh,
ijk.zxcvbnml, lm.qwertyuiopa, lm.zxcvbnmasdfgh, lm.zxcvbnml, lm.lkjhgfdswert
ORDER BY lm.lkjhgfdswert ASC
```
where the return items lose their alignment on the RETURN statement. This PR forces a non-break split after `DISTINCT`, meaning we now get 
```
MATCH (abcde:wxyz)-[]->(fgh:wxyz)-[]->(ijk:wxyz)-[]->(lm:wxyz)
WHERE abcde.zxcvbnml = "XyZpQ8Rt"
RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
                fgh.qwertyuiopa, fgh.zxcvbnmasdfgh, fgh.zxcvbnml,
                ijk.qwertyuiopa, ijk.zxcvbnmasdfgh, ijk.zxcvbnml,
                lm.qwertyuiopa, lm.zxcvbnmasdfgh, lm.zxcvbnml, lm.lkjhgfdswert
                ORDER BY lm.lkjhgfdswert ASC
```
instead.

## Testing
- Added the above as a test