### PR TITLE
Fixes connection state incorrectly being set to inactive

### DIFF
--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -60,11 +60,14 @@ export async function deleteConnectionAndUpdateDatabaseConnection(
     return;
   }
 
+  const activeConnection = getActiveConnection();
+  const isActiveConnection = activeConnection && activeConnection.key === key;
+
   delete connections[key];
   await saveConnections(connections);
   await deletePasswordByKey(key);
 
-  if (connection.state !== 'inactive') {
+  if (isActiveConnection) {
     const result = await disconnectFromDatabaseAndNotifyLanguageClient();
     connection.state = 'inactive';
     displayMessageForConnectionResult(connection, result);

--- a/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
+++ b/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
@@ -226,7 +226,7 @@ suite('Execute commands spec', () => {
 
       // This test is flaky due to the deletion command occasionally happening too quickly, so wait
       // for it a bit.
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 10000));
 
       await commands.executeCommand(
         CONSTANTS.COMMANDS.DELETE_CONNECTION_COMMAND,

--- a/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
+++ b/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
@@ -224,10 +224,6 @@ suite('Execute commands spec', () => {
         CONSTANTS.MESSAGES.CONNECTED_MESSAGE,
       );
 
-      // This test is flaky due to the deletion command occasionally happening too quickly, so wait
-      // for it a bit.
-      await new Promise((resolve) => setTimeout(resolve, 10000));
-
       await commands.executeCommand(
         CONSTANTS.COMMANDS.DELETE_CONNECTION_COMMAND,
         {

--- a/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
+++ b/packages/vscode-extension/tests/specs/unit/executeCommands.spec.ts
@@ -224,6 +224,10 @@ suite('Execute commands spec', () => {
         CONSTANTS.MESSAGES.CONNECTED_MESSAGE,
       );
 
+      // This test is flaky due to the deletion command occasionally happening too quickly, so wait
+      // for it a bit.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       await commands.executeCommand(
         CONSTANTS.COMMANDS.DELETE_CONNECTION_COMMAND,
         {


### PR DESCRIPTION
## Description

I've noticed that most of the e2e CI / CD runs have been failling recently, see for instance;

https://github.com/neo4j/cypher-language-support/actions/runs/13897318639/job/38880796738?pr=412

https://github.com/neo4j/cypher-language-support/actions/runs/13897573797/job/38881589386?pr=411

They all fail due to the the test `Deleting another connection should not disconnect the current one` which makes sure that deleting a connection that is not the activec one does not give a "disconnected" message (as far as I can tell, at least).  

This was actually brought up by @anderson4j while reviewing this PR https://github.com/neo4j/cypher-language-support/pull/357 and a test was added for it, but for some reason the functionality works locally but not on the GH e2e test runner 😢 

This PR adds the suggested check to make sure that the "disconnected" message is only shown if the deleted connection is the one that is currently active.

### Testing
I've run the e2e tests on the Github CI/CD 3 times, and it has passed every time.
edit: the full e2e tests failed once but due to another reason; the test in question passed on that run