### PR TITLE
Fixes trim becoming a keyword in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -54,6 +54,7 @@ import {
   SetClauseContext,
   StatementsOrCommandsContext,
   SubqueryClauseContext,
+  TrimFunctionContext,
   UnwindClauseContext,
   UseClauseContext,
   WhereClauseContext,
@@ -1166,6 +1167,23 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.breakLine();
       this.visit(ctx.singleQuery(i + 1));
     }
+  };
+
+  visitTrimFunction = (ctx: TrimFunctionContext) => {
+    this.visitTerminalRaw(ctx.TRIM());
+    this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    this.visit(ctx.LPAREN());
+    this.avoidBreakBetween();
+    const trimGrp = this.startGroup();
+    this.visitIfNotNull(ctx.BOTH());
+    this.visitIfNotNull(ctx.LEADING());
+    this.visitIfNotNull(ctx.TRAILING());
+    this.visitIfNotNull(ctx._trimCharacterString);
+    this.visitIfNotNull(ctx.FROM());
+    this.visit(ctx._trimSource);
+    this.visit(ctx.RPAREN());
+    this.endGroup(trimGrp);
   };
 
   visitFunctionInvocation = (ctx: FunctionInvocationContext) => {

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -631,4 +631,30 @@ RETURN n, m`;
     const expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('should not treat the trim function as a keyword', () => {
+    const query = `MATCH (v)
+WHERE trim(v.authors) <> ''
+RETURN v`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+
+  test('trim with leading/trailling/both', () => {
+    let query = `MATCH (n)
+WHERE trim(LEADING ' ' FROM n.name) = 'Neo'
+RETURN n`;
+    let expected = query;
+    verifyFormatting(query, expected);
+    query = `MATCH (n)
+WHERE trim(TRAILING ' ' FROM n.name) = 'Neo'
+RETURN n`;
+    expected = query;
+    verifyFormatting(query, expected);
+    query = `MATCH (n)
+WHERE trim(BOTH ' ' FROM n.name) = 'Neo'
+RETURN n`;
+    expected = query;
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
## Description

We got feedback from the #team-cypher channel that `trim` was incorrectly being capitalized and getting weird spacing. The cause of this was that `trimFunction` is a specific grammar construct (why?). This PR adds a visit method for it and some tests to make sure that the trim function gets formatted like expected.

### Before
```
MATCH (v)
WHERE TRIM (v.authors) <> ''
RETURN v
```
### After
```
MATCH (v)
WHERE trim(v.authors) <> ''
RETURN v
```

## Testing
- Adds the test above and a few tests that should cover all the different versions of trim functions that the grammar supports
