### PR TITLE
adding support for :play command

### DIFF
--- a/.changeset/chatty-needles-guess.md
+++ b/.changeset/chatty-needles-guess.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+adding support for :play command

--- a/package-lock.json
+++ b/package-lock.json
@@ -20006,9 +20006,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.11.tgz",
-      "integrity": "sha512-4mVdhLkZ0vpqZLGJhNm+X1n7juqXApEMGlUXcOQawA45UmpxivOYaMBkI/Js3FlBsNA8hCgEnX5X04moFitSGw==",
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.12.tgz",
+      "integrity": "sha512-qrMwavANtSz91nDy3zEiUHMtL09x0mniQsSMvDkNxuCBM1W5vriJ22hEmwTth6DhLSWsZnHBT0yHFAQXt6efGA==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
@@ -19,3 +19,5 @@ SYSINFO: S Y S I N F O;
 STYLE: S T Y L E;
 
 RESET: R E S E T;
+
+PLAY: P L A Y;

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -19,6 +19,7 @@ consoleCommand: COLON (
     | welcomeCmd
     | sysInfoCmd
     | styleCmd
+    | playCmd
 );
 
 paramsCmd: PARAM paramsArgs?;
@@ -46,6 +47,8 @@ sysInfoCmd: SYSINFO;
 styleCmd: STYLE RESET?;
 
 welcomeCmd: WELCOME;
+
+playCmd: PLAY;
 
 // These rules are needed to distinguish cypher <-> commands, for exapmle `USE` and `:use` in autocompletion
 listCompletionRule: LIST; 

--- a/packages/language-support/src/lexerSymbols.ts
+++ b/packages/language-support/src/lexerSymbols.ts
@@ -376,6 +376,7 @@ export const lexerConsoleCmds = [
   CypherLexer.SYSINFO,
   CypherLexer.STYLE,
   CypherLexer.RESET,
+  CypherLexer.PLAY,
 ];
 
 function toTokentypeObject(arr: number[], tokenType: CypherTokenType) {

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -480,7 +480,8 @@ export type ParsedCommandNoPosition =
   | { type: 'welcome' }
   | { type: 'parse-error' }
   | { type: 'sysinfo' }
-  | { type: 'style'; operation?: 'reset' };
+  | { type: 'style'; operation?: 'reset' }
+  | { type: 'play' };
 
 export type ParsedCommand = ParsedCommandNoPosition & RuleTokens;
 
@@ -632,6 +633,11 @@ function parseToCommand(
           stop,
           operation: styleCmd.RESET() ? 'reset' : undefined,
         };
+      }
+
+      const playCmd = consoleCmd.playCmd();
+      if (playCmd) {
+        return { type: 'play', start, stop };
       }
 
       return { type: 'parse-error', start, stop };

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -204,10 +204,26 @@ describe('sanity checks', () => {
     ]);
   });
 
+  expect(applySyntaxColouring(':play')).toEqual([
+    {
+      length: 1,
+      position: { line: 0, startCharacter: 0, startOffset: 0 },
+      token: ':',
+      tokenType: 'consoleCommand',
+    },
+    {
+      length: 4,
+      position: { line: 0, startCharacter: 1, startOffset: 1 },
+      token: 'play',
+      tokenType: 'consoleCommand',
+    },
+  ]);
+
   test('completes basic console cmds on :', () => {
     expect(autocomplete(':', {})).toEqual([
       { kind: 23, label: 'server' },
       { kind: 23, label: 'use' },
+      { kind: 23, label: 'play' },
       { kind: 23, label: 'style' },
       { kind: 23, label: 'style reset' },
       { kind: 23, label: 'sysinfo' },
@@ -252,7 +268,7 @@ describe('sanity checks', () => {
   test('handles misspelled or non-existing command', () => {
     expectErrorMessage(
       ':foo',
-      'Expected any of style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
+      'Expected any of play, style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
     );
 
     expectErrorMessage(':clea', 'Unexpected token. Did you mean clear?');

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -54,6 +54,7 @@ describe('sanity checks', () => {
     expectParsedCommands(':disconnect', [{ type: 'disconnect' }]);
     expectParsedCommands(':sysinfo', [{ type: 'sysinfo' }]);
     expectParsedCommands(':style', [{ type: 'style' }]);
+    expectParsedCommands(':play', [{ type: 'play' }]);
   });
 
   test('properly highlights simple commands', () => {


### PR DESCRIPTION
This pr is to add support for the `:play` command, which is used to play custom guides within the query application.