### PR TITLE
Adds preservation of newlines between statements in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -290,16 +290,16 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     throw new Error('Internal formatting error in findBottomChild');
   };
 
-  preserveExplicitNewlineAfter = (ctx: ParserRuleContext) => {
+  preserveExplicitNewlineAfter = (ctx: ParserRuleContext | TerminalNode) => {
     this.preserveExplicitNewline(ctx, 'after');
   };
 
-  preserveExplicitNewlineBefore = (ctx: ParserRuleContext) => {
+  preserveExplicitNewlineBefore = (ctx: ParserRuleContext | TerminalNode) => {
     this.preserveExplicitNewline(ctx, 'before');
   };
 
   preserveExplicitNewline = (
-    ctx: ParserRuleContext,
+    ctx: ParserRuleContext | TerminalNode,
     side: 'before' | 'after',
   ) => {
     const bottomChild = this.getBottomChild(ctx, side);
@@ -414,6 +414,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
           this.currentBuffer().pop();
         }
         this.visit(ctx.SEMICOLON(i));
+        this.preserveExplicitNewlineAfter(ctx.SEMICOLON(i));
       }
     }
   };

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -920,4 +920,69 @@ LIMIT 10`.trimStart();
     const expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('two statements', () => {
+    const query = `
+MATCH (n)
+
+RETURN n;
+
+MATCH (n)
+
+RETURN m;`;
+    const expected = query.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('multiple statements with comments inbetween', () => {
+    const query = `
+MATCH (n)
+
+RETURN n;
+// This is a comment
+
+MATCH (n)
+
+RETURN n;
+
+// This is another comment
+
+MATCH (n)
+RETURN n;`;
+    const expected = query.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('end of statement with multiple newlines', () => {
+    const query = `
+MATCH (n)
+RETURN m;
+
+
+`;
+    const expected = `MATCH (n)
+RETURN m;`;
+    verifyFormatting(query, expected);
+  });
+
+  test('too many newlines between statements should truncate to one', () => {
+    const query = `
+MATCH (n)
+RETURN n;
+
+
+
+
+
+
+MATCH (n)
+RETURN m;`;
+    const expected = `
+MATCH (n)
+RETURN n;
+
+MATCH (n)
+RETURN m;`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
## Description

PR #382 added preservation of explicit newlines, but only between different clauses. As a result, in queries like:

```
MATCH (a)
RETURN a;

MATCH (b)
RETURN b;
```

the blank line  after `a;` is removed. This PR allows preserving newlines between statements, so that users can separate statements with a blank line.

### Testing

4 new simple tests for statements with newlines after them