### PR TITLE
Improves formatting of shortest path examples

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -892,7 +892,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.visitIfNotNull(ctx.selector());
       this.endGroup(selectorGroup);
     }
+    const anonymousPatternGrp = this.startGroup();
     this.visit(ctx.anonymousPattern());
+    this.endGroup(anonymousPatternGrp);
     this.endGroup(selectorAnonymousPatternGrp);
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -38,6 +38,7 @@ import {
   NumberLiteralContext,
   ParameterContext,
   ParenthesizedExpressionContext,
+  ParenthesizedPathContext,
   PathLengthContext,
   PatternContext,
   PatternListContext,
@@ -801,6 +802,20 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  visitParenthesizedPath = (ctx: ParenthesizedPathContext) => {
+    this.visit(ctx.LPAREN());
+    this.avoidBreakBetween();
+    const parenthesizedPathGrp = this.startGroup();
+    this.visit(ctx.pattern());
+    if (ctx.WHERE()) {
+      this.visit(ctx.WHERE());
+      this.visit(ctx.expression());
+    }
+    this.endGroup(parenthesizedPathGrp);
+    this.visit(ctx.RPAREN());
+    this.visitIfNotNull(ctx.quantifier());
+  };
+
   visitArrowLine = (ctx: ArrowLineContext) => {
     this.visitRawIfNotNull(ctx.MINUS());
     this.visitRawIfNotNull(ctx.ARROW_LINE());
@@ -871,10 +886,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.visit(ctx.EQ());
       this.avoidBreakBetween();
     }
+    const selectorAnonymousPatternGrp = this.startGroup();
     this.visitIfNotNull(ctx.selector());
-    const anonymousPatternGrp = this.startGroup();
     this.visit(ctx.anonymousPattern());
-    this.endGroup(anonymousPatternGrp);
+    this.endGroup(selectorAnonymousPatternGrp);
   };
 
   visitPatternList = (ctx: PatternListContext) => {
@@ -1248,6 +1263,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitListItemsPredicate = (ctx: ListItemsPredicateContext) => {
+    const wholeListItemGrp = this.startGroup();
     this.visitRawIfNotNull(ctx.ALL());
     this.visitRawIfNotNull(ctx.ANY());
     this.visitRawIfNotNull(ctx.NONE());
@@ -1265,6 +1281,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.endGroup(listGrp);
     this.visit(ctx.RPAREN());
+    this.endGroup(wholeListItemGrp);
   };
 
   visitListLiteral = (ctx: ListLiteralContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -887,7 +887,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.avoidBreakBetween();
     }
     const selectorAnonymousPatternGrp = this.startGroup();
-    this.visitIfNotNull(ctx.selector());
+    if (ctx.selector()) {
+      const selectorGroup = this.startGroup();
+      this.visitIfNotNull(ctx.selector());
+      this.endGroup(selectorGroup);
+    }
     this.visit(ctx.anonymousPattern());
     this.endGroup(selectorAnonymousPatternGrp);
   };

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -414,15 +414,29 @@ RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
     verifyFormatting(query, expected);
   });
 
-  test('path length example', () => {
+  test('selector example', () => {
     const query = `MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
                  (:Station {name: 'Cheltenham Spa'}) WHERE none(
                  stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
 RETURN [stop IN n[.. -1] | stop.name] AS stops`;
     const expected = `
-MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
-                  (:Station {name: 'Cheltenham Spa'}) WHERE
+MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'})
+                  (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE
                   none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
+RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('selector example with path', () => {
+    const query = `MATCH p = SHORTEST 1 ((:Station {name: 'Thisisanabsurdlylongnametomakeitawkward'})
+           (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE
+           none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
+RETURN [stop IN n[.. -1] | stop.name] AS stops`;
+    const expected = `
+MATCH p = SHORTEST 1
+          ((:Station {name: 'Thisisanabsurdlylongnametomakeitawkward'})
+           (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE
+           none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
 RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -440,6 +440,17 @@ MATCH p = SHORTEST 1
 RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
     verifyFormatting(query, expected);
   });
+
+  test('selector and quantifier example', () => {
+    const query = `MATCH path = ANY
+  (:Station {name: 'Pershore'})-[l:LINK WHERE l.distance < 10]-+(b:Station {name: 'Bromsgrove'})
+RETURN [r IN relationships(path) | r.distance] AS distances`;
+    const expected = `
+MATCH path = ANY (:Station {name: 'Pershore'})-[l:LINK WHERE l.distance < 10]-+
+             (b:Station {name: 'Bromsgrove'})
+RETURN [r IN relationships(path) | r.distance] AS distances`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -413,6 +413,19 @@ RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
                 ORDER BY lm.lkjhgfdswert ASC`;
     verifyFormatting(query, expected);
   });
+
+  test('path length example', () => {
+    const query = `MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
+                 (:Station {name: 'Cheltenham Spa'}) WHERE none(
+                 stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
+RETURN [stop IN n[.. -1] | stop.name] AS stops`;
+    const expected = `
+MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
+                  (:Station {name: 'Cheltenham Spa'}) WHERE
+                  none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
+RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -420,9 +420,10 @@ RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
   (()--(n))+
   (:Station {name: 'Cheltenham Spa'})
 RETURN [stop in n[..-1] | stop.name] AS stops`;
-    const expected = `MATCH SHORTEST 1 (:Station {name: 'Hartlebury'}) (()--(n))+
-      (:Station {name: 'Cheltenham Spa'})
-RETURN [stop IN n[.. -1] | stop.name] AS stops`;
+    const expected = `
+MATCH SHORTEST 1 (:Station {name: 'Hartlebury'}) (()--(n))+
+                 (:Station {name: 'Cheltenham Spa'})
+RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
     verifyFormatting(query, expected);
   });
 
@@ -432,8 +433,8 @@ RETURN [stop IN n[.. -1] | stop.name] AS stops`;
                  stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
 RETURN [stop IN n[.. -1] | stop.name] AS stops`;
     const expected = `
-MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'})
-                  (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE
+MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
+                  (:Station {name: 'Cheltenham Spa'}) WHERE
                   none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
 RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
     verifyFormatting(query, expected);
@@ -459,7 +460,7 @@ RETURN [stop IN n[.. -1] | stop.name] AS stops`.trimStart();
 RETURN [r IN relationships(path) | r.distance] AS distances`;
     const expected = `
 MATCH path = ANY (:Station {name: 'Pershore'})-[l:LINK WHERE l.distance < 10]-+
-             (b:Station {name: 'Bromsgrove'})
+                 (b:Station {name: 'Bromsgrove'})
 RETURN [r IN relationships(path) | r.distance] AS distances`.trimStart();
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -414,7 +414,19 @@ RETURN DISTINCT abcde.qwertyuiopa, abcde.zxcvbnmasdfgh, abcde.zxcvbnml,
     verifyFormatting(query, expected);
   });
 
-  test('selector example', () => {
+  test('simple selector example', () => {
+    const query = `MATCH SHORTEST 1
+  (:Station {name: 'Hartlebury'})
+  (()--(n))+
+  (:Station {name: 'Cheltenham Spa'})
+RETURN [stop in n[..-1] | stop.name] AS stops`;
+    const expected = `MATCH SHORTEST 1 (:Station {name: 'Hartlebury'}) (()--(n))+
+      (:Station {name: 'Cheltenham Spa'})
+RETURN [stop IN n[.. -1] | stop.name] AS stops`;
+    verifyFormatting(query, expected);
+  });
+
+  test('complex selector example', () => {
     const query = `MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
                  (:Station {name: 'Cheltenham Spa'}) WHERE none(
                  stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))


### PR DESCRIPTION
## Description

Greg noted that some of the examples from [this page](https://neo4j.com/docs/cypher-manual/current/patterns/shortest-paths/) have some quirks that would be good to straighten out. This PR addresses those concerns, by making the following changes:

- The selector (e.g. `SHORTEST 1`) now prefers not to split (and if it does, it lines up to the right of the path if there is one)
- Fixed a grouping issue with listItemsPredicate
    - I considered forcing a break after the WHERE as well but that only made it worse in my opinion
- Parenthesized paths with a quantifier prefer to stick together.
    - I considered a forced break after quantifiers, which looks good in some examples, but looks weird for e.g. this one MATCH (p)-[]->*(q)

## Examples (from the page linked above)
### Before
```
MATCH SHORTEST 1 (:Station {name: 'Hartlebury'}) (()--(n))+
                 (:Station {name: 'Cheltenham Spa'})
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
                 (:Station {name: 'Cheltenham Spa'}) WHERE none(
                 stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH p = SHORTEST
      1 ((:Station {name: 'Thisisanabsurdlylongnametomakeitawkward'})
        (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE none(
        stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH path = ANY (:Station {name: 'Pershore'})-[l:LINK WHERE l.distance < 10]-+
                 (b:Station {name: 'Bromsgrove'})
RETURN [r IN relationships(path) | r.distance] AS distances
```

### After

```
MATCH SHORTEST 1 (:Station {name: 'Hartlebury'}) (()--(n))+
                 (:Station {name: 'Cheltenham Spa'})
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH SHORTEST 1 ((:Station {name: 'Hartlebury'}) (()--(n:Station))+
                  (:Station {name: 'Cheltenham Spa'}) WHERE
                  none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH p = SHORTEST 1
          ((:Station {name: 'Thisisanabsurdlylongnametomakeitawkward'})
           (()--(n:Station))+(:Station {name: 'Cheltenham Spa'}) WHERE
           none(stop IN n[.. -1] WHERE stop.name = 'Bromsgrove'))
RETURN [stop IN n[.. -1] | stop.name] AS stops;

MATCH path = ANY (:Station {name: 'Pershore'})-[l:LINK WHERE l.distance < 10]-+
                 (b:Station {name: 'Bromsgrove'})
RETURN [r IN relationships(path) | r.distance] AS distances
```

## Testing

- Added tests for the queries listed above
