### PR TITLE
adding semantic validation for missing paramters

### DIFF
--- a/.changeset/rich-fans-happen.md
+++ b/.changeset/rich-fans-happen.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+adding semantic validation for missing paramters

--- a/package-lock.json
+++ b/package-lock.json
@@ -20006,9 +20006,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.11.tgz",
-      "integrity": "sha512-4mVdhLkZ0vpqZLGJhNm+X1n7juqXApEMGlUXcOQawA45UmpxivOYaMBkI/Js3FlBsNA8hCgEnX5X04moFitSGw==",
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.12.tgz",
+      "integrity": "sha512-qrMwavANtSz91nDy3zEiUHMtL09x0mniQsSMvDkNxuCBM1W5vriJ22hEmwTth6DhLSWsZnHBT0yHFAQXt6efGA==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -89,39 +89,31 @@ function couldCreateNewLabel(ctx: ParserRuleContext): boolean {
   }
 }
 
-export type LabelOrRelType = {
+export type HasPosition = {
+  line: number;
+  column: number;
+  offsets: {
+    start: number;
+    end: number;
+  };
+};
+
+export type LabelOrRelType = HasPosition & {
   labelType: LabelType;
   labelText: string;
   couldCreateNewLabel: boolean;
-  line: number;
-  column: number;
-  offsets: {
-    start: number;
-    end: number;
-  };
 };
 
-export type ParsedParameter = {
+export type ParsedParameter = HasPosition & {
   name: string;
   rawText: string;
-  line: number;
-  column: number;
-  offsets: {
-    start: number;
-    end: number;
-  };
 };
 
-export type ParsedFunction = {
+export type ParsedFunction = HasPosition & {
   name: string;
   rawText: string;
-  line: number;
-  column: number;
-  offsets: {
-    start: number;
-    end: number;
-  };
 };
+
 export type ParsedProcedure = ParsedFunction;
 
 export function createParsingScaffolding(query: string): ParsingScaffolding {
@@ -319,7 +311,7 @@ class ParameterCollector implements ParseTreeListener {
       if (parameterName) {
         this.parameters.push({
           name: parameterName,
-          rawText: parameterName,
+          rawText: ctx.getText(),
           line: ctx.start.line,
           column: ctx.start.column,
           offsets: {

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -12,6 +12,7 @@ import {
   FunctionNameContext,
   LabelNameContext,
   LabelOrRelTypeContext,
+  ParameterContext,
   ProcedureNameContext,
   ProcedureResultItemContext,
   StatementOrCommandContext,
@@ -44,6 +45,7 @@ export interface ParsedStatement {
   stopNode: ParserRuleContext;
   collectedLabelOrRelTypes: LabelOrRelType[];
   collectedVariables: string[];
+  collectedParameters: ParsedParameter[];
   collectedFunctions: ParsedFunction[];
   collectedProcedures: ParsedProcedure[];
   cypherVersion?: CypherVersion;
@@ -91,6 +93,17 @@ export type LabelOrRelType = {
   labelType: LabelType;
   labelText: string;
   couldCreateNewLabel: boolean;
+  line: number;
+  column: number;
+  offsets: {
+    start: number;
+    end: number;
+  };
+};
+
+export type ParsedParameter = {
+  name: string;
+  rawText: string;
   line: number;
   column: number;
   offsets: {
@@ -177,6 +190,7 @@ export function createParsingResult(
     parsingScaffolding.statementsScaffolding.map((statementScaffolding) => {
       const { parser, tokens } = statementScaffolding;
       const labelsCollector = new LabelAndRelTypesCollector();
+      const parameterFinder = new ParameterCollector();
       const variableFinder = new VariableCollector();
       const methodsFinder = new MethodsCollector(tokens);
       const cypherVersionCollector = new CypherVersionCollector();
@@ -186,6 +200,7 @@ export function createParsingResult(
       );
       parser._parseListeners = [
         labelsCollector,
+        parameterFinder,
         variableFinder,
         methodsFinder,
         cypherVersionCollector,
@@ -214,6 +229,7 @@ export function createParsingResult(
         stopNode: findStopNode(ctx),
         collectedLabelOrRelTypes: labelsCollector.labelOrRelTypes,
         collectedVariables: variableFinder.variables,
+        collectedParameters: parameterFinder.parameters,
         collectedFunctions: methodsFinder.functions,
         collectedProcedures: methodsFinder.procedures,
         cypherVersion: cypherVersionCollector.cypherVersion,
@@ -273,6 +289,37 @@ class LabelAndRelTypesCollector extends ParseTreeListener {
           labelType: getLabelType(ctx),
           labelText: symbolicName.start.text,
           couldCreateNewLabel: couldCreateNewLabel(ctx),
+          line: ctx.start.line,
+          column: ctx.start.column,
+          offsets: {
+            start: ctx.start.start,
+            end: ctx.stop.stop + 1,
+          },
+        });
+      }
+    }
+  }
+}
+
+class ParameterCollector implements ParseTreeListener {
+  parameters: ParsedParameter[] = [];
+  enterEveryRule() {
+    /* no-op */
+  }
+  visitTerminal() {
+    /* no-op */
+  }
+  visitErrorNode() {
+    /* no-op */
+  }
+
+  exitEveryRule(ctx: unknown) {
+    if (ctx instanceof ParameterContext) {
+      const parameterName = ctx.parameterName().getText();
+      if (parameterName) {
+        this.parameters.push({
+          name: parameterName,
+          rawText: parameterName,
           line: ctx.start.line,
           column: ctx.start.column,
           offsets: {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -396,8 +396,8 @@ function errorOnUndeclaredParameters(
         parameter.name = parameter.name.substring(1, parameter.name.length - 1);
       }
       const parameterName = parameter.name;
-      const isParamExists = !!dbSchema.parameters?.[parameterName];
-      if (!isParamExists) {
+      const paramExists = !!dbSchema.parameters?.[parameterName];
+      if (!paramExists) {
         errors.push(
           generateSyntaxDiagnostic(
             parameterName,

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -2131,4 +2131,40 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
       },
     ]);
   });
+
+  test('Shows errors for missing parameters correctly with parameter names containing space', () => {
+    const query =
+      'MATCH (n: Person) WHERE n.name = $`missing param` and n.age = $`some param` RETURN n';
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          ...testData.mockSchema,
+          parameters: {
+            'some param': 21,
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        message: 'Parameter $`missing param` is not defined.',
+        offsets: {
+          end: 49,
+          start: 33,
+        },
+        range: {
+          end: {
+            character: 46,
+            line: 0,
+          },
+          start: {
+            character: 33,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
 });

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -2091,7 +2091,7 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         },
         range: {
           end: {
-            character: 45,
+            character: 46,
             line: 0,
           },
           start: {
@@ -2119,7 +2119,7 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         },
         range: {
           end: {
-            character: 45,
+            character: 48,
             line: 0,
           },
           start: {
@@ -2155,7 +2155,7 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
         },
         range: {
           end: {
-            character: 46,
+            character: 49,
             line: 0,
           },
           start: {

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -2075,4 +2075,60 @@ In this case, \`p\` is defined in the same \`MATCH\` clause as ((a)-[e]->(b {h: 
       },
     ]);
   });
+
+  test('Shows errors for missing parameters', () => {
+    const query =
+      'MATCH (n: Person) WHERE n.name = $missingParam and n.age = $myParam RETURN n';
+
+    expect(
+      getDiagnosticsForQuery({ query, dbSchema: testData.mockSchema }),
+    ).toEqual([
+      {
+        message: 'Parameter $missingParam is not defined.',
+        offsets: {
+          end: 46,
+          start: 33,
+        },
+        range: {
+          end: {
+            character: 45,
+            line: 0,
+          },
+          start: {
+            character: 33,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Shows errors for missing parameters correctly with backticked parameters', () => {
+    const query =
+      'MATCH (n: Person) WHERE n.name = $`missingParam` and n.age = $`myParam` RETURN n';
+
+    expect(
+      getDiagnosticsForQuery({ query, dbSchema: testData.mockSchema }),
+    ).toEqual([
+      {
+        message: 'Parameter $`missingParam` is not defined.',
+        offsets: {
+          end: 48,
+          start: 33,
+        },
+        range: {
+          end: {
+            character: 45,
+            line: 0,
+          },
+          start: {
+            character: 33,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
 });

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -404,7 +404,11 @@ describe('Syntactic validation spec', () => {
     expect(
       getDiagnosticsForQuery({
         query,
-        dbSchema: { labels: ['Dog', 'Cat'], relationshipTypes: ['Person'] },
+        dbSchema: {
+          labels: ['Dog', 'Cat'],
+          relationshipTypes: ['Person'],
+          parameters: { value: 'mockedName' },
+        },
       }),
     ).toEqual([]);
   });


### PR DESCRIPTION
This pr is to show semantic errors to users for the missing parameters. 

A look from my local:

<img width="760" alt="Screenshot 2025-04-03 at 10 59 19" src="https://github.com/user-attachments/assets/0b929733-6486-43f9-849d-87481021e69c" />
