### PR TITLE
Prepares VSCode release

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -85,17 +85,17 @@ Clicking on an instance will automatically connect to it. You can also manage a 
 ![demo-connect](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-connect.png?raw=true)
 ![demo-disconnect](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-disconnect.png?raw=true)
 
-Once a connection is added, and a connection to your Neo4j instance is established, you will be able to use database aware features of the extension.
+Once a connection is added, and a connection to your Neo4j instance is established, you will be able to use database aware features of the extension. You can change the database you want to run queries against by clicking or right clicking (`Switch to database`) on it.
 
 You can store connections to different Neo4j instances.
 
-## Managing parameters
+## Managing parameters
 
 To add a new parameter, you can use the `Neo4j: Add parameter` command from the Command Palette or use the `+` on the Neo4j parameters pane:
 
 ![demo-add-parameter](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-add-parameter.png?raw=true)
 
-You'll be prompted for the name and value you want to use for that parameter. The type will be automatically recognized from the value you try and set. Some examples:
+You will be prompted for the name and value you want to use for that parameter. The type will be automatically recognized from the value. Some examples:
 
 ```
 "something" // would set a string parameter
@@ -104,13 +104,16 @@ datetime() // would set a datetime parameter
 [1,2,3] // would set a List parameter
 ```
 
-As a rule of thumb, any expression that can appear in a `RETURN expression` can be set as value.
+As a rule of thumb, any `expression` that can appear in a `RETURN expression` can be set as value.
 
 Parameters can be accessed from the code prepending them with a dollar sign `$`.
 
-## Executing a Cypher file
+## Executing a Cypher file
 
-Once you've written your desired query (for example `RETURN $a, $b`) you can execute it using the `Neo4j: Run cypher statements` command from the Command Palette, by right clicking inside the file you want to run and clicking on the `Neo4j: Run cypher statements` item or by pressing the keyboard shortcut `Ctrl+Command+Space` (where `Command` is either the `⌘` key or the Windows key depending on your keyboard).
+Once you've written your desired query (for example `RETURN $a, $b`) you can execute it by either of:
+* Using the `Neo4j: Run cypher statements` command from the Command Palette.
+* Right clicking inside the file you want to run and clicking on the `Neo4j: Run cypher statements` item.
+* Using the shortcut `Ctrl+Command+Space` (where `Command` is either the `⌘` key or the Windows key depending on your keyboard).
 
 ![demo-execution](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-execution.png?raw=true)
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -104,16 +104,22 @@ datetime() // would set a datetime parameter
 [1,2,3] // would set a List parameter
 ```
 
-As a rule of thumb, any `expression` that can appear in a `RETURN expression` can be set as value.
+Any `expression` that can appear in a `RETURN expression` can be set as value.
 
-Parameters can be accessed from the code prepending them with a dollar sign `$`.
+Parameters can be accessed from in a query prepending them with a dollar sign `$`.
+
+Parameters can be edited / deleted hovering over them.
+
+![demo-param-editing](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-param-editing.png?raw=true)
+
+
 
 ## Executing a Cypher file
 
 Once you've written your desired query (for example `RETURN $a, $b`) you can execute it by either of:
 * Using the `Neo4j: Run cypher statements` command from the Command Palette.
 * Right clicking inside the file you want to run and clicking on the `Neo4j: Run cypher statements` item.
-* Using the shortcut `Ctrl+Command+Space` (where `Command` is either the `⌘` key or the Windows key depending on your keyboard).
+* Using the shortcut `Ctrl+Command+Space` (where `Command` is either the `⌘` key or the `alt` key depending on your keyboard).
 
 ![demo-execution](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-execution.png?raw=true)
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -2,21 +2,30 @@
 
 ## Getting started
 
-After installing the extension from the VS Code Marketplace, open a file with a `.cypher` to start using the extension. To enable database aware features (such as completing labels/functions), set up a connection to a Neo4j instance using the database connection pane and any settings described in the settings section below.
+After installing the extension from the VS Code Marketplace, open a file with a `.cypher` extension to start using it. To enable database aware features (such as completing labels, functions and procedures), set up a connection to a Neo4j instance using the database connection pane.
 
 ## Feature Highlights
 
 Our extension preview provides a rich set of features for working with Cypher, the query language for Neo4j databases, including:
 
 - Syntax highlighting
-- Syntax checking - both simple and semantic errors (e.g. type errors, unknown labels, etc)
+- Linting - both simple and semantic errors (e.g. type errors, unknown labels, etc)
 - Autocompletion for Cypher keywords, functions, labels, properties, database names and more
 - Signature help for functions - shows the signature of the function while typing
 - Formatting - format the document according to the Cypher styleguide
+- Connection management.
+- Query parameter management.
+- Query execution.
 
 ![demo-gif](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo.gif?raw=true)
 
-It also provides a basic database connection management pane and syntax highlighting embedded in other languages, namely Markdown, Java, Python, Javascriopt, .NET and Go. This is possible having a multiline string that starts with `//cypher` or `/*cypher*/` or a single line string starting with `/*cypher*/`. We also support a templated string `/*cypher*/`{{query here}}` in Javascript. Examples:
+It also provides syntax highlighting embedded in other languages, namely Markdown, Java, Python, Javascriopt, .NET and Go. This is possible having a multiline string that starts with `//cypher` or `/*cypher*/` or a single line string starting with `/*cypher*/`. We also support a templated string `/*cypher*/`{{query here}}` in Javascript. 
+
+Inside those languages you can also select a Cypher snippet and either create a `cypher` file with language smarts (completions, linting, etc) from it or execute that snippet.
+
+![demo-embedded-cypher-menus](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-embedded-cypher-menus.png?raw=true)
+
+Examples for the syntax highligting:
 
 ### Markdown
 
@@ -65,24 +74,53 @@ const d = '/*cypher*/ MATCH (n) RETURN n';
 
 ## Managing connections
 
-You can launch the connection pane from the Neo4j icon in the Activity Bar, or by using the `Neo4j: Edit Connection` command from the Command Palette.
+To add a new instance connection, you can launch the connection pane from the Neo4j icon in the Activity Bar (either on the `Add new connection` button when the pane is empty or on the `+` icon), or by using the `Neo4j: Create New Connection` command from the Command Palette.
+
+![demo-new-connection](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-new-connection.png?raw=true)
 
 ![demo-manage-connection](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-manage-connection.png?raw=true)
 
-From here you can manage, connect to, or disconnect from your database connections.
+Clicking on an instance will automatically connect to it. You can also manage a connection by right clicking on it, to connect, disconnect or edit it.
 
 ![demo-connect](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-connect.png?raw=true)
 ![demo-disconnect](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-disconnect.png?raw=true)
 
 Once a connection is added, and a connection to your Neo4j instance is established, you will be able to use database aware features of the extension.
 
+You can store connections to different Neo4j instances.
+
+## Managing parameters
+
+To add a new parameter, you can use the `Neo4j: Add parameter` command from the Command Palette or use the `+` on the Neo4j parameters pane:
+
+![demo-add-parameter](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-add-parameter.png?raw=true)
+
+You'll be prompted for the name and value you want to use for that parameter. The type will be automatically recognized from the value you try and set. Some examples:
+
+```
+"something" // would set a string parameter
+1234 // would set an Integer parameter
+datetime() // would set a datetime parameter
+[1,2,3] // would set a List parameter
+```
+
+As a rule of thumb, any expression that can appear in a `RETURN expression` can be set as value.
+
+Parameters can be accessed from the code prepending them with a dollar sign `$`.
+
+## Executing a Cypher file
+
+Once you've written your desired query (for example `RETURN $a, $b`) you can execute it using the `Neo4j: Run cypher statements` command from the Command Palette, by right clicking inside the file you want to run and clicking on the `Neo4j: Run cypher statements` item or by pressing the keyboard shortcut `Ctrl+Command+Space` (where `Command` is either the `⌘` key or the Windows key depending on your keyboard).
+
+![demo-execution](https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/resources/images/demo-execution.png?raw=true)
+
 ## Upcoming features
 
 We're working on adding more features to the extension, such as:
 
-- Improved database connection management
-- Embedded cypher support in other file types
-- Query execution and result visualization
+- Dynamically adjusting the language server depending on the neo4j version.
+- Improved query results table.
+- Graph visualization for the results.
 
 ## Extension settings
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "author": "Neo4j Inc.",
   "license": "Apache-2.0",
   "version": "1.9.0",
-  "preview": true,
+  "preview": false,
   "categories": [
     "Programming Languages",
     "Linters",
@@ -80,7 +80,7 @@
       },
       {
         "command": "neo4j.runCypher",
-        "title": "Neo4j: Run Cypher statements",
+        "title": "Run Cypher statements",
         "category": "Neo4j"
       },
       {
@@ -134,12 +134,12 @@
       "editor/context": [
         {
           "command": "neo4j.runCypher",
-          "when": "resourceLangId == cypher || (editorHasSelection && (resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python))",
+          "when": "resourceLangId == cypher || (editorHasSelection && (resourceLangId == java || resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python))",
           "group": "z_commands"
         },
         {
           "command": "neo4j.cypherFileFromSelection",
-          "when": "editorHasSelection && (resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python)",
+          "when": "editorHasSelection && (resourceLangId == java || resourceLangId == javascript || resourceLangId == typescript || resourceLangId == go || resourceLangId == fsharp || resourceLangId == csharp || resourceLangId == markdown || resourceLangId == python)",
           "group": "z_commands"
         }
       ],

--- a/packages/vscode-extension/resources/images/demo-add-parameter.png
+++ b/packages/vscode-extension/resources/images/demo-add-parameter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c5c6c5e88e89712f3e91ec6025c365fb79f9e93f1e4e90e1e5606c8d0948a31
+size 119028

--- a/packages/vscode-extension/resources/images/demo-connect.png
+++ b/packages/vscode-extension/resources/images/demo-connect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:988978cb64c01aa2d9fc0858ee8c603ca1c009109a5145fbd9c610d17fcbac51
-size 94592
+oid sha256:fdefb2ec644e18a2aa7c1b7fc36700c074ae95040f9b5d29717393531ff75034
+size 96031

--- a/packages/vscode-extension/resources/images/demo-disconnect.png
+++ b/packages/vscode-extension/resources/images/demo-disconnect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d267e1ab95f944016c579d6602064ccb0e90b2606ca88737a1b6b181da504ff8
-size 100325
+oid sha256:a040b4e672850d5463fb73cac5cd2e28b1ffaca1d324027a5792041529c8317c
+size 112346

--- a/packages/vscode-extension/resources/images/demo-embedded-cypher-menus.png
+++ b/packages/vscode-extension/resources/images/demo-embedded-cypher-menus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:214dafb409068e84d54f02d9398dfcfc154aa0e2e86f8db9353a8aaaac012d8b
+size 249073

--- a/packages/vscode-extension/resources/images/demo-execution.png
+++ b/packages/vscode-extension/resources/images/demo-execution.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a0c0c722368013de0111fd35e5f570981fbd0fab87cefeeb547482894714cd
+size 343838

--- a/packages/vscode-extension/resources/images/demo-manage-connection.png
+++ b/packages/vscode-extension/resources/images/demo-manage-connection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7b706c7d9a2319390be6408b79c08c87aa242e9b6edf6010b88fd7293d38c51
-size 144813
+oid sha256:30c8845cc303d4f288d5e8d9915a6ad0135a260aab17aae87ddddcbc42af06d1
+size 207654

--- a/packages/vscode-extension/resources/images/demo-new-connection.png
+++ b/packages/vscode-extension/resources/images/demo-new-connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0269c8e5a3a0b981dc953d2579707d11d97f9bfe70aa16460e01957fcc155d59
+size 87040

--- a/packages/vscode-extension/resources/images/demo-param-editing.png
+++ b/packages/vscode-extension/resources/images/demo-param-editing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:087d908e027e28c80dacbebf67a6d7f51172c209b3f20ec49f0ca11c66d363ee
+size 40509


### PR DESCRIPTION
* Gets out of the preview mode (no more red preview banner on the VSCode marketplace)
* Reviews the VSCode extension `README`
* Corrects a few small bugs in the VSCode extension `package.json` (we could not use the embedded menus to create a cypher file from a selection in Java for example) or we were showing `Neo4j: Neo4j Run Cypher statements` in the command palette (duplicated `Neo4j`)