### PR TITLE
Adds support for common commands to formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -577,6 +577,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitCommandOptions = (ctx: CommandOptionsContext) => {
     this.breakLine();
     this.visit(ctx.OPTIONS());
+    this.avoidBreakBetween();
     this.visit(ctx.mapOrParameter());
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -459,6 +459,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
   };
 
+  breakAndVisitChildren = (ctx: ParserRuleContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
   visitStatementsOrCommands = (ctx: StatementsOrCommandsContext) => {
     const n = ctx.statementOrCommand_list().length;
     for (let i = 0; i < n; i++) {
@@ -474,8 +479,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitCommand = (ctx: CommandContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
     this.preserveExplicitNewlineAfter(ctx);
   };
 
@@ -540,22 +544,18 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitConstraintTyped = (ctx: ConstraintTypedContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
   };
 
   visitConstraintIsUnique = (ctx: ConstraintIsUniqueContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
   };
 
   visitConstraintKey = (ctx: ConstraintKeyContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
   };
   visitConstraintIsNotNull = (ctx: ConstraintIsNotNullContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
   };
 
   visitCreateIndex_ = (ctx: CreateIndex_Context) => {
@@ -659,8 +659,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Handled separately because clauses should start on new lines, see
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
   visitClause = (ctx: ClauseContext) => {
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
     this.preserveExplicitNewlineAfter(ctx);
   };
 
@@ -765,8 +764,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   visitLimit = (ctx: LimitContext) => {
     this.preserveExplicitNewlineBefore(ctx);
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
   };
 
   visitReturnItem = (ctx: ReturnItemContext) => {
@@ -1524,8 +1522,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
   visitMergeAction = (ctx: MergeActionContext) => {
     this.addBaseIndentation();
-    this.breakLine();
-    this.visitChildren(ctx);
+    this.breakAndVisitChildren(ctx);
     this.removeBaseIndentation();
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -19,6 +19,7 @@ import {
   CreateClauseContext,
   CreateCommandContext,
   CreateConstraintContext,
+  CreateIndex_Context,
   DeleteClauseContext,
   ExistsExpressionContext,
   Expression10Context,
@@ -472,6 +473,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.preserveExplicitNewlineAfter(ctx);
   };
 
+  _visitCommandIfNotExists = (
+    ctx: CreateConstraintContext | CreateIndex_Context,
+  ) => {
+    if (ctx.IF()) {
+      this.avoidBreakBetween();
+      this.visit(ctx.IF());
+      this.avoidBreakBetween();
+      this.visit(ctx.NOT());
+      this.avoidBreakBetween();
+      this.visit(ctx.EXISTS());
+    }
+  };
+
   visitCreateCommand = (ctx: CreateCommandContext) => {
     this.visit(ctx.CREATE());
     this.avoidBreakBetween();
@@ -493,14 +507,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.CONSTRAINT());
     this.avoidBreakBetween();
     this.visitIfNotNull(ctx.symbolicNameOrStringParameter());
-    if (ctx.IF()) {
-      this.avoidBreakBetween();
-      this.visit(ctx.IF());
-      this.avoidBreakBetween();
-      this.visit(ctx.NOT());
-      this.avoidBreakBetween();
-      this.visit(ctx.EXISTS());
-    }
+    this._visitCommandIfNotExists(ctx);
     this.breakLine();
     this.visit(ctx.FOR());
     this.avoidBreakBetween();
@@ -527,6 +534,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   visitConstraintIsNotNull = (ctx: ConstraintIsNotNullContext) => {
     this.breakLine();
     this.visitChildren(ctx);
+  };
+
+  visitCreateIndex_ = (ctx: CreateIndex_Context) => {
+    this.visitIfNotNull(ctx.symbolicNameOrStringParameter());
+    this._visitCommandIfNotExists(ctx);
+    this.breakLine();
+    this.visit(ctx.FOR());
+    this.visitIfNotNull(ctx.commandNodePattern());
+    this.visitIfNotNull(ctx.commandRelPattern());
+    this.breakLine();
+    this.visit(ctx.ON());
+    this.visit(ctx.propertyList());
+    this.visitIfNotNull(ctx.commandOptions());
   };
 
   visitCommandNodePattern = (ctx: CommandNodePatternContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -70,6 +70,7 @@ import {
   ReturnItemContext,
   ReturnItemsContext,
   SetClauseContext,
+  ShowCommandYieldContext,
   StatementsOrCommandsContext,
   SubqueryClauseContext,
   TrimFunctionContext,
@@ -491,6 +492,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.visit(ctx.NOT());
       this.avoidBreakBetween();
       this.visit(ctx.EXISTS());
+    }
+  };
+
+  visitShowCommandYield = (ctx: ShowCommandYieldContext) => {
+    if (ctx.yieldClause()) {
+      this.breakLine();
+      this.visit(ctx.yieldClause());
+      if (ctx.returnClause()) {
+        this.breakLine();
+        this.visit(ctx.returnClause());
+      }
+    } else {
+      this.visit(ctx.whereClause());
     }
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -11,6 +11,7 @@ import {
   CommandContext,
   CommandNodePatternContext,
   CommandOptionsContext,
+  CommandRelPatternContext,
   ConstraintIsNotNullContext,
   ConstraintIsUniqueContext,
   ConstraintKeyContext,
@@ -63,6 +64,7 @@ import {
   ReduceExpressionContext,
   RegularQueryContext,
   RelationshipPatternContext,
+  RelTypeContext,
   ReturnBodyContext,
   ReturnClauseContext,
   ReturnItemContext,
@@ -603,6 +605,40 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.visit(ctx.labelType());
     this.concatenate();
     this.visit(ctx.RPAREN());
+  };
+
+  visitCommandRelPattern = (ctx: CommandRelPatternContext) => {
+    this.visit(ctx.LPAREN(0));
+    this.visit(ctx.RPAREN(0));
+    if (ctx.leftArrow()) {
+      this.visit(ctx.leftArrow());
+      this.concatenate();
+    }
+    this.visit(ctx.arrowLine(0));
+    this.concatenate();
+    this.avoidSpaceBetween();
+    this.visit(ctx.LBRACKET());
+    this.avoidSpaceBetween();
+    this.avoidBreakBetween();
+    this.visit(ctx.variable());
+    this.avoidSpaceBetween();
+    this.visit(ctx.relType());
+    this.visit(ctx.RBRACKET());
+    this.visit(ctx.arrowLine(1));
+    this.concatenate();
+    if (ctx.rightArrow()) {
+      this.visit(ctx.rightArrow());
+      this.concatenate();
+    }
+    this.avoidSpaceBetween();
+    this.visit(ctx.LPAREN(1));
+    this.visit(ctx.RPAREN(1));
+  };
+
+  visitRelType = (ctx: RelTypeContext) => {
+    this.visit(ctx.COLON());
+    this.avoidSpaceBetween();
+    this.visit(ctx.symbolicNameString());
   };
 
   // Handled separately because clauses should start on new lines, see

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -8,9 +8,17 @@ import {
   CaseExpressionContext,
   ClauseContext,
   CollectExpressionContext,
+  CommandContext,
+  CommandNodePatternContext,
+  ConstraintIsNotNullContext,
+  ConstraintIsUniqueContext,
+  ConstraintKeyContext,
+  ConstraintTypedContext,
   CountExpressionContext,
   CountStarContext,
   CreateClauseContext,
+  CreateCommandContext,
+  CreateConstraintContext,
   DeleteClauseContext,
   ExistsExpressionContext,
   Expression10Context,
@@ -456,6 +464,78 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         this.preserveExplicitNewlineAfter(ctx.SEMICOLON(i));
       }
     }
+  };
+
+  visitCommand = (ctx: CommandContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+    this.preserveExplicitNewlineAfter(ctx);
+  };
+
+  visitCreateCommand = (ctx: CreateCommandContext) => {
+    this.visit(ctx.CREATE());
+    this.avoidBreakBetween();
+    if (ctx.OR()) {
+      this.visit(ctx.OR());
+      this.avoidBreakBetween();
+      this.visit(ctx.REPLACE());
+      this.avoidBreakBetween();
+    }
+    this.visitIfNotNull(ctx.createCompositeDatabase());
+    this.visitIfNotNull(ctx.createConstraint());
+    this.visitIfNotNull(ctx.createDatabase());
+    this.visitIfNotNull(ctx.createIndex());
+    this.visitIfNotNull(ctx.createRole());
+    this.visitIfNotNull(ctx.createUser());
+  };
+
+  visitCreateConstraint = (ctx: CreateConstraintContext) => {
+    this.visit(ctx.CONSTRAINT());
+    this.avoidBreakBetween();
+    this.visitIfNotNull(ctx.symbolicNameOrStringParameter());
+    if (ctx.IF()) {
+      this.avoidBreakBetween();
+      this.visit(ctx.IF());
+      this.avoidBreakBetween();
+      this.visit(ctx.NOT());
+      this.avoidBreakBetween();
+      this.visit(ctx.EXISTS());
+    }
+    this.breakLine();
+    this.visit(ctx.FOR());
+    this.avoidBreakBetween();
+    this.visitIfNotNull(ctx.commandNodePattern());
+    this.visitIfNotNull(ctx.commandRelPattern());
+    this.visit(ctx.constraintType());
+    this.visitIfNotNull(ctx.commandOptions());
+  };
+
+  visitConstraintTyped = (ctx: ConstraintTypedContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
+  visitConstraintIsUnique = (ctx: ConstraintIsUniqueContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
+  visitConstraintKey = (ctx: ConstraintKeyContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+  visitConstraintIsNotNull = (ctx: ConstraintIsNotNullContext) => {
+    this.breakLine();
+    this.visitChildren(ctx);
+  };
+
+  visitCommandNodePattern = (ctx: CommandNodePatternContext) => {
+    this.visit(ctx.LPAREN());
+    this.visit(ctx.variable());
+    this.concatenate();
+    this.visit(ctx.labelType());
+    this.concatenate();
+    this.visit(ctx.RPAREN());
   };
 
   // Handled separately because clauses should start on new lines, see

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -49,6 +49,14 @@ ON (a.id)`;
     verifyFormatting(query, expected);
   });
 
+  test('create index with command rel pattern', () => {
+    const query = `create index relationship_index for ()-[rel:FRIENDS_WITH]-() on (rel.since, rel.status)`;
+    const expected = `CREATE INDEX relationship_index
+FOR ()-[rel:FRIENDS_WITH]-()
+ON (rel.since, rel.status)`;
+    verifyFormatting(query, expected);
+  });
+
   test('create constraint with options', () => {
     const query = `create constraint for (a: Athlete) require a.id is unique options { constraintName: 'Athlete_Id_Unique' }`;
     const expected = `

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -121,6 +121,23 @@ OPTIONS {aaaaaa: "20z9vakp",
           aaaaaa: ["EEJJKZGC", "GGDt2msc"]}}`;
     verifyFormatting(query, expected);
   });
+
+  test('show indexes with where and return', () => {
+    const query = `SHOW INDEXES YIELD aaaaaa, aaaaaa, aaaaaa, aaaaaa, aaaaaa
+WHERE aaaaaa = "wjL0ojNI" RETURN aaaaaa, aaaaaa, aaaaaa, aaaaaa`;
+    const expected = `SHOW INDEXES
+YIELD aaaaaa, aaaaaa, aaaaaa, aaaaaa, aaaaaa
+WHERE aaaaaa = "wjL0ojNI"
+RETURN aaaaaa, aaaaaa, aaaaaa, aaaaaa`;
+    verifyFormatting(query, expected);
+  });
+
+  test('show indexes with just a where clause', () => {
+    const query = `SHOW INDEXES WHERE aaaaaa = "wjL0ojNI"`;
+    const expected = `SHOW INDEXES
+WHERE aaaaaa = "wjL0ojNI"`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for explicit newlines in commands', () => {

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -48,4 +48,13 @@ FOR (a:Athlete)
 ON (a.id)`;
     verifyFormatting(query, expected);
   });
+
+  test('create fulltext index', () => {
+    const query = `create fulltext index index_name for (a: Athlete) on each [a.name]`;
+    const expected = `
+CREATE FULLTEXT INDEX index_name
+FOR (a:Athlete)
+ON EACH [a.name]`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -40,4 +40,12 @@ FOR (a:Athlete)
 REQUIRE a.id IS NOT NULL`;
     verifyFormatting(query, expected);
   });
+
+  test('basic create index for on', () => {
+    const query = `create index index_name for (a: Athlete) on (a.id)`;
+    const expected = `CREATE INDEX index_name
+FOR (a:Athlete)
+ON (a.id)`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -59,6 +59,16 @@ OPTIONS {constraintName: 'Athlete_Id_Unique'}`.trimStart();
     verifyFormatting(query, expected);
   });
 
+  test('create constraint with multiple options', () => {
+    const query = `create constraint for (a: Athlete) require a.id is unique options { constraintName: 'Athlete_Id_Unique', enforced: true }`;
+    const expected = `
+CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS UNIQUE
+OPTIONS {constraintName: 'Athlete_Id_Unique', enforced: true}`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
   test('create fulltext index', () => {
     const query = `create fulltext index index_name for (a: Athlete) on each [a.name]`;
     const expected = `

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -104,6 +104,23 @@ FOR (a:Athlete|CouchPotato|Olympian)
 ON EACH [a.name]`.trimStart();
     verifyFormatting(query, expected);
   });
+
+  test('should not break after options', () => {
+    const query = `CREATE CONSTRAINT aaaaaa FOR ( aaaaaa : aaaaaa ) REQUIRE ( aaaaaa . aaaaaa ) IS UNIQUE OPTIONS { aaaaaa : "20z9vakp" , aaaaaa : { aaaaaa : [ "aotV0uiw" , "SCxu0Vyn" , "ekTx6ngu" ] , aaaaaa : [ "WqAr9IvS" , "j5fYJwuN" ] , aaaaaa : [ "HUDXLCRN" , "LUfKWGc7" ] , aaaaaa : [ "qbk3JzMe" , "Ca4n1Ea9" , "I96Uwq16" ] , aaaaaa : [ "zcBcWjoJ" , "dz78begI" ] , aaaaaa : [ "MIADLwls" , "qkacQgzY" , "wYYAgiGo" ] , aaaaaa : [ "Jmw0tXjZ" , "ALiXrHno" , "QRYTGYFd" ] , aaaaaa : [ "EEJJKZGC" , "GGDt2msc" ] } }`;
+    const expected = `CREATE CONSTRAINT aaaaaa
+FOR (aaaaaa:aaaaaa)
+REQUIRE (aaaaaa.aaaaaa) IS UNIQUE
+OPTIONS {aaaaaa: "20z9vakp",
+         aaaaaa:
+         {aaaaaa: ["aotV0uiw", "SCxu0Vyn", "ekTx6ngu"],
+          aaaaaa: ["WqAr9IvS", "j5fYJwuN"], aaaaaa: ["HUDXLCRN", "LUfKWGc7"],
+          aaaaaa: ["qbk3JzMe", "Ca4n1Ea9", "I96Uwq16"],
+          aaaaaa: ["zcBcWjoJ", "dz78begI"],
+          aaaaaa: ["MIADLwls", "qkacQgzY", "wYYAgiGo"],
+          aaaaaa: ["Jmw0tXjZ", "ALiXrHno", "QRYTGYFd"],
+          aaaaaa: ["EEJJKZGC", "GGDt2msc"]}}`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for explicit newlines in commands', () => {

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -1,0 +1,43 @@
+import { verifyFormatting } from './testutil';
+
+describe('tests for create constraint', () => {
+  test('basic create constraint is unique', () => {
+    const query = `create constraint for (a: Athlete) require a.id is unique`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS UNIQUE`;
+    verifyFormatting(query, expected);
+  });
+
+  test('basic create constraint with "::"', () => {
+    const query = `create constraint for (a: Athlete) require a.id :: int`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id :: INT`;
+    verifyFormatting(query, expected);
+  });
+
+  test('basic create with "is typed"', () => {
+    const query = `create constraint for (a: Athlete) require a.id is typed int`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS TYPED INT`;
+    verifyFormatting(query, expected);
+  });
+
+  test('basic create constraint with key', () => {
+    const query = `create constraint for (a: Athlete) require a.id is key`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS KEY`;
+    verifyFormatting(query, expected);
+  });
+
+  test('basic create constraint with not null', () => {
+    const query = `create constraint for (a: Athlete) require a.id is not null`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS NOT NULL`;
+    verifyFormatting(query, expected);
+  });
+});

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -106,7 +106,7 @@ ON EACH [a.name]`.trimStart();
   });
 });
 
-describe('tests for explicit newlines', () => {
+describe('tests for explicit newlines in commands', () => {
   test('two indexes with explicit newline inbetween', () => {
     const query = `
 CREATE FULLTEXT INDEX index_name FOR (a:Athlete) ON EACH [a.name];

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -57,6 +57,16 @@ ON (rel.since, rel.status)`;
     verifyFormatting(query, expected);
   });
 
+  test('create index on relationship with options', () => {
+    const query = `create index index_name for ()-[r:RELATIONTYPE]-() on (r.since) options { indexProvider: 'range-1.0' }`;
+    const expected = `
+CREATE INDEX index_name
+FOR ()-[r:RELATIONTYPE]-()
+ON (r.since)
+OPTIONS {indexProvider: 'range-1.0'}`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
   test('create constraint with options', () => {
     const query = `create constraint for (a: Athlete) require a.id is unique options { constraintName: 'Athlete_Id_Unique' }`;
     const expected = `

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -54,7 +54,16 @@ ON (a.id)`;
     const expected = `
 CREATE FULLTEXT INDEX index_name
 FOR (a:Athlete)
-ON EACH [a.name]`;
+ON EACH [a.name]`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('create fulltext index with multiple bars', () => {
+    const query = `create fulltext index index_name for (a: Athlete|CouchPotato|Olympian) on each [a.name]`;
+    const expected = `
+CREATE FULLTEXT INDEX index_name
+FOR (a:Athlete|CouchPotato|Olympian)
+ON EACH [a.name]`.trimStart();
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -49,6 +49,16 @@ ON (a.id)`;
     verifyFormatting(query, expected);
   });
 
+  test('create constraint with options', () => {
+    const query = `create constraint for (a: Athlete) require a.id is unique options { constraintName: 'Athlete_Id_Unique' }`;
+    const expected = `
+CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS UNIQUE
+OPTIONS {constraintName: 'Athlete_Id_Unique'}`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
   test('create fulltext index', () => {
     const query = `create fulltext index index_name for (a: Athlete) on each [a.name]`;
     const expected = `

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -1,6 +1,6 @@
 import { verifyFormatting } from './testutil';
 
-describe('tests for create constraint', () => {
+describe('tests for commands', () => {
   test('basic create constraint is unique', () => {
     const query = `create constraint for (a: Athlete) require a.id is unique`;
     const expected = `CREATE CONSTRAINT

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -105,3 +105,35 @@ ON EACH [a.name]`.trimStart();
     verifyFormatting(query, expected);
   });
 });
+
+describe('tests for explicit newlines', () => {
+  test('two indexes with explicit newline inbetween', () => {
+    const query = `
+CREATE FULLTEXT INDEX index_name FOR (a:Athlete) ON EACH [a.name];
+
+CREATE FULLTEXT INDEX index_name FOR (a:Athlete) ON EACH [a.id];`;
+    const expected = `
+CREATE FULLTEXT INDEX index_name
+FOR (a:Athlete)
+ON EACH [a.name];
+
+CREATE FULLTEXT INDEX index_name
+FOR (a:Athlete)
+ON EACH [a.id];`.trimStart();
+    verifyFormatting(query, expected);
+  });
+
+  test('two constraints with comments', () => {
+    const query = `CREATE CONSTRAINT FOR (a:Athlete) REQUIRE a.id IS UNIQUE
+
+// This is a comment and there is an explicit newline
+OPTIONS {constraintName: 'Athlete_Id_Unique'}`;
+    const expected = `CREATE CONSTRAINT
+FOR (a:Athlete)
+REQUIRE a.id IS UNIQUE
+
+// This is a comment and there is an explicit newline
+OPTIONS {constraintName: 'Athlete_Id_Unique'}`;
+    verifyFormatting(query, expected);
+  });
+});

--- a/packages/language-support/src/tests/formatting/commands.test.ts
+++ b/packages/language-support/src/tests/formatting/commands.test.ts
@@ -17,7 +17,7 @@ REQUIRE a.id :: INT`;
     verifyFormatting(query, expected);
   });
 
-  test('basic create with "is typed"', () => {
+  test('basic create constraint with "is typed"', () => {
     const query = `create constraint for (a: Athlete) require a.id is typed int`;
     const expected = `CREATE CONSTRAINT
 FOR (a:Athlete)


### PR DESCRIPTION
## Description
Commands are administrative queries that you can run against a neo4j database, such as 
```
CREATE CONSTRAINT `constraintName` IF NOT EXISTS
FOR (n: nodeType)
REQUIRE (n.id) IS UNIQUE;
```
or a plethora of other ones, such as `DROP INDEX`, `SHOW TRANSACTIONS` etc. etc.

As of yet, we have had very limited support for these, beyond capitalizing the keywords. The main reason for this is that commands have grammar that is essentially completely separated from the rest of the grammar (including e.g. node and relationship patterns). This PR adds support for _most_ of the common commands.

### Scoping / context
Most queries are not commands. In fact, out of 1174529 queries, 11749 of them (1%) were commands or contained at least one command. Further, out of those 11749 commands, 7811 of them contained "CREATE CONSTRAINT" (tested with a simple grep so might not be 100% accurate). Another 1338 of them contained "CREATE INDEX". 

Given the numbers above, we have decided that we don't necessarily care about supporting 100% of commands (yet) since they are unlikely to ever reach our formatter (a lot of commands also don't need formatting, e.g. `SHOW TRANSACTIONS`). At some point, when the formatter is in a more stable state, it might make sense to go for full support, but it is not prioritized right now (we are prioritizing V3 over this).

Instead, this PR focuses on the most commonly used ones, such as `CREATE CONSTRAINT`and `CREATE INDEX`.

## Testing

### Unit tests
17 new unit tests that test all the `CREATE CONSTRAINT`and `CREATE INDEX` grammar cases plus a few other things

### ✨Vibe check✨ 
I spent roughly 25 minutes clicking through all the commands from the sample queries, and evaluated (based on vibes) whether the formatting was reasonable. All the output I saw was reasonable (though I am probably missing a few rare commands).

### Verification check
I ran the verification check on the 11749 commands, and all but 6 passed. The ones that didn't pass were all `SHOW TRANSACTIONS`, which is valid cypher (I could run it in query) but does not actually follow the grammar since it is missing some required parts. This leads to an internal error in `getBottomChild` because of the missing node. The syntax error Pr (#412) will take care of this however so I have not fixed it here. 