### PR TITLE
Adds icons to edit/delete params, better error message when setting against system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20006,10 +20006,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.10.tgz",
-      "integrity": "sha512-f2ueoukYTMI/5kMMT7wW+ol3zL6z6PjN28zYrGKAjnbzXhRXWXPThD3uN6muCp+TbfXaDgGvRuPsg6mwVLaWwQ==",
-      "license": "MIT",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.11.tgz",
+      "integrity": "sha512-4mVdhLkZ0vpqZLGJhNm+X1n7juqXApEMGlUXcOQawA45UmpxivOYaMBkI/Js3FlBsNA8hCgEnX5X04moFitSGw==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -103,12 +103,14 @@
       {
         "command": "neo4j.deleteParameter",
         "title": "Delete parameter",
-        "category": "Neo4j"
+        "category": "Neo4j",
+        "icon": "$(trash)"
       },
       {
         "command": "neo4j.editParameter",
         "title": "Edit parameter",
-        "category": "Neo4j"
+        "category": "Neo4j",
+        "icon": "$(pencil)"
       }
     ],
     "keybindings": [
@@ -224,6 +226,16 @@
         {
           "command": "neo4j.editParameter",
           "when": "view == neo4jParameters && viewItem == parameter"
+        },
+        {
+          "command": "neo4j.editParameter",
+          "when": "view == neo4jParameters && viewItem == parameter",
+          "group": "inline"
+        },
+        {
+          "command": "neo4j.deleteParameter",
+          "when": "view == neo4jParameters && viewItem == parameter",
+          "group": "inline"
         }
       ]
     },

--- a/packages/vscode-extension/src/commandHandlers/connection.ts
+++ b/packages/vscode-extension/src/commandHandlers/connection.ts
@@ -150,6 +150,12 @@ export async function switchToDatabase(
     return;
   }
   const database = connectionItem.key;
+  await switchToDatabaseWithName(database);
+}
+
+export async function switchToDatabaseWithName(
+  database: string,
+): Promise<void> {
   const connection = getActiveConnection();
   const result = await switchDatabase({ ...connection, database });
   displayMessageForSwitchDatabaseResult(database, result);

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -19,6 +19,7 @@ export const CONSTANTS = {
       FORCE_DELETE_PARAMETER: 'neo4j.internal.forceDeleteParam',
       FORCE_DISCONNECT: 'neo4j.internal.forceDisconnect',
       FORCE_CONNECT: 'neo4j.internal.forceConnect',
+      SWITCH_DATABASE: 'neo4j.internal.forceSwitchDatabase',
     },
   },
   MESSAGES: {

--- a/packages/vscode-extension/src/parameterService.ts
+++ b/packages/vscode-extension/src/parameterService.ts
@@ -66,7 +66,7 @@ export async function setParameter(param: Parameter) {
   parameters[key] = param;
   await saveParameters(parameters);
   await sendParametersToLanguageServer();
-  void vscode.window.showInformationMessage(`Parameter \`${key}\` set.`);
+  void vscode.window.showInformationMessage(`Parameter '${key}' set.`);
 }
 
 /**

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -9,6 +9,7 @@ import {
   saveConnectionAndDisplayConnectionResult,
   showConnectionPanelForConnectionItem,
   switchToDatabase,
+  switchToDatabaseWithName,
   toggleConnectionItemsConnectionState,
 } from './commandHandlers/connection';
 import {
@@ -86,6 +87,10 @@ export function registerDisposables(): Disposable[] {
     commands.registerCommand(
       CONSTANTS.COMMANDS.SWITCH_DATABASE_COMMAND,
       (connectionItem: ConnectionItem) => switchToDatabase(connectionItem),
+    ),
+    commands.registerCommand(
+      CONSTANTS.COMMANDS.INTERNAL.SWITCH_DATABASE,
+      switchToDatabaseWithName,
     ),
     commands.registerCommand(
       CONSTANTS.COMMANDS.CYPHER_FILE_FROM_SELECTION,

--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -14,7 +14,7 @@ suite('Params panel testing', () => {
     workbench = await browser.getWorkbench();
   });
 
-  async function addParam() {
+  async function addParamWithInputBox() {
     await browser.executeWorkbench(async (vscode) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       await vscode.commands.executeCommand('neo4j.addParameter');
@@ -167,7 +167,7 @@ suite('Params panel testing', () => {
     await forceDisconnect();
     // This tries to add the params with the window prompts we cannot manipulate in the tests
     // but it will fail before showing those prompts because we are not connected to the database
-    void addParam();
+    void addParamWithInputBox();
     await waitUntilNotification(
       browser,
       'You need to be connected to neo4j to set parameters.',
@@ -177,13 +177,21 @@ suite('Params panel testing', () => {
 
   test('Parameters cannot be set when connected to system', async function () {
     await forceSwitchDatabase('system');
-    void forceAddParam('a', '"charmander"');
-    await waitUntilNotification(
-      browser,
-      'Parameters cannot be evaluated against a system database. Please connect to a user database.',
-    );
+    await clearParams();
 
-    // cleanup
+    void forceAddParam('a', '"charmander"');
+    void forceAddParam('b', '"caterpie"');
+    void forceAddParam('some param', '"pikachu"');
+    void forceAddParam('some-param', '"bulbasur"');
+
+    // to execute the file we need to be on the user database
     await forceSwitchDatabase('neo4j');
+    await executeFile(workbench, 'params.cypher');
+    await checkResultsContent(workbench, async () => {
+      const text = await (await $('#query-error')).getText();
+      await expect(text).toContain(
+        'Error executing query RETURN $a, $b, $`some param`, $`some-param`:\nExpected parameter(s): a, b, some param, some-param',
+      );
+    });
   });
 });

--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -175,25 +175,15 @@ suite('Params panel testing', () => {
     await forceConnect(1);
   });
 
-  test('Can still set parameters, even when connected to system', async function () {
+  test('Parameters cannot be set when connected to system', async function () {
     await forceSwitchDatabase('system');
-    await clearParams();
+    void forceAddParam('a', '"charmander"');
+    await waitUntilNotification(
+      browser,
+      'Parameters cannot be evaluated against a system database. Please connect to a user database.',
+    );
 
-    await forceAddParam('a', '"charmander"');
-    await forceAddParam('b', '"caterpie"');
-    await forceAddParam('some param', '"pikachu"');
-    await forceAddParam('some-param', '"bulbasur"');
-
-    // We need to go back to the neo4j database to execute the query
-    // because it would fail to execute a non system query against the system db
+    // cleanup
     await forceSwitchDatabase('neo4j');
-    await executeFile(workbench, 'params.cypher');
-    await checkResultsContent(workbench, async () => {
-      const queryResult = await (await $('#query-result')).getText();
-      await expect(queryResult).toContain('charmander');
-      await expect(queryResult).toContain('caterpie');
-      await expect(queryResult).toContain('pikachu');
-      await expect(queryResult).toContain('bulbasur');
-    });
   });
 });


### PR DESCRIPTION
This PR introduces a couple of improvements to the parameters pane:

* Adds icons to edit / remove a parameter when you get on top of it in the VSCode parameter pane.

<img width="630"  src="https://github.com/user-attachments/assets/27426b65-f933-4f00-9c97-2b02b74da029" />

Unfortunately those icons cannot be permanently shown, you need to hover on the params pane.

* ~Aside from that, I realized we could not set parameters if we were connected to the system database and we were getting a very cryptic message. I've just added an extra step to find a `user` database from the ones in the active connection, so we evaluate the parameters against that database.~ Gives a better error message when trying to evaluate params against the system database.

