### PR TITLE
Adds an environment to AWS-codeartifact fetching workflow

### DIFF
--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   fetch-artifacts:
+   environment: aws-artifacts
    runs-on: ubuntu-latest
    steps:
     - name: Checkout Repository


### PR DESCRIPTION
Before accessing secrets like ${{ secrets.AWS_ACCESS_USERNAME }} would access AWS_ACCESS_USERNAME from the repo secrets. Now with the secrets moved to a repo environment (aws-codeartifacts) this PR allows us to access them from there