### PR TITLE
Fixes formatter treating normalize as a keyword

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -37,6 +37,7 @@ import {
   MergeClauseContext,
   NamespaceContext,
   NodePatternContext,
+  NormalizeFunctionContext,
   NumberLiteralContext,
   ParameterContext,
   ParenthesizedExpressionContext,
@@ -1207,6 +1208,23 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.breakLine();
       this.visit(ctx.singleQuery(i + 1));
     }
+  };
+
+  visitNormalizeFunction = (ctx: NormalizeFunctionContext) => {
+    this.visitTerminalRaw(ctx.NORMALIZE());
+    this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    this.visit(ctx.LPAREN());
+    const normalizeGrp = this.startGroup();
+    this.avoidBreakBetween();
+    this.avoidSpaceBetween();
+    this.visit(ctx.expression());
+    if (ctx.COMMA()) {
+      this.visit(ctx.COMMA());
+      this.visit(ctx.normalForm());
+    }
+    this.visit(ctx.RPAREN());
+    this.endGroup(normalizeGrp);
   };
 
   visitTrimFunction = (ctx: TrimFunctionContext) => {

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -657,4 +657,13 @@ RETURN n`;
     expected = query;
     verifyFormatting(query, expected);
   });
+
+  test('should not treat the normalize function as a keyword', () => {
+    let query = `RETURN normalize('Café') AS normalizedDefault`;
+    let expected = query;
+    verifyFormatting(query, expected);
+    query = `RETURN normalize('Café', NFD) AS normalizedNFD`;
+    expected = query;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -659,11 +659,14 @@ RETURN n`;
   });
 
   test('should not treat the normalize function as a keyword', () => {
-    let query = `RETURN normalize('Café') AS normalizedDefault`;
-    let expected = query;
+    const query = `RETURN normalize('Café') AS normalizedDefault`;
+    const expected = query;
     verifyFormatting(query, expected);
-    query = `RETURN normalize('Café', NFD) AS normalizedNFD`;
-    expected = query;
+  });
+
+  test('should not forget about the second argument in normalize', () => {
+    const query = `RETURN normalize('Café', NFD) AS normalizedNFD`;
+    const expected = query;
     verifyFormatting(query, expected);
   });
 });


### PR DESCRIPTION
## Description
We got some feedback in the #team-cypher thread about certain weird functions getting formatted like keywords. #407 fixed one of these issues, but there were 4 cases in total that behaved similarly. We already handle three of them, but `normalizeFunction` is still broken similarly to trim(). This PR fixes that (final) case as well.

They also mentioned that "_we will be adding VECTOR for the vectorValueConstructor soonish too_" which we might want to look out for in the future.

## Testing
Adds tests for normalize which cover all the ways it can be expressed according to the grammar