### PR TITLE
Fixes tech debt (indentations, outdated code) for formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -69,6 +69,7 @@ import {
   CommentChunk,
   findTargetToken,
   getParseTreeAndTokens,
+  initialIndentation,
   isComment,
   RegularChunk,
   wantsToBeConcatenated,
@@ -375,11 +376,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         text,
         groupsStarting: this.startGroupCounter,
         groupsEnding: 0,
-        indentation: {
-          base: 0,
-          special: 0,
-          align: AlignIndentationOptions.Maintain,
-        },
+        indentation: { ...initialIndentation },
       };
       this.startGroupCounter = 0;
       this.currentBuffer().push(chunk);
@@ -416,11 +413,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         text,
         groupsStarting: 0,
         groupsEnding: 0,
-        indentation: {
-          base: 0,
-          special: 0,
-          align: AlignIndentationOptions.Maintain,
-        },
+        indentation: { ...initialIndentation },
       };
       // If we have a "hard-break" comment, i.e. one that has a newline before it,
       // we end all currently active groups. Otherwise, that comment becomes part of the group,
@@ -714,11 +707,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       node,
       groupsStarting: this.startGroupCounter,
       groupsEnding: 0,
-      indentation: {
-        base: 0,
-        special: 0,
-        align: AlignIndentationOptions.Maintain,
-      },
+      indentation: { ...initialIndentation },
     };
     this.startGroupCounter = 0;
     if (node.symbol.tokenIndex === this.targetToken) {
@@ -759,11 +748,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       node,
       groupsStarting: this.startGroupCounter,
       groupsEnding: 0,
-      indentation: {
-        base: 0,
-        special: 0,
-        align: AlignIndentationOptions.Maintain,
-      },
+      indentation: { ...initialIndentation },
     };
     this.startGroupCounter = 0;
     if (node.symbol.tokenIndex === this.targetToken) {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -272,8 +272,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     type: 'base' | 'special' | 'align',
   ) => {
     const chunk = this.lastInCurrentBuffer();
-    if (type === 'align' && chunk[type] !== AlignIndentationOptions.Maintain) {
-      new Error('Error: align should not be modified if it is not maintain');
+    if (
+      type === 'align' &&
+      chunk.indentation[type] !== AlignIndentationOptions.Maintain
+    ) {
+      throw new Error(
+        'Error: align should not be modified if it is not maintain',
+      );
     }
     if (modifier === 'add') {
       chunk.indentation[type] += 1;

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -278,11 +278,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
-  addIndentation = () => {
+  addBaseIndentation = () => {
     this.setIndentationProperty('add', 'base');
   };
 
-  removeIndentation = () => {
+  removeBaseIndentation = () => {
     this.setIndentationProperty('remove', 'base');
   };
 
@@ -1198,10 +1198,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.CALL());
     this.visitIfNotNull(ctx.subqueryScope());
     this.visit(ctx.LCURLY());
-    this.addIndentation();
+    this.addBaseIndentation();
     this.breakLine();
     this.visit(ctx.regularQuery());
-    this.removeIndentation();
+    this.removeBaseIndentation();
     this.breakLine();
     this.visit(ctx.RCURLY());
     this.visitIfNotNull(ctx.subqueryInTransactionsParameters());
@@ -1212,10 +1212,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.singleQuery(0));
     const n = ctx.singleQuery_list().length - 1;
     for (let i = 0; i < n; i++) {
-      this.addIndentation();
+      this.addBaseIndentation();
       this.breakLine();
       this.visit(ctx.UNION(i));
-      this.removeIndentation();
+      this.removeBaseIndentation();
       if (ctx.ALL(i)) {
         this.visit(ctx.ALL(i));
       } else if (ctx.DISTINCT(i)) {
@@ -1291,10 +1291,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Handled separately because it wants indentation
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
   visitMergeAction = (ctx: MergeActionContext) => {
-    this.addIndentation();
+    this.addBaseIndentation();
     this.breakLine();
     this.visitChildren(ctx);
-    this.removeIndentation();
+    this.removeBaseIndentation();
   };
 
   visitSetClause = (ctx: SetClauseContext) => {
@@ -1407,9 +1407,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
     const n = ctx.clause_list().length;
     for (let i = 0; i < n; i++) {
-      this.addIndentation();
+      this.addBaseIndentation();
       this.visit(ctx.clause(i));
-      this.removeIndentation();
+      this.removeBaseIndentation();
     }
     this.breakLine();
     this.visit(ctx.RPAREN());

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -717,7 +717,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       indentation: {
         base: 0,
         special: 0,
-        align: 0,
+        align: AlignIndentationOptions.Maintain,
       },
     };
     this.startGroupCounter = 0;
@@ -762,7 +762,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       indentation: {
         base: 0,
         special: 0,
-        align: 0,
+        align: AlignIndentationOptions.Maintain,
       },
     };
     this.startGroupCounter = 0;

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -278,7 +278,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       chunk.indentation[type] !== AlignIndentationOptions.Maintain
     ) {
       throw new Error(
-        'Error: align should not be modified if it is not maintain',
+        'Internal formatting error: Chunk should not get its alignIndentation set twice',
       );
     }
     if (modifier === 'add') {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -271,10 +271,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     modifier: 'add' | 'remove',
     type: 'base' | 'special' | 'align',
   ) => {
+    const chunk = this.lastInCurrentBuffer();
+    if (type === 'align' && chunk[type] !== AlignIndentationOptions.Maintain) {
+      new Error('Error: align should not modify if it is not maintain');
+    }
     if (modifier === 'add') {
-      this.lastInCurrentBuffer().indentation[type] += 1;
+      chunk.indentation[type] += 1;
     } else if (modifier === 'remove') {
-      this.lastInCurrentBuffer().indentation[type] -= 1;
+      chunk.indentation[type] -= 1;
     }
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -273,7 +273,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   ) => {
     const chunk = this.lastInCurrentBuffer();
     if (type === 'align' && chunk[type] !== AlignIndentationOptions.Maintain) {
-      new Error('Error: align should not modify if it is not maintain');
+      new Error('Error: align should not be modified if it is not maintain');
     }
     if (modifier === 'add') {
       chunk.indentation[type] += 1;

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -77,6 +77,20 @@ export interface CommentChunk extends BaseChunk {
 // Union type for all chunk types
 export type Chunk = RegularChunk | CommentChunk;
 
+export const initialIndentation: ChunkIndentation = {
+  base: 0,
+  special: 0,
+  align: AlignIndentationOptions.Maintain,
+};
+
+export const emptyChunk: RegularChunk = {
+  type: 'REGULAR',
+  text: '',
+  groupsStarting: 0,
+  groupsEnding: 0,
+  indentation: { ...initialIndentation },
+};
+
 const traillingCharacters = [
   CypherCmdLexer.SEMICOLON,
   CypherCmdLexer.COMMA,

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -44,15 +44,19 @@ export enum AlignIndentationOptions {
   Maintain = 0,
 }
 
+interface ChunkIndentation {
+  base: number;
+  special: number;
+  align: AlignIndentationOptions;
+}
+
 export interface BaseChunk {
   isCursor?: boolean;
   doubleBreak?: true;
   text: string;
   groupsStarting: number;
   groupsEnding: number;
-  modifyIndentation: number;
-  specialIndentation: number;
-  alignIndentation: AlignIndentationOptions;
+  indentation: ChunkIndentation;
 }
 
 // Regular chunk specific properties

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -44,7 +44,7 @@ export enum AlignIndentationOptions {
   Maintain = 0,
 }
 
-interface ChunkIndentation {
+export interface ChunkIndentation {
   base: number;
   special: number;
   align: AlignIndentationOptions;

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -184,16 +184,13 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
 
   // Case 3: Currently for EXISTS, COLLECT and COUNT
   if (state.indentationState.align.length > 0) {
-    const finalIndent =
+    let finalIndent =
       state.activeGroups.length > 0
         ? state.activeGroups.at(-1).align
         : align.at(-1) + INDENTATION + state.indentationState.base;
 
     if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
+      finalIndent = align.pop();
     }
 
     return {

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -125,7 +125,7 @@ export function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
   );
 }
 
-function getNextIndentationLevel(
+function deriveNextIndentationState(
   chunkIndentation: ChunkIndentation,
   indentationState: IndentationState,
 ): IndentationState {
@@ -137,7 +137,7 @@ function getNextIndentationLevel(
 }
 
 function getIndentations(state: State, chunk: Chunk): IndentationResult {
-  const { base, special, align } = getNextIndentationLevel(
+  const { base, special, align } = deriveNextIndentationState(
     chunk.indentation,
     state.indentationState,
   );

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -129,15 +129,10 @@ function getNextIndentationLevel(
   chunkIndentation: ChunkIndentation,
   indentationState: IndentationState,
 ): IndentationState {
-  const nextBaseIndent =
-    indentationState.base + chunkIndentation.base * INDENTATION;
-  const nextSpecialIndent =
-    indentationState.special + chunkIndentation.special * INDENTATION;
-  const align = [...indentationState.align];
   return {
-    base: nextBaseIndent,
-    special: nextSpecialIndent,
-    align: align,
+    base: indentationState.base + chunkIndentation.base * INDENTATION,
+    special: indentationState.special + chunkIndentation.special * INDENTATION,
+    align: [...indentationState.align],
   };
 }
 

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -204,19 +204,8 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
 
   // Case 4: No special indentation rules applied
   if (state.activeGroups.length > 0) {
-    const finalIndent = state.activeGroups.at(-1).align;
-
     return {
-      finalIndentation: finalIndent,
-      indentationState: { base, special, align },
-    };
-  }
-
-  // End of a align indentation
-  // Closing bracket needs ot match with base group
-  if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-    return {
-      finalIndentation: align.pop(),
+      finalIndentation: state.activeGroups.at(-1).align,
       indentationState: { base, special, align },
     };
   }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -108,9 +108,11 @@ const emptyChunk: RegularChunk = {
   text: '',
   groupsStarting: 0,
   groupsEnding: 0,
-  modifyIndentation: 0,
-  specialIndentation: 0,
-  alignIndentation: 0,
+  indentation: {
+    base: 0,
+    special: 0,
+    align: 0,
+  },
 };
 
 export function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
@@ -125,13 +127,13 @@ export function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
 function getIndentations(curr: State, choice: Choice): IndentationResult {
   const currBaseIndent = curr.indentationState.base;
   const nextBaseIndent =
-    currBaseIndent + choice.left.modifyIndentation * INDENTATION;
+    currBaseIndent + choice.left.indentation.base * INDENTATION;
   const nextSpecialIndent =
     curr.indentationState.special +
-    choice.left.specialIndentation * INDENTATION;
+    choice.left.indentation.special * INDENTATION;
   let finalIndent = currBaseIndent;
   const align = [...curr.indentationState.align];
-  if (choice.left.alignIndentation === AlignIndentationOptions.Add) {
+  if (choice.left.indentation.align === AlignIndentationOptions.Add) {
     align.push(curr.activeGroups.at(0).align);
   }
 
@@ -169,7 +171,7 @@ function getIndentations(curr: State, choice: Choice): IndentationResult {
     // When not at the start of a line, no indentation
     finalIndent = 0;
   }
-  if (choice.left.alignIndentation === AlignIndentationOptions.Remove) {
+  if (choice.left.indentation.align === AlignIndentationOptions.Remove) {
     finalIndent = align.pop();
   }
 

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -244,11 +244,7 @@ function getNeighbourState(curr: State, choice: Choice, split: Split): State {
 
   const actualColumn = curr.column === 0 ? finalIndentation : curr.column;
   const splitLength = !isBreak ? split.splitType.length : 0;
-  const leftLength =
-    choice.left.type === 'COMMENT' || choice.left.type === 'REGULAR'
-      ? choice.left.text.length
-      : 0;
-  const thisWordEnd = actualColumn + leftLength + splitLength;
+  const thisWordEnd = actualColumn + choice.left.text.length + splitLength;
   // We don't consider comments nor an empty space as overflowing
   const endWithoutCommentAndSplit =
     choice.left.type === 'COMMENT'

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -212,15 +212,18 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     };
   }
 
-  // Default case
-  let finalIndent = state.indentationState.base;
-
+  // End of a align indentation
+  // Closing bracket needs ot match with base group
   if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-    finalIndent = align.pop();
+    return {
+      finalIndentation: align.pop(),
+      indentationState: { base, special, align },
+    };
   }
 
+  // Default case
   return {
-    finalIndentation: finalIndent,
+    finalIndentation: state.indentationState.base,
     indentationState: { base, special, align },
   };
 }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -153,13 +153,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
 
   // When not at the start of a line, no indentation
   if (state.column !== 0) {
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
-
     return {
       finalIndentation: 0,
       indentationState: { base, special, align },
@@ -170,14 +163,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   if (chunk.type === 'COMMENT' && chunk.breakBefore) {
     const baseGroup = state.activeGroups[0];
     const finalIndent = baseGroup ? baseGroup.align : base;
-
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
-
     return {
       finalIndentation: finalIndent,
       indentationState: { base, special, align },

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -4,9 +4,9 @@ import {
   AlignIndentationOptions,
   Chunk,
   ChunkIndentation,
+  emptyChunk,
   isCommentBreak,
   MAX_COL,
-  RegularChunk,
 } from './formattingHelpers';
 
 const errorMessage = `
@@ -103,18 +103,6 @@ const noBreakSplit: Split[] = [{ splitType: ' ', cost: 0 }];
 const noSpaceNoBreakSplit: Split[] = [{ splitType: '', cost: 0 }];
 const onlyBreakSplit: Split[] = [{ splitType: '\n', cost: 0 }];
 const onlyDoubleBreakSplit: Split[] = [{ splitType: '\n\n', cost: 0 }];
-
-const emptyChunk: RegularChunk = {
-  type: 'REGULAR',
-  text: '',
-  groupsStarting: 0,
-  groupsEnding: 0,
-  indentation: {
-    base: 0,
-    special: 0,
-    align: 0,
-  },
-};
 
 function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
   return (

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -390,19 +390,11 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
   let cursorPos = -1;
   decisions.forEach((decision) => {
     buffer.push(' '.repeat(decision.indentation));
-    const leftType = decision.left.type;
-    if (
-      (leftType === 'REGULAR' || leftType === 'COMMENT') &&
-      decision.left.isCursor
-    ) {
+    if (decision.left.isCursor) {
       cursorPos = buffer.join('').length;
     }
     if (showGroups) addGroupStart(buffer, decision);
-    buffer.push(
-      leftType === 'REGULAR' || leftType === 'COMMENT'
-        ? decision.left.text
-        : '',
-    );
+    buffer.push(decision.left.text);
     if (showGroups) addGroupEnd(buffer, decision);
     buffer.push(decision.chosenSplit.splitType);
   });
@@ -410,10 +402,8 @@ function decisionsToFormatted(decisions: Decision[]): FinalResult {
   if (decisions.at(-1).left.doubleBreak) {
     result += '\n';
   }
-  if (cursorPos === -1) {
-    return result;
-  }
-  return { formattedString: result, cursorPos: cursorPos };
+  // Return appropriate result type based on cursor presence
+  return cursorPos === -1 ? result : { formattedString: result, cursorPos };
 }
 
 function determineSplits(chunk: Chunk, nextChunk: Chunk): Split[] {

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -141,53 +141,53 @@ function getNextIndentationLevel(
   };
 }
 
-function getIndentations(curr: State, choice: Choice): IndentationResult {
+function getIndentations(state: State, chunk: Chunk): IndentationResult {
   const { base, special, align } = getNextIndentationLevel(
-    choice.left.indentation,
-    curr.indentationState,
+    chunk.indentation,
+    state.indentationState,
   );
 
-  if (choice.left.indentation.align === AlignIndentationOptions.Add) {
-    align.push(curr.activeGroups.at(0).align);
+  if (chunk.indentation.align === AlignIndentationOptions.Add) {
+    align.push(state.activeGroups.at(0).align);
   }
 
-  let finalIndent = curr.indentationState.base;
+  let finalIndent = state.indentationState.base;
 
   // Only apply indentation at the start of a line (column === 0)
-  if (curr.column === 0) {
+  if (state.column === 0) {
     // Case 1: Hard-break comments align with base group or base indentation
-    if (choice.left.type === 'COMMENT' && choice.left.breakBefore) {
-      const baseGroup = curr.activeGroups[0];
+    if (chunk.type === 'COMMENT' && chunk.breakBefore) {
+      const baseGroup = state.activeGroups[0];
       finalIndent = baseGroup ? baseGroup.align : base;
     }
     // Case 2: Special indentation, used with CASE
     // Aligns as usual if more than one group exists
     // else indents as specified in state
-    else if (curr.indentationState.special !== 0) {
+    else if (state.indentationState.special !== 0) {
       finalIndent =
-        curr.activeGroups.length > 1
-          ? curr.activeGroups.at(-1).align
-          : curr.indentationState.special;
+        state.activeGroups.length > 1
+          ? state.activeGroups.at(-1).align
+          : state.indentationState.special;
       // Case 3: Currently for for EXISTS, COLLECT and COUNT,
       // Aligning with base group plus indentation plus possible baseIndentation.
       // baseIndentation can happen with UNION
-    } else if (curr.indentationState.align.length > 0) {
+    } else if (state.indentationState.align.length > 0) {
       finalIndent =
-        curr.activeGroups.length > 0
-          ? curr.activeGroups.at(-1).align
-          : align.at(-1) + INDENTATION + curr.indentationState.base;
+        state.activeGroups.length > 0
+          ? state.activeGroups.at(-1).align
+          : align.at(-1) + INDENTATION + state.indentationState.base;
     }
     // Case 4: No special indentation rules applied,
     // Align with latest added active group
-    else if (curr.activeGroups.length > 0) {
-      finalIndent = curr.activeGroups.at(-1).align;
+    else if (state.activeGroups.length > 0) {
+      finalIndent = state.activeGroups.at(-1).align;
     }
     // Default case is already set to currBaseIndent
   } else {
     // When not at the start of a line, no indentation
     finalIndent = 0;
   }
-  if (choice.left.indentation.align === AlignIndentationOptions.Remove) {
+  if (chunk.indentation.align === AlignIndentationOptions.Remove) {
     finalIndent = align.pop();
   }
 
@@ -216,7 +216,10 @@ function getNeighbourState(curr: State, choice: Choice, split: Split): State {
   // over the base indentation.
   const nextGroups = [...curr.activeGroups];
 
-  const { finalIndentation, indentationState } = getIndentations(curr, choice);
+  const { finalIndentation, indentationState } = getIndentations(
+    curr,
+    choice.left,
+  );
 
   const actualColumn = curr.column === 0 ? finalIndentation : curr.column;
   const splitLength = !isBreak ? split.splitType.length : 0;

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -15,7 +15,7 @@ This is likely a bug in the formatter itself. If possible, please report the iss
 along with your input on GitHub:
 https://github.com/neo4j/cypher-language-support.`.trim();
 
-const INDENTATION = 2;
+const INDENTATION_SPACES = 2;
 const showGroups = false;
 
 interface Split {
@@ -130,8 +130,9 @@ function deriveNextIndentationState(
   indentationState: IndentationState,
 ): IndentationState {
   return {
-    base: indentationState.base + chunkIndentation.base * INDENTATION,
-    special: indentationState.special + chunkIndentation.special * INDENTATION,
+    base: indentationState.base + chunkIndentation.base * INDENTATION_SPACES,
+    special:
+      indentationState.special + chunkIndentation.special * INDENTATION_SPACES,
     align: [...indentationState.align],
   };
 }
@@ -193,7 +194,8 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   // Case 3: Currently for EXISTS, COLLECT and COUNT
   if (state.indentationState.align.length > 0) {
     // base case
-    let finalIndent = align.at(-1) + INDENTATION + state.indentationState.base;
+    let finalIndent =
+      align.at(-1) + INDENTATION_SPACES + state.indentationState.base;
 
     // more than one group, align as usual
     if (state.activeGroups.length > 0) {

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -184,11 +184,17 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
 
   // Case 3: Currently for EXISTS, COLLECT and COUNT
   if (state.indentationState.align.length > 0) {
-    let finalIndent =
-      state.activeGroups.length > 0
-        ? state.activeGroups.at(-1).align
-        : align.at(-1) + INDENTATION + state.indentationState.base;
+    // base case
+    let finalIndent = align.at(-1) + INDENTATION + state.indentationState.base;
 
+    // more than one group, align as usual
+    if (state.activeGroups.length > 0) {
+      finalIndent = state.activeGroups.at(-1).align;
+    }
+
+    // Removing one indentationstep
+    // Right bracket should align with base group
+    // What was (align.at(-1))
     if (chunk.indentation.align === AlignIndentationOptions.Remove) {
       finalIndent = align.pop();
     }
@@ -200,6 +206,7 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   }
 
   // Case 4: No special indentation rules applied
+  // Align on the active groups
   if (state.activeGroups.length > 0) {
     return {
       finalIndentation: state.activeGroups.at(-1).align,

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -159,16 +159,17 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     };
   }
 
+  if (chunk.indentation.align === AlignIndentationOptions.Remove) {
+    return {
+      finalIndentation: align.pop(),
+      indentationState: { base, special, align },
+    };
+  }
+
   // Case 1: Hard-break comments align with base group or base indentation
   if (chunk.type === 'COMMENT' && chunk.breakBefore) {
     const baseGroup = state.activeGroups[0];
     const finalIndent = baseGroup ? baseGroup.align : base;
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
     return {
       finalIndentation: finalIndent,
       indentationState: { base, special, align },
@@ -181,12 +182,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
       state.activeGroups.length > 1
         ? state.activeGroups.at(-1).align
         : state.indentationState.special;
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
 
     return {
       finalIndentation: finalIndent,
@@ -202,13 +197,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     // more than one group, align as usual
     if (state.activeGroups.length > 0) {
       finalIndent = state.activeGroups.at(-1).align;
-    }
-
-    // Removing one indentationstep
-    // Right bracket should align with base group
-    // What was (align.at(-1))
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      finalIndent = align.pop();
     }
 
     return {

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -131,6 +131,16 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     state.indentationState,
   );
 
+  // A closing bracket of EXISTS, COLLECT, COUNT
+  // Should align with the first group, which alignment only exist
+  // in align group
+  if (chunk.indentation.align === AlignIndentationOptions.Remove) {
+    return {
+      finalIndentation: align.pop(),
+      indentationState: { base, special, align },
+    };
+  }
+
   // AlignIndentation, used for EXISTS, COUNT, COLLECT
   // Pushes base groups alignment to list to be used later
   // for closing bracket
@@ -142,16 +152,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   if (state.column !== 0) {
     return {
       finalIndentation: 0,
-      indentationState: { base, special, align },
-    };
-  }
-
-  // A closing bracket of EXISTS, COLLECT, COUNT
-  // Should align with the first group, which alignment only exist
-  // in align group
-  if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-    return {
-      finalIndentation: align.pop(),
       indentationState: { base, special, align },
     };
   }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -142,6 +142,9 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     state.indentationState,
   );
 
+  // AlignIndentation, used for EXISTS, COUNT, COLLECT
+  // Pushes base groups alignment to list to be used later
+  // for closing bracket
   if (chunk.indentation.align === AlignIndentationOptions.Add) {
     align.push(state.activeGroups.at(0).align);
   }
@@ -154,6 +157,9 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
     };
   }
 
+  // A closing bracket of EXISTS, COLLECT, COUNT
+  // Should align with the first group, which alignment only exist
+  // in align group
   if (chunk.indentation.align === AlignIndentationOptions.Remove) {
     return {
       finalIndentation: align.pop(),

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -176,13 +176,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
         ? state.activeGroups.at(-1).align
         : state.indentationState.special;
 
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
-
     return {
       finalIndentation: finalIndent,
       indentationState: { base, special, align },
@@ -212,13 +205,6 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   // Case 4: No special indentation rules applied
   if (state.activeGroups.length > 0) {
     const finalIndent = state.activeGroups.at(-1).align;
-
-    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
-      return {
-        finalIndentation: align.pop(),
-        indentationState: { base, special, align },
-      };
-    }
 
     return {
       finalIndentation: finalIndent,

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -163,6 +163,12 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
   if (chunk.type === 'COMMENT' && chunk.breakBefore) {
     const baseGroup = state.activeGroups[0];
     const finalIndent = baseGroup ? baseGroup.align : base;
+    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
+      return {
+        finalIndentation: align.pop(),
+        indentationState: { base, special, align },
+      };
+    }
     return {
       finalIndentation: finalIndent,
       indentationState: { base, special, align },
@@ -175,6 +181,12 @@ function getIndentations(state: State, chunk: Chunk): IndentationResult {
       state.activeGroups.length > 1
         ? state.activeGroups.at(-1).align
         : state.indentationState.special;
+    if (chunk.indentation.align === AlignIndentationOptions.Remove) {
+      return {
+        finalIndentation: align.pop(),
+        indentationState: { base, special, align },
+      };
+    }
 
     return {
       finalIndentation: finalIndent,

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -18,12 +18,12 @@ https://github.com/neo4j/cypher-language-support.`.trim();
 const INDENTATION = 2;
 const showGroups = false;
 
-export interface Split {
+interface Split {
   splitType: ' ' | '' | '\n' | '\n\n';
   cost: number;
 }
 
-export interface Choice {
+interface Choice {
   left: Chunk;
   right: Chunk;
   // The possible splits that the best first search can choose
@@ -35,14 +35,14 @@ interface Group {
   breakCost: number;
 }
 
-export interface Decision {
+interface Decision {
   indentation: number;
   left: Chunk;
   right: Chunk;
   chosenSplit: Split;
 }
 
-export interface State {
+interface State {
   activeGroups: Group[];
   column: number;
   choiceIndex: number;
@@ -57,7 +57,7 @@ interface StateEdge {
   decision: Decision;
 }
 
-export interface Result {
+interface Result {
   cost: number;
   decisions: Decision[];
   indentation: IndentationState;
@@ -116,7 +116,7 @@ const emptyChunk: RegularChunk = {
   },
 };
 
-export function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
+function doesNotWantSpace(chunk: Chunk, nextChunk: Chunk): boolean {
   return (
     nextChunk?.type !== 'COMMENT' &&
     chunk.type === 'REGULAR' &&


### PR DESCRIPTION
## Description
This PR primarily addresses technical debt related to how indentation is handled. Additionally, it removes some unnecessary checks, improving code clarity.

### Indentation
In PR: https://github.com/neo4j/cypher-language-support/pull/404 and https://github.com/neo4j/cypher-language-support/pull/400 a changes was made to how indentations was made. However, these also introduced tech debt in form that it became much more difficult to understand how indentation works. This is hopefully improved in this PR. The main idea is to create a clear distinction between how indentation is handled in the Chunk, and how the chunk affects the State:s indentation.

The function which calculates the indentation for the current chunk also got an overhaul. Instead of nested if statements we do a if check and return immediately. This hopefully helps with understanding what is responsible of what and what should be returned.

### Cleanup of Unnecessary Checks
This PR also removes redundant checks introduced in [#375](https://github.com/neo4j/cypher-language-support/pull/375). That PR changed the behavior so that only RegularChunk or CommentChunk can be present in the buffers and ChunkList, making certain checks unnecessary.

### Unnecessary exports
This PR also found some interfaces which was unnecessarily exported, these exports was removed. 

### Test
 - All tests passes
 - The sanity check with 10 000 queries passes