### PR TITLE
Fixes count and collect

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -7,6 +7,7 @@ import {
   CaseAlternativeContext,
   CaseExpressionContext,
   ClauseContext,
+  CollectExpressionContext,
   CountStarContext,
   CreateClauseContext,
   DeleteClauseContext,
@@ -1042,6 +1043,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.visitIfNotNull(ctx.whereClause());
       this.visit(ctx.RCURLY());
     }
+  };
+
+  visitCollectExpression = (ctx: CollectExpressionContext) => {
+    this.visit(ctx.COLLECT());
+    this.avoidBreakBetween();
+    this.visit(ctx.LCURLY());
+    this.addAlignIndentation();
+    this.visit(ctx.regularQuery());
+    this.breakLine();
+    const endOfCollectGroup = this.startGroup();
+    this.visit(ctx.RCURLY());
+    this.removeAlignIndentation();
+    this.groupsToEndOnBreak.push(endOfCollectGroup);
   };
 
   visitCaseAlternative = (ctx: CaseAlternativeContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -8,6 +8,7 @@ import {
   CaseExpressionContext,
   ClauseContext,
   CollectExpressionContext,
+  CountExpressionContext,
   CountStarContext,
   CreateClauseContext,
   DeleteClauseContext,
@@ -1056,6 +1057,29 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.RCURLY());
     this.removeAlignIndentation();
     this.groupsToEndOnBreak.push(endOfCollectGroup);
+  };
+
+  visitCountExpression = (ctx: CountExpressionContext) => {
+    this.visit(ctx.COUNT());
+    this.avoidBreakBetween();
+    this.visit(ctx.LCURLY());
+
+    if (ctx.regularQuery()) {
+      this.addAlignIndentation();
+      this.visit(ctx.regularQuery());
+      this.breakLine();
+      this.mustBreakBetween();
+      // This is a workaround because group does not translate between chunk lists
+      const endOfCountGroup = this.startGroup();
+      this.visit(ctx.RCURLY());
+      this.removeAlignIndentation();
+      this.groupsToEndOnBreak.push(endOfCountGroup);
+    } else {
+      this.visitIfNotNull(ctx.matchMode());
+      this.visit(ctx.patternList());
+      this.visitIfNotNull(ctx.whereClause());
+      this.visit(ctx.RCURLY());
+    }
   };
 
   visitCaseAlternative = (ctx: CaseAlternativeContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1053,6 +1053,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.addAlignIndentation();
     this.visit(ctx.regularQuery());
     this.breakLine();
+    // This is a workaround because group does not translate between chunk lists
     const endOfCollectGroup = this.startGroup();
     this.visit(ctx.RCURLY());
     this.removeAlignIndentation();

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -150,13 +150,14 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
         curr.activeGroups.length > 1
           ? curr.activeGroups.at(-1).align
           : curr.indentationState.special;
-      // Case 3: Currently only for EXISTS,
-      // Aaligning with base group plus indentation
+      // Case 3: Currently for for EXISTS, COLLECT and COUNT,
+      // Aligning with base group plus indentation plus possible baseIndentation
+      // baseIndentation can happen with UNION
     } else if (curr.indentationState.align.length > 0) {
       finalIndent =
         curr.activeGroups.length > 0
           ? curr.activeGroups.at(-1).align
-          : align.at(-1) + INDENTATION;
+          : align.at(-1) + INDENTATION + currBaseIndent;
     }
     // Case 4: No special indentation rules applied,
     // Align with latest added active group

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -151,7 +151,7 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
           ? curr.activeGroups.at(-1).align
           : curr.indentationState.special;
       // Case 3: Currently for for EXISTS, COLLECT and COUNT,
-      // Aligning with base group plus indentation plus possible baseIndentation
+      // Aligning with base group plus indentation plus possible baseIndentation.
       // baseIndentation can happen with UNION
     } else if (curr.indentationState.align.length > 0) {
       finalIndent =

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -485,7 +485,7 @@ RETURN person.name AS name`;
 RETURN person.name AS name, COUNT {
          MATCH (person)-[:HAS_DOG]->(dog:Dog)
          RETURN dog.name AS petName
-         UNION
+           UNION
          MATCH (person)-[:HAS_CAT]->(cat:Cat)
          RETURN cat.name AS petName
        } AS numPets`;

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -463,6 +463,16 @@ WHERE ((size(apoc.coll.intersection(labels(user), idp_label_list)) = "3INQ6teR"
       } AND user.last_login > datetime() - duration({days: 30}))`;
     verifyFormatting(query, expected);
   });
+  test('test that clause under collect gets properly indented', () => {
+    const query = `MATCH (person:Person)
+RETURN person.name AS name, COLLECT {
+         MATCH (person)-[r:HAS_DOG]->(dog:Dog)
+         WHERE r.since > 2017
+         RETURN dog.name
+       } AS youngDogs`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -473,6 +473,25 @@ RETURN person.name AS name, COLLECT {
     const expected = query;
     verifyFormatting(query, expected);
   });
+  test('count expression with only expression', () => {
+    const query = `MATCH (person:Person)
+WHERE COUNT { (person)-[:HAS_DOG]->(:Dog) } > 1
+RETURN person.name AS name`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+  test('count expression with regular query', () => {
+    const query = `MATCH (person:Person)
+RETURN person.name AS name, COUNT {
+         MATCH (person)-[:HAS_DOG]->(dog:Dog)
+         RETURN dog.name AS petName
+         UNION
+         MATCH (person)-[:HAS_CAT]->(cat:Cat)
+         RETURN cat.name AS petName
+       } AS numPets`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {


### PR DESCRIPTION
### Description
This PR fixes correct indentation for `COUNT` and `COLLECT`. This was something that was discovered in this PR: https://github.com/neo4j/cypher-language-support/pull/400
as something which should have similar behavior to `EXISTS`.
The following are before and after for `COUNT` and `COLLECT` respectively:
Before:
```
MATCH (person:Person)
RETURN person.name AS name, COUNT {
MATCH (person)-[:HAS_DOG]->(dog:Dog)
RETURN dog.name AS petName
  UNION
MATCH (person)-[:HAS_CAT]->(cat:Cat)
RETURN cat.name AS petName } AS numPets
```
After:
```
MATCH (person:Person)
RETURN person.name AS name, COUNT {
         MATCH (person)-[:HAS_DOG]->(dog:Dog)
         RETURN dog.name AS petName
           UNION
         MATCH (person)-[:HAS_CAT]->(cat:Cat)
         RETURN cat.name AS petName
       } AS numPets
```
Before:
```
MATCH (person:Person)
RETURN person.name AS name, COLLECT {
MATCH (person)-[r:HAS_DOG]->(dog:Dog)
WHERE r.since > 2017
RETURN dog.name } AS youngDogs
```
After:
```
MATCH (person:Person)
RETURN person.name AS name, COLLECT {
         MATCH (person)-[r:HAS_DOG]->(dog:Dog)
         WHERE r.since > 2017
         RETURN dog.name
       } AS youngDogs
```

### Additional
This PR does not only add visitors for `COUNT` and `COLLECT`, but also makes sure that `UNION` is correctly indented in COUNT. This is made sure by using both align indentation and the old baseIndentation. 

### Tech debt
We acknowledge that this PR has tech debt that was introduced in: https://github.com/neo4j/cypher-language-support/pull/400. This is related to that there are mixed use of indentation properties. Chunks uses similar indentation properties as the indentation interface used by State. But it currently cant use that interface because of those differences. These will be cleared up in later PR.

### Tests
 - Two tests added for `COUNT`
 - One test added for `COLLECT`