### PR TITLE
Adjusts job to update grammar and semantic analysis

### DIFF
--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '10 4 1-7 * 5'
+    - cron: '10 4 4,7 * *'
   workflow_dispatch:
   
 
@@ -80,7 +80,15 @@ jobs:
         BRANCH_NAME="update-artifacts-$(date +%Y%m%d-%H%M%S)"
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
+    - name: Check for modified files
+      shell: bash
+      id: git-check
+      run: |
+        git update-index --refresh || true
+        echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+
     - name: Commit and Push Changes
+      if: steps.git-check.outputs.modified == 'true'
       run: |
         git add ./packages/language-support/src/antlr-grammar
         git add ./packages/language-support/src/syntaxValidation
@@ -88,6 +96,7 @@ jobs:
         git push origin HEAD:${{ env.BRANCH_NAME }}
 
     - name: Create Pull Request
+      if: steps.git-check.outputs.modified == 'true'
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -99,7 +99,7 @@ jobs:
       if: steps.git-check.outputs.modified == 'true'
       uses: peter-evans/create-pull-request@v7
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT_TOKEN }}
         branch: ${{ env.BRANCH_NAME }}
         base: main
         title: "Automated update of artifacts"

--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '10 4 4,7 * *'
+    - cron: '10 4 3,6 * *'
   workflow_dispatch:
   
 

--- a/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
@@ -76,7 +76,7 @@ export async function testCompletionContains({
   });
 }
 
-suite('Auto completion spec', () => {
+suite.only('Auto completion spec', () => {
   test('Completes allShortestPaths ', async () => {
     const position = new vscode.Position(2, 28);
 

--- a/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
@@ -76,7 +76,7 @@ export async function testCompletionContains({
   });
 }
 
-suite.only('Auto completion spec', () => {
+suite('Auto completion spec', () => {
   test('Completes allShortestPaths ', async () => {
     const position = new vscode.Position(2, 28);
 


### PR DESCRIPTION
Bear in mind the database is cut off 

This PR contains changes to:

* Fix the cron job expression we were using, which was executing everyday from the 1st day on the month to the 7th and on Fridays. We wanted something that was executing only the first Friday of every month, but that does not seem possible to get with cron, so we have settled for executing the 4th day of the month and the 7th day of the month. 

In the worst case scenario the 1st day of the month is a Friday so we would get the update on the Sunday (3rd day), leaving us with a whole week to do the changes. If the 1st day of the month was a Saturday, then we would get this update on the first Friday, the 6th.

* Uses a PAT token to make the PRs execute the CI when they are opened, rather than the default `GITHUB_TOKEN`