### PR TITLE
Fixes parameters not being available on disconnect in VSCode

### DIFF
--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -352,7 +352,9 @@ const parameterCompletions = (
         // We need to have the insert text without the starting $ in VSCode,
         // otherwise when we have 'RETURN $' and we get offered $param
         // we would complete RETURN $$param, which is not what we want
-        maybeInsertText = suffix ? { insertText: paramName } : {};
+        maybeInsertText = suffix
+          ? { insertText: param.slice(1) }
+          : maybeInsertText;
       }
 
       return {

--- a/packages/language-support/src/tests/autocompletion/parameterCompletions.test.ts
+++ b/packages/language-support/src/tests/autocompletion/parameterCompletions.test.ts
@@ -11,6 +11,7 @@ describe('Completes parameters outside of databases, roles, user names', () => {
       mapParam: {
         property: 'value',
       },
+      'some param': 'something',
     },
   };
 
@@ -35,6 +36,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
           insertText: 'mapParam',
           kind: CompletionItemKind.Variable,
         },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '`some param`',
+        },
       ],
     });
   });
@@ -57,6 +63,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
           label: '$mapParam',
           kind: CompletionItemKind.Variable,
         },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '$`some param`',
+        },
       ],
     });
   });
@@ -70,6 +81,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         { label: '$stringParam', kind: CompletionItemKind.Variable },
         { label: '$intParam', kind: CompletionItemKind.Variable },
         { label: '$mapParam', kind: CompletionItemKind.Variable },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '$`some param`',
+        },
       ],
     });
   });
@@ -95,6 +111,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
           kind: CompletionItemKind.Variable,
           insertText: 'mapParam',
         },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '`some param`',
+        },
       ],
     });
   });
@@ -108,6 +129,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         { label: '$stringParam', kind: CompletionItemKind.Variable },
         { label: '$intParam', kind: CompletionItemKind.Variable },
         { label: '$mapParam', kind: CompletionItemKind.Variable },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '$`some param`',
+        },
       ],
     });
   });
@@ -130,6 +156,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         {
           label: '$mapParam',
           kind: CompletionItemKind.Variable,
+        },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '$`some param`',
         },
       ],
     });
@@ -161,6 +192,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
       excluded: [
         { label: '$stringParam', kind: CompletionItemKind.Variable },
         { label: '$intParam', kind: CompletionItemKind.Variable },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+          insertText: '$`some param`',
+        },
       ],
     });
   });
@@ -174,6 +210,10 @@ describe('Completes parameters outside of databases, roles, user names', () => {
       excluded: [
         { label: '$stringParam', kind: CompletionItemKind.Variable },
         { label: '$intParam', kind: CompletionItemKind.Variable },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+        },
       ],
     });
   });
@@ -214,6 +254,10 @@ describe('Completes parameters outside of databases, roles, user names', () => {
       excluded: [
         { label: '$stringParam', kind: CompletionItemKind.Variable },
         { label: '$intParam', kind: CompletionItemKind.Variable },
+        {
+          label: '$some param',
+          kind: CompletionItemKind.Variable,
+        },
       ],
     });
   });
@@ -239,6 +283,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         dbSchema,
         expected: [
           { label: '$stringParam', kind: CompletionItemKind.Variable },
+          {
+            label: '$some param',
+            kind: CompletionItemKind.Variable,
+            insertText: '$`some param`',
+          },
         ],
         excluded: [
           { label: '$intParam', kind: CompletionItemKind.Variable },
@@ -255,6 +304,10 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         excluded: [
           { label: '$intParam', kind: CompletionItemKind.Variable },
           { label: '$stringParam', kind: CompletionItemKind.Variable },
+          {
+            label: '$some param',
+            kind: CompletionItemKind.Variable,
+          },
         ],
       });
     });
@@ -272,6 +325,11 @@ describe('Completes parameters outside of databases, roles, user names', () => {
         dbSchema,
         expected: [
           { label: '$stringParam', kind: CompletionItemKind.Variable },
+          {
+            label: '$some param',
+            kind: CompletionItemKind.Variable,
+            insertText: '$`some param`',
+          },
         ],
         excluded: [
           { label: '$intParam', kind: CompletionItemKind.Variable },

--- a/packages/schema-poller/src/schemaPoller.ts
+++ b/packages/schema-poller/src/schemaPoller.ts
@@ -140,7 +140,10 @@ export class Neo4jSchemaPoller {
     this.connection?.dispose();
     this.metadata?.stopBackgroundPolling();
     this.connection = undefined;
-    this.metadata = undefined;
+    if (this.metadata) {
+      const parameters = this.metadata.dbSchema.parameters;
+      this.metadata.dbSchema = { parameters: parameters };
+    }
     this.driver = undefined;
     clearTimeout(this.reconnectionTimeout);
   }


### PR DESCRIPTION
When disconnecting from the VSCode extension, we want the parameters to still be available for completions, because it is a bit weird they are present in the side pane but cannot be used.