### PR TITLE
triggering a param add pop-up if running a cypher with missing params

### DIFF
--- a/packages/vscode-extension/src/commandHandlers/params.ts
+++ b/packages/vscode-extension/src/commandHandlers/params.ts
@@ -44,7 +44,7 @@ export function validateParamInput(
   return undefined;
 }
 
-export async function addParameter(): Promise<void> {
+export async function addParameter(defaultParamName?: string): Promise<void> {
   const connected = await isConnected();
 
   if (!connected) {
@@ -54,12 +54,14 @@ export async function addParameter(): Promise<void> {
     return;
   }
 
-  const paramName = await window.showInputBox({
-    prompt: 'Parameter name',
-    placeHolder:
-      'The name you want to store your parameter with, for example: param, p, `my parameter`',
-    ignoreFocusOut: true,
-  });
+  const paramName =
+    defaultParamName ??
+    (await window.showInputBox({
+      prompt: 'Parameter name',
+      placeHolder:
+        'The name you want to store your parameter with, for example: param, p, `my parameter`',
+      ignoreFocusOut: true,
+    }));
   if (!paramName) {
     await window.showErrorMessage('Parameter name cannot be empty.');
     return;
@@ -67,7 +69,9 @@ export async function addParameter(): Promise<void> {
   const schemaPoller = getSchemaPoller();
   const dbSchema = schemaPoller.metadata.dbSchema;
   const paramValue = await window.showInputBox({
-    prompt: 'Parameter value',
+    prompt: defaultParamName
+      ? `Parameter value for the parameter ${defaultParamName}`
+      : 'Parameter value',
     placeHolder:
       'The value for your parameter (anything you could evaluate in a RETURN), for example: 1234, "some string", datetime(), {a: 1, b: "some string"}',
     ignoreFocusOut: true,
@@ -75,7 +79,7 @@ export async function addParameter(): Promise<void> {
   });
 
   if (!paramValue) {
-    await window.showErrorMessage('Parameter value cannot be empty.');
+    void window.showErrorMessage('Parameter value cannot be empty.');
     return;
   }
 
@@ -141,7 +145,7 @@ export async function evaluateParam(
     const db = getCurrentDatabase();
 
     if (db.type === 'system') {
-      await window.showErrorMessage(
+      void window.showErrorMessage(
         'Parameters cannot be evaluated against a system database. Please connect to a user database.',
       );
       return;
@@ -177,7 +181,7 @@ export async function evaluateParam(
     if (e instanceof Neo4jError) {
       //If we can get past linting-check with invalid query but still have failing query
       //when executing, we catch here as a backup
-      await window.showErrorMessage(
+      void window.showErrorMessage(
         'Failed to evaluate parameter: ' + e.message,
       );
     } else {

--- a/packages/vscode-extension/src/cypherRunner.ts
+++ b/packages/vscode-extension/src/cypherRunner.ts
@@ -1,7 +1,31 @@
 import { parseStatementsStrs } from '@neo4j-cypher/language-support';
 import { Uri } from 'vscode';
+import { addParameter } from './commandHandlers/params';
 import { Connection } from './connectionService';
+import { getDeserializedParams } from './parameterService';
 import ResultWindow from './webviews/resultWindow';
+
+export function extractParameters(strings: string[]): string[] {
+  const paramSet = new Set<string>();
+
+  strings.forEach((str) => {
+    const matches = str.match(/\$`([^`]+)`|\$(\w+)/g);
+    if (matches) {
+      matches.forEach((match) => {
+        // Remove the '$'
+        const param = match.slice(1);
+        if (param.startsWith('`') && param.endsWith('`')) {
+          // Remove the backticks
+          paramSet.add(param.slice(1, -1));
+        } else {
+          paramSet.add(param);
+        }
+      });
+    }
+  });
+
+  return Array.from(paramSet);
+}
 
 export default class CypherRunner {
   private results: Map<string, ResultWindow> = new Map();
@@ -11,6 +35,14 @@ export default class CypherRunner {
   async run(connection: Connection, uri: Uri, input: string) {
     const statements = parseStatementsStrs(input);
     const filePath = uri.toString();
+    const parameters = getDeserializedParams();
+    const statementParams = extractParameters(statements);
+
+    for (const param of statementParams) {
+      if (parameters[param] === undefined) {
+        await addParameter(param);
+      }
+    }
 
     if (this.results.has(filePath)) {
       const resultWindow = this.results.get(filePath);

--- a/packages/vscode-extension/tests/fixtures/params.cypher
+++ b/packages/vscode-extension/tests/fixtures/params.cypher
@@ -1,1 +1,1 @@
-RETURN $a, $b, $`some param`, $`some-param`
+RETURN $a, $b, $`some param`, $`some-param`, $a + $b;

--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -1,6 +1,7 @@
 import { browser } from '@wdio/globals';
 import { before } from 'mocha';
 import { Workbench } from 'wdio-vscode-service';
+import { Key } from 'webdriverio';
 import {
   checkResultsContent,
   executeFile,
@@ -100,10 +101,17 @@ suite('Params panel testing', () => {
     await clearParams();
 
     await executeFile(workbench, 'params.cypher');
+
+    // to close the automatic param add pop-ups
+    for (let i = 0; i < 4; i++) {
+      await browser.keys([Key.Escape]);
+      await browser.pause(300);
+    }
+
     await checkResultsContent(workbench, async () => {
       const text = await (await $('#query-error')).getText();
       await expect(text).toContain(
-        'Error executing query RETURN $a, $b, $`some param`, $`some-param`:\nExpected parameter(s): a, b, some param, some-param',
+        'Error executing query RETURN $a, $b, $`some param`, $`some-param`, $a + $b;:\nExpected parameter(s): a, b, some param, some-param',
       );
     });
   });
@@ -155,10 +163,17 @@ suite('Params panel testing', () => {
     await forceDeleteParam('b');
 
     await executeFile(workbench, 'params.cypher');
+
+    // to close the automatic param add pop-ups
+    for (let i = 0; i < 2; i++) {
+      await browser.keys([Key.Escape]);
+      await browser.pause(300);
+    }
+
     await checkResultsContent(workbench, async () => {
       const text = await (await $('#query-error')).getText();
       await expect(text).toContain(
-        'Error executing query RETURN $a, $b, $`some param`, $`some-param`:\nExpected parameter(s): a, b',
+        'Error executing query RETURN $a, $b, $`some param`, $`some-param`, $a + $b;:\nExpected parameter(s): a, b',
       );
     });
   });
@@ -187,11 +202,45 @@ suite('Params panel testing', () => {
     // to execute the file we need to be on the user database
     await forceSwitchDatabase('neo4j');
     await executeFile(workbench, 'params.cypher');
+
+    // to close the automatic param add pop-ups
+    for (let i = 0; i < 4; i++) {
+      await browser.keys([Key.Escape]);
+      await browser.pause(300);
+    }
+
     await checkResultsContent(workbench, async () => {
       const text = await (await $('#query-error')).getText();
       await expect(text).toContain(
-        'Error executing query RETURN $a, $b, $`some param`, $`some-param`:\nExpected parameter(s): a, b, some param, some-param',
+        'Error executing query RETURN $a, $b, $`some param`, $`some-param`, $a + $b;:\nExpected parameter(s): a, b',
       );
+    });
+  });
+
+  test('Should trigger parameter add pop-up when running a query with an unknown parameter', async () => {
+    await clearParams();
+    await forceAddParam('a', '1998');
+    await executeFile(workbench, 'params.cypher');
+
+    // initial pop-up for param b
+    await browser.pause(300);
+    await browser.keys(['1', '2', Key.Enter]);
+
+    // initial pop-up for param `some param`
+    await browser.pause(300);
+    await browser.keys(['f', 'a', 'l', 's', 'e', Key.Enter]);
+
+    // initial pop-up for param `some-param`
+    await browser.pause(300);
+    await browser.keys(['5', Key.Enter]);
+
+    await checkResultsContent(workbench, async () => {
+      const queryResult = await (await $('#query-result')).getText();
+      await expect(queryResult).toContain('1998');
+      await expect(queryResult).toContain('12');
+      await expect(queryResult).toContain('false');
+      await expect(queryResult).toContain('5');
+      await expect(queryResult).toContain('2010');
     });
   });
 });


### PR DESCRIPTION
This pr is to trigger the parameter add pop-up when a user wants to run a query with missing parameters. With these changes:
- Passing a defaultName to the addParameter and adding param name to the `prompt`
- Changing parameter error messages from `await` to `void` to prevent the wait for user to manually close the error message before opening the add pop-up for the following missing parameter
- Adding a function `extractParameters` which gets an array of strings(queries) and returns distinct paramNames