### PR TITLE
Adds check to formatter that ensures correct group starts/ends

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -152,7 +152,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   format = () => {
     this._visit(this.root);
     // There may be some trailling groups that are left to achieve indentation
-    this.removeAllActiveGroups();
+    this.removeAllPendingGroups();
     const result = buffersToFormattedString(this.buffers);
     this.cursorPos += result.cursorPos;
     const resultString = result.formattedString + this.unParseable;
@@ -178,7 +178,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   lastInCurrentBuffer = () => this.currentBuffer().at(-1);
 
-  removeAllActiveGroups = () => {
+  removeAllPendingGroups = () => {
     // Groups that have not even been added to a chunk yet should just disappear
     for (let i = 0; i < this.startGroupCounter; i++) {
       this.groupStack.pop();
@@ -193,7 +193,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     // NOTE: Groups do not translate between line breaks. In some cases (primarily CASE and EXISTS)
     // groups might be active when breakLine() is called, but it does not make sense to keeep them active
     // so clear all groups when this happens.
-    this.removeAllActiveGroups();
+    this.removeAllPendingGroups();
 
     if (this.currentBuffer().length > 0) {
       this.buffers.push([]);

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1884,17 +1884,19 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
           commaIdx++;
         }
       }
-      const procedureListGrp = this.startGroup();
-      for (let i = 0; i < m; i++) {
-        this._visit(ctx.procedureResultItem(i));
-        if (i < m - 1) {
-          this._visit(ctx.COMMA(commaIdx));
-          commaIdx++;
+      if (m > 0) {
+        const procedureListGrp = this.startGroup();
+        for (let i = 0; i < m; i++) {
+          this._visit(ctx.procedureResultItem(i));
+          if (i < m - 1) {
+            this._visit(ctx.COMMA(commaIdx));
+            commaIdx++;
+          }
         }
+        this.endGroup(procedureListGrp);
       }
-      this.endGroup(procedureListGrp);
-      this._visit(ctx.whereClause());
       this.endGroup(yieldGrp);
+      this._visit(ctx.whereClause());
     }
   };
 }

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -313,12 +313,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.groupStack.pop();
   };
 
-  removeAllGroups = () => {
-    for (let i = 0; i < this.lastInCurrentBuffer().groupsStarting; i++) {
-      this.groupStack.pop();
-    }
-  };
-
   endAllExceptBaseGroup = () => {
     while (this.groupStack.length > 1) {
       this.endGroup(this.groupStack.at(-1));

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -777,8 +777,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.avoidBreakBetween();
     const withClauseGrp = this.startGroupAlsoOnComment();
     this._visit(ctx.returnBody());
-    this._visit(ctx.whereClause());
     this.endGroup(withClauseGrp);
+    this._visit(ctx.whereClause());
   };
 
   visitMatchClause = (ctx: MatchClauseContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -185,10 +185,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     for (let i = 0; i < this.startGroupCounter; i++) {
       this.groupStack.pop();
     }
+    this.startGroupCounter = 0;
     while (this.groupStack.length > 0) {
       this.endGroup(this.groupStack.at(-1));
     }
-    this.startGroupCounter = 0;
     if (this.currentBuffer().length > 0) {
       this.buffers.push([]);
     }

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -151,6 +151,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   format = () => {
     this._visit(this.root);
+    // There may be some trailling groups that are left to achieve indentation
+    this.removeAllActiveGroups();
     const result = buffersToFormattedString(this.buffers);
     this.cursorPos += result.cursorPos;
     const resultString = result.formattedString + this.unParseable;
@@ -176,11 +178,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   lastInCurrentBuffer = () => this.currentBuffer().at(-1);
 
-  breakLine = () => {
-    // NOTE: Groups do not translate between line breaks. In some cases (primarily CASE and EXISTS)
-    // groups might be active when breakLine() is called, but it does not make sense to keeep them active
-    // so clear all groups when this happens.
-
+  removeAllActiveGroups = () => {
     // Groups that have not even been added to a chunk yet should just disappear
     for (let i = 0; i < this.startGroupCounter; i++) {
       this.groupStack.pop();
@@ -189,6 +187,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     while (this.groupStack.length > 0) {
       this.endGroup(this.groupStack.at(-1));
     }
+  };
+
+  breakLine = () => {
+    // NOTE: Groups do not translate between line breaks. In some cases (primarily CASE and EXISTS)
+    // groups might be active when breakLine() is called, but it does not make sense to keeep them active
+    // so clear all groups when this happens.
+    this.removeAllActiveGroups();
+
     if (this.currentBuffer().length > 0) {
       this.buffers.push([]);
     }

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1454,7 +1454,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.breakLine();
       this.mustBreakBetween();
       // Workaround to get indentation because groups do not translate between chunk lists.
-      // This group will be ended on the next breakLine()
+      // This group will be ended on the next breakLine() or after all nodes are visited.
       this.startGroup();
       this._visit(ctx.RCURLY());
       this.removeAlignIndentation();
@@ -1474,7 +1474,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.regularQuery());
     this.breakLine();
     // Workaround to get indentation because groups do not translate between chunk lists.
-    // This group will be ended on the next breakLine()
+    // This group will be ended on the next breakLine() or after all nodes are visited.
     this.startGroup();
     this._visit(ctx.RCURLY());
     this.removeAlignIndentation();
@@ -1491,7 +1491,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.breakLine();
       this.mustBreakBetween();
       // Workaround to get indentation because groups do not translate between chunk lists.
-      // This group will be ended on the next breakLine()
+      // This group will be ended on the next breakLine() or after all nodes are visited.
       this.startGroup();
       this._visit(ctx.RCURLY());
       this.removeAlignIndentation();

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -552,11 +552,12 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const chunk: SyntaxErrorChunk = {
       type: 'SYNTAX_ERROR',
       text: combinedText,
-      groupsStarting: 0,
+      groupsStarting: this.startGroupCounter,
       groupsEnding: 0,
       indentation: { ...initialIndentation },
     };
 
+    this.startGroupCounter = 0;
     this.currentBuffer().push(chunk);
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -181,7 +181,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     // groups might be active when breakLine() is called, but it does not make sense to keeep them active
     // so clear all groups when this happens.
     while (this.groupStack.length > 0) {
-      this.endGroup(this.groupStack.pop());
+      this.endGroup(this.groupStack.at(-1));
     }
     this.startGroupCounter = 0;
     if (this.currentBuffer().length > 0) {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -180,7 +180,9 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     // NOTE: Groups do not translate between line breaks. In some cases (primarily CASE and EXISTS)
     // groups might be active when breakLine() is called, but it does not make sense to keeep them active
     // so clear all groups when this happens.
-    this.groupStack = [];
+    while (this.groupStack.length > 0) {
+      this.endGroup(this.groupStack.pop());
+    }
     this.startGroupCounter = 0;
     if (this.currentBuffer().length > 0) {
       this.buffers.push([]);

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -180,6 +180,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     // NOTE: Groups do not translate between line breaks. In some cases (primarily CASE and EXISTS)
     // groups might be active when breakLine() is called, but it does not make sense to keeep them active
     // so clear all groups when this happens.
+
+    // Groups that have not even been added to a chunk yet should just disappear
+    for (let i = 0; i < this.startGroupCounter; i++) {
+      this.groupStack.pop();
+    }
     while (this.groupStack.length > 0) {
       this.endGroup(this.groupStack.at(-1));
     }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -230,6 +230,10 @@ function getNeighbourState(curr: State, choice: Choice, split: Split): State {
     });
   }
   for (let i = 0; i < choice.left.groupsEnding; i++) {
+    const stateString = stateToString(curr) as string;
+    if (nextGroups.length === 0) {
+      throw new Error('POPPED EMPTY' + '\n\n\n' + stateString);
+    }
     nextGroups.pop();
   }
 

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -331,6 +331,9 @@ function bestFirstSolnSearch(
     // We found a solution. Since we do best first, it has to be the best
     // solution, so reconstruct that path of decisions
     if (state.choiceIndex === choiceList.length) {
+      if (state.activeGroups.length > 0) {
+        throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
+      }
       return reconstructBestPath(state);
     }
     const choice = choiceList[state.choiceIndex];

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -231,7 +231,7 @@ function getNeighbourState(curr: State, choice: Choice, split: Split): State {
   }
   for (let i = 0; i < choice.left.groupsEnding; i++) {
     if (nextGroups.length === 0) {
-      throw new Error('POPPED EMPTY');
+      throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
     }
     nextGroups.pop();
   }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -230,9 +230,8 @@ function getNeighbourState(curr: State, choice: Choice, split: Split): State {
     });
   }
   for (let i = 0; i < choice.left.groupsEnding; i++) {
-    const stateString = stateToString(curr) as string;
     if (nextGroups.length === 0) {
-      throw new Error('POPPED EMPTY' + '\n\n\n' + stateString);
+      throw new Error('POPPED EMPTY');
     }
     nextGroups.pop();
   }


### PR DESCRIPTION
## Description
There are a few queries that result in groups being started but never ended, or vice versa. This should never happen if all visit methods are correct, though because of some complicated cases (pun intended) it still happens.

This PR fixes all of those cases, and additionally adds adds two checks:
1. We should never end a group if there is not a group active
2. There should not be any active groups left when we are done formatting

If either of these are true, **the formatter suffers an internal error**.

### Testing
- No new tests added, but all tests pass without triggering the above checks.