### PR TITLE
Adds validation when entering param value, and improves error messages

### DIFF
--- a/packages/vscode-extension/tests/specs/unit/paramUnitTest.spec.ts
+++ b/packages/vscode-extension/tests/specs/unit/paramUnitTest.spec.ts
@@ -1,0 +1,51 @@
+import { testData } from '../../../../language-support/src/tests/testData';
+import { validateParamInput } from '../../../src/commandHandlers/params';
+
+suite('Execute commands spec', () => {
+  //   let sandbox: sinon.SinonSandbox;
+  //   let showInformationMessageStub: sinon.SinonStub;
+  //   let showErrorMessageStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    // sandbox = sinon.createSandbox();
+    // showInformationMessageStub = sandbox.stub(window, 'showInformationMessage');
+    // showErrorMessageStub = sandbox.stub(window, 'showErrorMessage');
+  });
+
+  afterEach(() => {
+    // sandbox.restore();
+  });
+
+  suite.only('Parameter validation spec', () => {
+    test('Parameter validation works as expected', async () => {
+      const dbSchema = {
+        labels: [],
+        relationshipTypes: [],
+        databaseNames: [],
+        aliasNames: [],
+        userNames: [],
+        roleNames: [],
+        parameters: {},
+        propertyKeys: [],
+        procedures: {},
+        functions: {
+          'CYPHER 5': {
+            datetime: {
+              ...testData.emptyFunction,
+              name: 'datetime',
+            },
+          },
+        },
+        defaultLanguage: 'CYPHER 5',
+      };
+      await expect(validateParamInput('datetime()', dbSchema)).toBe(null);
+      await expect(validateParamInput('500', dbSchema)).toBe(null);
+      await expect(validateParamInput('datetime(', dbSchema)).toBe(
+        'Invalid parameter value',
+      );
+      await expect(validateParamInput('500q', dbSchema)).toBe(
+        'Invalid parameter value',
+      );
+    });
+  });
+});


### PR DESCRIPTION
As parameter values are entered they are linted in the background from the query that would be executed to get the parameter value (`RETURN $paramValue AS param`), and the error from the linter is propagated if the value is invalid.
Ex.
![image](https://github.com/user-attachments/assets/1baee8f6-4e41-48f5-ada4-6c0eb8898875)
![image](https://github.com/user-attachments/assets/5b3e3a7a-b46b-4860-8224-372e3ccb1d0c)

If the linting function doesnt capture an error that actually exists when running the query against the db, the message from the thrown Neo4jError is appended to the error message. (I know no example for this, it would be a bug in our linting)