### PR TITLE
Fixes EXISTS expressions

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -61,6 +61,7 @@ import {
 } from '../generated-parser/CypherCmdParser';
 import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
 import {
+  AlignIndentationOptions,
   Chunk,
   CommentChunk,
   findTargetToken,
@@ -151,7 +152,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       groupsEnding: prefix.groupsEnding + suffix.groupsEnding,
       modifyIndentation: prefix.modifyIndentation + suffix.modifyIndentation,
       specialIndentation: prefix.specialIndentation + suffix.specialIndentation,
-      alignIndentation: prefix.alignIndentation + suffix.alignIndentation,
+      alignIndentation: prefix.alignIndentation,
       ...(hasCursor && { isCursor: true }),
     };
     this.currentBuffer()[indices[1]] = chunk;
@@ -280,12 +281,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   addAlignIndentation = () => {
-    this.lastInCurrentBuffer().alignIndentation += 1;
+    this.lastInCurrentBuffer().alignIndentation = AlignIndentationOptions.Add;
   };
 
   removeAlignIndentation = () => {
     const idx = this.getFirstNonCommentIdx();
-    this.currentBuffer().at(idx).alignIndentation -= 1;
+    this.currentBuffer().at(idx).alignIndentation =
+      AlignIndentationOptions.Remove;
   };
 
   getBottomChild = (
@@ -354,7 +356,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         groupsEnding: 0,
         modifyIndentation: 0,
         specialIndentation: 0,
-        alignIndentation: 0,
+        alignIndentation: AlignIndentationOptions.Maintain,
       };
       this.startGroupCounter = 0;
       this.currentBuffer().push(chunk);
@@ -393,7 +395,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         groupsEnding: 0,
         modifyIndentation: 0,
         specialIndentation: 0,
-        alignIndentation: 0,
+        alignIndentation: AlignIndentationOptions.Maintain,
       };
       // If we have a "hard-break" comment, i.e. one that has a newline before it,
       // we end all currently active groups. Otherwise, that comment becomes part of the group,

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -90,7 +90,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   groupID = 0;
   groupStack: number[] = [];
   startGroupCounter = 0;
-  shouldEndOnNext: number[] = [];
+  groupsToEndOnBreak: number[] = [];
 
   constructor(private tokenStream: CommonTokenStream) {
     super();
@@ -109,8 +109,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   lastInCurrentBuffer = () => this.currentBuffer().at(-1);
 
   breakLine = () => {
-    if (this.shouldEndOnNext.length > 0) {
-      this.endGroup(this.shouldEndOnNext.pop());
+    if (this.groupsToEndOnBreak.length > 0) {
+      this.endGroup(this.groupsToEndOnBreak.pop());
     }
     if (this.currentBuffer().length > 0) {
       this.buffers.push([]);
@@ -1032,7 +1032,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       const endOfExistGroup = this.startGroup();
       this.visit(ctx.RCURLY());
       this.removeAlignIndentation();
-      this.shouldEndOnNext.push(endOfExistGroup);
+      this.groupsToEndOnBreak.push(endOfExistGroup);
     } else {
       this.visitIfNotNull(ctx.matchMode());
       this.visit(ctx.patternList());

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1023,25 +1023,21 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.EXISTS());
     this.avoidBreakBetween();
     this.visit(ctx.LCURLY());
-    const isRegularQuery = ctx.regularQuery() ? true : false;
-    if (isRegularQuery) {
+
+    if (ctx.regularQuery()) {
       this.addAlignIndentation();
       this.visit(ctx.regularQuery());
       this.breakLine();
+      this.mustBreakBetween();
+      const endOfExistGroup = this.startGroup();
+      this.visit(ctx.RCURLY());
+      this.removeAlignIndentation();
+      this.shouldEndOnNext.push(endOfExistGroup);
     } else {
       this.visitIfNotNull(ctx.matchMode());
       this.visit(ctx.patternList());
       this.visitIfNotNull(ctx.whereClause());
-    }
-    let endOfExistGroup: number;
-    if (isRegularQuery) {
-      this.mustBreakBetween();
-      endOfExistGroup = this.startGroup();
-    }
-    this.visit(ctx.RCURLY());
-    if (isRegularQuery) {
-      this.removeAlignIndentation();
-      this.shouldEndOnNext.push(endOfExistGroup);
+      this.visit(ctx.RCURLY());
     }
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -279,7 +279,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   addAlignIndentation = () => {
-    this.currentBuffer().at(-1).alignIndentation += 1;
+    this.lastInCurrentBuffer().alignIndentation += 1;
   };
 
   removeAlignIndentation = () => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -109,6 +109,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   lastInCurrentBuffer = () => this.currentBuffer().at(-1);
 
   breakLine = () => {
+    // This is a workaround because group does not translate between chunk lists
     if (this.groupsToEndOnBreak.length > 0) {
       this.endGroup(this.groupsToEndOnBreak.pop());
     }
@@ -1029,6 +1030,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.visit(ctx.regularQuery());
       this.breakLine();
       this.mustBreakBetween();
+      // This is a workaround because group does not translate between chunk lists
       const endOfExistGroup = this.startGroup();
       this.visit(ctx.RCURLY());
       this.removeAlignIndentation();

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -48,6 +48,7 @@ export interface BaseChunk {
   groupsEnding: number;
   modifyIndentation: number;
   specialIndentation: number;
+  alignIndentation: number;
 }
 
 // Regular chunk specific properties

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -40,6 +40,12 @@ export class FormatterErrorsListener
  */
 export const MAX_COL = 80;
 
+export enum AlignIndentationOptions {
+  Add = 1,
+  Remove = -1,
+  Maintain = 0,
+}
+
 export interface BaseChunk {
   isCursor?: boolean;
   doubleBreak?: true;
@@ -48,7 +54,7 @@ export interface BaseChunk {
   groupsEnding: number;
   modifyIndentation: number;
   specialIndentation: number;
-  alignIndentation: number;
+  alignIndentation: AlignIndentationOptions;
 }
 
 // Regular chunk specific properties

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -141,21 +141,24 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
       const baseGroup = curr.activeGroups[0];
       finalIndent = baseGroup ? baseGroup.align : nextBaseIndent;
     }
-    // Case 2: Special indentation with active groups
+    // Case 2: Special indentation, used with CASE
+    // Aligns as usual if more than one group exists
+    // else indents as specified in state
     else if (curr.indentationState.special !== 0) {
       finalIndent =
         curr.activeGroups.length > 1
           ? curr.activeGroups.at(-1).align
           : curr.indentationState.special;
-      // Case 3: align indentation
+      // Case 3: Currently only for EXISTS,
+      // Aaligning with base group plus indentation
     } else if (curr.indentationState.align.length > 0) {
-      if (curr.activeGroups.length === 0) {
-        finalIndent = align.at(-1) + INDENTATION;
-      } else if (curr.activeGroups.length > 0) {
-        finalIndent = curr.activeGroups.at(-1).align;
-      }
+      finalIndent =
+        curr.activeGroups.length > 0
+          ? curr.activeGroups.at(-1).align
+          : align.at(-1) + INDENTATION;
     }
-    // Case 4: Active groups exist
+    // Case 4: No special indentation rules applied,
+    // Align with latest added active group
     else if (curr.activeGroups.length > 0) {
       finalIndent = curr.activeGroups.at(-1).align;
     }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -128,8 +128,11 @@ function getIndentations(curr: State, choice: Choice): Indentations {
   const nextSpecialIndent =
     curr.indentationState.special +
     choice.left.specialIndentation * INDENTATION;
-
   let finalIndent = currBaseIndent;
+  const align = [...curr.indentationState.align];
+  if (choice.left.alignIndentation > 0) {
+    align.push(curr.activeGroups.at(0).align);
+  }
 
   // Only apply indentation at the start of a line (column === 0)
   if (curr.column === 0) {
@@ -144,6 +147,13 @@ function getIndentations(curr: State, choice: Choice): Indentations {
         curr.activeGroups.length > 1
           ? curr.activeGroups.at(-1).align
           : curr.indentationState.special;
+      // Case 42: align indentation
+    } else if (curr.indentationState.align.length > 0) {
+      if (curr.activeGroups.length === 0) {
+        finalIndent = align.at(-1) + INDENTATION;
+      } else if (curr.activeGroups.length > 0) {
+        finalIndent = curr.activeGroups.at(-1).align;
+      }
     }
     // Case 3: Active groups exist
     else if (curr.activeGroups.length > 0) {
@@ -154,13 +164,16 @@ function getIndentations(curr: State, choice: Choice): Indentations {
     // When not at the start of a line, no indentation
     finalIndent = 0;
   }
+  if (choice.left.alignIndentation < 0) {
+    finalIndent = align.pop();
+  }
 
   return {
     finalIndentation: finalIndent,
     indentationState: {
-      align: curr.indentationState.align,
       base: nextBaseIndent,
       special: nextSpecialIndent,
+      align: align,
     },
   };
 }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -147,7 +147,7 @@ function getIndentations(curr: State, choice: Choice): Indentations {
         curr.activeGroups.length > 1
           ? curr.activeGroups.at(-1).align
           : curr.indentationState.special;
-      // Case 42: align indentation
+      // Case 3: align indentation
     } else if (curr.indentationState.align.length > 0) {
       if (curr.activeGroups.length === 0) {
         finalIndent = align.at(-1) + INDENTATION;
@@ -155,7 +155,7 @@ function getIndentations(curr: State, choice: Choice): Indentations {
         finalIndent = curr.activeGroups.at(-1).align;
       }
     }
-    // Case 3: Active groups exist
+    // Case 4: Active groups exist
     else if (curr.activeGroups.length > 0) {
       finalIndent = curr.activeGroups.at(-1).align;
     }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -1,6 +1,7 @@
 import { Heap } from 'heap-js';
 import CypherCmdLexer from '../generated-parser/CypherCmdLexer';
 import {
+  AlignIndentationOptions,
   Chunk,
   isCommentBreak,
   MAX_COL,
@@ -130,7 +131,7 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
     choice.left.specialIndentation * INDENTATION;
   let finalIndent = currBaseIndent;
   const align = [...curr.indentationState.align];
-  if (choice.left.alignIndentation > 0) {
+  if (choice.left.alignIndentation === AlignIndentationOptions.Add) {
     align.push(curr.activeGroups.at(0).align);
   }
 
@@ -167,7 +168,7 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
     // When not at the start of a line, no indentation
     finalIndent = 0;
   }
-  if (choice.left.alignIndentation < 0) {
+  if (choice.left.alignIndentation === AlignIndentationOptions.Remove) {
     finalIndent = align.pop();
   }
 

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -413,6 +413,56 @@ RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
                 ORDER BY lm.lkjhgfdswert ASC`;
     verifyFormatting(query, expected);
   });
+  test('test for nested exists cases', () => {
+    const query = `MATCH (user:Actor {actor_type:"EFXxFHob"})
+WHERE(
+(size(apoc.coll.intersection(labels(user),idp_label_list))="3INQ6teR" OR user.service_type="UlAAMmmD")AND NOT EXISTS{
+MATCH(user)-[:PART_OF]->(group:Actor{actor_type:"A0cFHwrB"})
+WITH group,apoc.coll.intersection(labels(group),idp_label_list)AS group_idp_labels
+WHERE(size(group_idp_labels)="7SOM63mX" OR group.service_type="11gaOJfr")AND EXISTS{
+MATCH(group)-[:HAS_ACCESS]->(resource:Resource)
+WHERE resource.sensitivity>7 AND NOT EXISTS{
+MATCH(resource)-[:PROTECTED_BY]->(policy:Policy)
+WHERE policy.enforcement="strict"
+}AND resource.type IN["confidential","restricted"]
+}OR group.created_at<datetime("2023-01-01") 
+OR group.created_at<datetime("2023-01-01")
+OR group.created_at<datetime("2023-01-01")
+}
+)OR(
+user.active=true AND EXISTS{
+MATCH(user)-[:HAS_ROLE]->(role:Role)
+WHERE role.type IN role_types AND NOT EXISTS{
+MATCH(role)-[:REQUIRES]->(approval:Approval)
+WHERE approval.status<>"granted"
+}AND(role.expiry_date>datetime()OR role.permanent=true)
+}AND user.last_login>datetime()-duration({days:30})
+)`;
+    const expected = `MATCH (user:Actor {actor_type: "EFXxFHob"})
+WHERE ((size(apoc.coll.intersection(labels(user), idp_label_list)) = "3INQ6teR"
+        OR user.service_type = "UlAAMmmD") AND NOT EXISTS {
+        MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
+        WITH group, apoc.coll.intersection(labels(group), idp_label_list)
+                    AS group_idp_labels
+        WHERE (size(group_idp_labels) = "7SOM63mX" OR
+               group.service_type = "11gaOJfr") AND EXISTS {
+                MATCH (group)-[:HAS_ACCESS]->(resource:Resource)
+                WHERE resource.sensitivity > 7 AND NOT EXISTS {
+                        MATCH (resource)-[:PROTECTED_BY]->(policy:Policy)
+                        WHERE policy.enforcement = "strict"
+                      } AND resource.type IN ["confidential", "restricted"]
+              } OR group.created_at < datetime("2023-01-01") OR
+              group.created_at < datetime("2023-01-01") OR
+              group.created_at < datetime("2023-01-01")
+      }) OR (user.active = true AND EXISTS {
+        MATCH (user)-[:HAS_ROLE]->(role:Role)
+        WHERE role.type IN role_types AND NOT EXISTS {
+                MATCH (role)-[:REQUIRES]->(approval:Approval)
+                WHERE approval.status <> "granted"
+              } AND (role.expiry_date > datetime() OR role.permanent = true)
+      } AND user.last_login > datetime() - duration({days: 30}))`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/styleguide.test.ts
+++ b/packages/language-support/src/tests/formatting/styleguide.test.ts
@@ -21,9 +21,9 @@ RETURN a.prop`;
 
     const expected = `MATCH (a:A)
 WHERE EXISTS {
-  MATCH (a)-->(b:B)
-  WHERE b.prop = 'yellow'
-}
+        MATCH (a)-->(b:B)
+        WHERE b.prop = 'yellow'
+      }
 RETURN a.foo`;
     verifyFormatting(query, expected);
   });
@@ -324,8 +324,8 @@ CALL (c, c2, trxs, avgTrx, totalSum) {
 ;`;
     const expected = `MATCH (c:Cuenta)-[:REALIZA]->(m:Movimiento)-[:HACIA]->(c2:Cuenta)
 WHERE NOT EXISTS {
-  MATCH (c)-[:TRANSFIERE]->(c2)
-}
+        MATCH (c)-[:TRANSFIERE]->(c2)
+      }
 WITH c, c2, count(m) AS trxs, avg(m.monto) AS avgTrx, sum(m.monto) AS totalSum
 LIMIT 1000
 CALL (c, c2, trxs, avgTrx, totalSum) {


### PR DESCRIPTION
### Description
This PR improves the indentation of EXISTS expressions in Cypher queries. Similar to CALL expressions, the content inside EXISTS expressions should be properly indented, but when these expressions appear within WHERE clauses, the indentation requires special handling:

```
MATCH (user:Actor {actor_type: "EFXxFHob"})
WITH user,
     apoc.coll.intersection(labels(user), idp_label_list) AS user_idp_labels
WHERE (size(user_idp_labels) = "3INQ6teR" OR user.service_type = "UlAAMmmD") AND
      NOT EXISTS {
  MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
  WITH apoc.coll.intersection(labels(group), idp_label_list)
       AS group_idp_labels
  WHERE size(group_idp_labels) = "7SOM63mX" OR
        group.service_type = "11gaOJfr" AND user_idp_labels = group_idp_labels
} AND toLower(user.status) = "p6MXYsvG"
RETURN user
``` 

This PR fixes this by aligning whats inside a EXISTS expression with its base group and adding one indentation step. Previous example becomes:
```
MATCH (user:Actor {actor_type: "EFXxFHob"})
WITH user,
     apoc.coll.intersection(labels(user), idp_label_list) AS user_idp_labels
WHERE (size(user_idp_labels) = "3INQ6teR" OR user.service_type = "UlAAMmmD") AND
      NOT EXISTS {
        MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
        WITH apoc.coll.intersection(labels(group), idp_label_list)
             AS group_idp_labels
        WHERE size(group_idp_labels) = "7SOM63mX" OR
              group.service_type = "11gaOJfr" AND
              user_idp_labels = group_idp_labels
      } AND toLower(user.status) = "p6MXYsvG"
RETURN user

```
When nested EXISTS appear, the rules still follows, aligning by the base group and adding one indentation step:
```
MATCH (user:Actor {actor_type: "EFXxFHob"})
WITH user,
     apoc.coll.intersection(labels(user), idp_label_list) AS user_idp_labels
WHERE (size(user_idp_labels) = "3INQ6teR" OR user.service_type = "UlAAMmmD") AND
      NOT EXISTS {
        MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
        WITH apoc.coll.intersection(labels(group), idp_label_list)
             AS group_idp_labels
        WHERE (size(group_idp_labels) = "7SOM63mX" OR
               group.service_type = "11gaOJfr" AND
               user_idp_labels = group_idp_labels) AND EXISTS {
                MATCH (user)-[:HAS_ACCESS]->(resource:Resource)
                WHERE resource.status = "active"
              }
      } AND toLower(user.status) = "p6MXYsvG"
RETURN user
```
### Technical challenge
A notable subtlety is that the base group for the second EXISTS expression is after the second WHERE clause, not the first WHERE. This occurs because clauses like MATCH have a breakLine() method that terminates all active groups, meaning that after a line break, we need use the established groups.

### Refactorisation
This PR refactors the state management by introducing an IndentationState that:
 - Encapsulates indentation-related state in a single object
 - Allows for easier state passing between different components

### Tests
 - Modifies two tests
 - Adds one test
 - All tests passes