### PR TITLE
Fixes IS CONNECTED concatenation bug in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -769,8 +769,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   ) => {
     this.visitIfNotNull(ctx.variable());
     this.visitIfNotNull(ctx.labelExpression());
-    if (ctx instanceof RelationshipPatternContext) {
-      this.visitIfNotNull(ctx.pathLength());
+    if (ctx instanceof RelationshipPatternContext && ctx.pathLength()) {
+      this.visit(ctx.pathLength());
       this.concatenate();
     }
     this.visitIfNotNull(ctx.properties());

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -617,4 +617,11 @@ FOREACH (item IN items |
 RETURN n`;
     verifyFormatting(query, expected);
   });
+
+  test('relation with IS CONNECTED should not concatenate to ISCONNECTED', () => {
+    const query = `MATCH (n)-[IS CONNECTED]->(m)
+RETURN n, m`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
## Description
While testing something else, I noticed that 2 of the 1.1M sample queries were not passing the AST integrity check, due to `IS CONNECTED` within relations being concatenated into `ISCONNECTED`. The issue was related to us always concatenating for path lengths even though a path length is not always present. This PR resolves that issue.

## Testing
- Added a new test for this case
- Reran the 1.1m queries and now all of them pass both checks