### PR TITLE
Configures defaults for formatting VSCode package.json

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,8 @@
   "preview": true,
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Formatters"
   ],
   "keywords": [
     "cypher",
@@ -320,7 +321,8 @@
     },
     "configurationDefaults": {
       "[cypher]": {
-        "editor.semanticHighlighting.enabled": true
+        "editor.semanticHighlighting.enabled": true,
+        "editor.defaultFormatter": "neo4j-extensions.neo4j-for-vscode"
       }
     }
   },


### PR DESCRIPTION
Configuring the formatter keyword is so that when someone tries to format a cypher file they get suggested our extension:

<img width="262" src="https://github.com/user-attachments/assets/68840750-2c06-4c83-a8ed-70ad1966623a" />
<img width="445" src="https://github.com/user-attachments/assets/9c7ed423-3c68-44d2-ac52-10f2ea4a2ca8" />


Adding `"editor.defaultFormatter": "neo4j-extensions.neo4j-for-vscode"` I'm hoping people don't get the following in Cypher files:

<img width="294" src="https://github.com/user-attachments/assets/1644f233-c0ab-4dcb-8696-ddb2b76254ca" />
