### PR TITLE
Improves CASE inside CALL clause

### DIFF
--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -170,7 +170,8 @@ function getFinalIndentation(
   if (state.indentationState.special !== 0) {
     return (
       state.indentationState.special +
-      INDENTATION_SPACES * state.indentationState.align.length
+      INDENTATION_SPACES * state.indentationState.align.length +
+      state.indentationState.base
     );
   }
 

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -862,4 +862,32 @@ RETURN
   END AS userProfile;`;
     verifyFormatting(query, expected);
   });
+  test('CASE expression inside a CALL clause', () => {
+    const query = `MATCH (u:User)
+CALL {
+    WITH u
+    OPTIONAL MATCH (u)-[:PURCHASED]->(:Product)
+    WITH u, COUNT(*) AS purchaseCount
+    RETURN 
+    CASE 
+    WHEN purchaseCount > 0 THEN 'Active' 
+    ELSE 'Inactive' 
+    END AS status
+}
+RETURN u.name, status;`;
+    const expected = `
+MATCH (u:User)
+CALL {
+  WITH u
+  OPTIONAL MATCH (u)-[:PURCHASED]->(:Product)
+  WITH u, COUNT(*) AS purchaseCount
+  RETURN
+    CASE
+      WHEN purchaseCount > 0 THEN 'Active'
+      ELSE 'Inactive'
+    END AS status
+}
+RETURN u.name, status;`.trimStart();
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
### Description
During #411 I noticed that `CASE` statements inside a `CALL` clause does not get the base indentation unlike `EXISTS` does. This PR improves `CASE` expression inside a `CALL` clause by adding correct base indentation. 

### Tests
 - One test added
 - All tests passes 