### PR TITLE
Fixes QPP with no comma bug in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -902,6 +902,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.avoidSpaceBetween();
       return;
     }
+    if (!ctx._from_ && !ctx._to) {
+      this.visitChildren(ctx);
+      this.concatenate();
+      this.concatenate();
+      this.concatenate();
+      this.avoidSpaceBetween();
+      return;
+    }
     if (!ctx._from_) {
       this.visitTerminalRaw(ctx.LCURLY(), { spacingChoice: 'EXTRA_SPACE' });
     } else {

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -405,6 +405,13 @@ RETURN m`;
     verifyFormatting(query, expected);
   });
 
+  test('QPP with only a number', () => {
+    const query = `MATCH (n)-->{4}(m)
+RETURN n`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+
   // Example 1 by Finbar
   test('QPP spacing with star', () => {
     const query = `


### PR DESCRIPTION
## Description
In #402 Oskar pointed out that one of his queries refused to format, and it turned out the formatter was experiencing an internal bug. The culprit turned out to be a QPP that failed because we always assume there is a comma within it, even though it can look like this as well: `{4}`

This PR addresses that grammar case in `visitQuantifier` and adds a test for it.

## Testing
- Added a new test for the case described
- Tried the query mentioned in #402 and it now formats like expected.
- Ran about 50k sample queries for good measure to see if this breaks anything else and they passed