### PR TITLE
Solves v3 tech debt: only one chunk list (STACKED PR; WRONG TARGET BRANCH)

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -2172,7 +2172,10 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this.removeIndentation(clauseIndent);
     this.breakLine();
-    this._visit(ctx.RPAREN());
+    this._visitTerminalRaw(ctx.RPAREN(), {
+      dontConcatenate: true,
+      spacingChoice: 'SPACE_AFTER',
+    });
   };
 
   visitProcedureName = (ctx: ProcedureNameContext) => {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -473,7 +473,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
         indentation: [],
       };
       this.getChunkList().push(chunk);
-      this.breakLine();
     }
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -573,10 +573,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const chunk: SyntaxErrorChunk = {
       type: 'SYNTAX_ERROR',
       text: combinedText,
-      groupsStarting: [],
+      groupsStarting: this.pendingGroups,
       groupsEnding: [],
       indentation: [],
     };
+    this.pendingGroups = [];
 
     this.getChunkList().push(chunk);
   };

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -235,6 +235,11 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   breakLine = () => {
+    // If there are active groups currently (such as when breakLine is called in EXISTS or
+    // CASE statements), they should all break.
+    this.groupStack.forEach((group) => {
+      group.breaksAll = true;
+    });
     this.mustBreakBetween();
   };
 
@@ -874,8 +879,8 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   _visitReturnBodyNotItems = (ctx: ReturnBodyContext) => {
     if (ctx.orderBy() || ctx.skip()) {
-      const orderSkipGrp = this.startGroup();
       this.breakLine();
+      const orderSkipGrp = this.startGroup();
       this._visit(ctx.orderBy());
       this._visit(ctx.skip());
       this.endGroup(orderSkipGrp);

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1900,15 +1900,13 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const mergeGrp = this.startGroup();
     this._visit(ctx.MERGE());
     const mergeClauseIndent = this.addIndentation();
-    const patternGrp = this.startGroup();
     this._visit(ctx.pattern());
     this.removeIndentation(mergeClauseIndent);
-    this.endGroup(patternGrp);
+    this.endGroup(mergeGrp);
     const n = ctx.mergeAction_list().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.mergeAction(i));
     }
-    this.endGroup(mergeGrp);
   };
 
   // Handled separately because it wants indentation

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -173,7 +173,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   format = () => {
     this._visit(this.root);
-    this.removeAllPendingGroups();
     this.fillInGroupSizes();
     const result = buffersToFormattedString(this.chunkList);
     this.cursorPos += result.cursorPos;
@@ -227,12 +226,6 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   getChunkList = () => this.chunkList;
 
   lastInChunkList = () => this.getChunkList().at(-1);
-
-  removeAllPendingGroups = () => {
-    while (this.groupStack.length > 0) {
-      this.endGroup(this.groupStack.at(-1).id);
-    }
-  };
 
   breakLine = () => {
     // If there are active groups currently (such as when breakLine is called in EXISTS or

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1912,8 +1912,14 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Handled separately because it wants indentation
   // https://neo4j.com/docs/cypher-manual/current/styleguide/#cypher-styleguide-indentation-and-line-breaks
   visitMergeAction = (ctx: MergeActionContext) => {
+    this.mustBreakBetween();
     const mergeActionIndent = this.addIndentation();
-    this.breakAndVisitChildren(ctx);
+    this._visit(ctx.ON());
+    this.avoidBreakBetween();
+    this._visit(ctx.MATCH());
+    this._visit(ctx.CREATE());
+    this.avoidBreakBetween();
+    this.visit(ctx.setClause());
     this.removeIndentation(mergeActionIndent);
   };
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1073,7 +1073,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (node.getText().startsWith(MISSING)) {
       return;
     }
-    if (this.chunkList.length === 1 && this.getChunkList().length === 0) {
+    if (this.chunkList.length === 0) {
       this.addCommentsBefore(node);
     }
     if (node.symbol.type === CypherCmdLexer.EOF) {
@@ -1114,7 +1114,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (node.getText().startsWith(MISSING)) {
       return;
     }
-    if (this.chunkList.length === 1 && this.getChunkList().length === 0) {
+    if (this.chunkList.length === 0) {
       this.addCommentsBefore(node);
     }
     let text = node.getText();

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -41,6 +41,7 @@ export interface RegularChunk extends BaseChunk {
 }
 
 export interface SyntaxErrorChunk extends BaseChunk {
+  mustBreak?: boolean;
   type: 'SYNTAX_ERROR';
 }
 

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -177,13 +177,11 @@ export function fillInRegularChunkGroupSizes(
   }
 }
 
-export function verifyGroupSizes(buffers: Chunk[][]) {
-  for (const chunkList of buffers) {
-    for (const chunk of chunkList) {
-      for (const group of chunk.groupsStarting) {
-        if (group.size !== group.dbgText.length) {
-          throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
-        }
+export function verifyGroupSizes(chunkList: Chunk[]) {
+  for (const chunk of chunkList) {
+    for (const group of chunk.groupsStarting) {
+      if (group.size !== group.dbgText.length) {
+        throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
       }
     }
   }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -125,7 +125,10 @@ function createStateTransition(
       choice.left,
       // We should apply the indentation also if it was a group that would want to split, but wasn't
       // allowed to (because of avoidBreakBetween() in the visitor).
-      isBreak || split.wantedToSplit,
+      isBreak ||
+        split.wantedToSplit ||
+        // For syntax errors
+        choice.right.text.startsWith('\n'),
     );
 
   const actualColumn = state.column === 0 ? indentationDecision : state.column;

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -152,7 +152,10 @@ function createStateTransition(
 }
 
 function determineSplits(chunk: Chunk, nextChunk: Chunk): Split[] {
-  if (chunk.type === 'SYNTAX_ERROR' || nextChunk?.type === 'SYNTAX_ERROR') {
+  if (chunk.type === 'SYNTAX_ERROR') {
+    return chunk.mustBreak ? onlyBreakSplit : noSpaceNoBreakSplit;
+  }
+  if (nextChunk?.type === 'SYNTAX_ERROR') {
     return noSpaceNoBreakSplit;
   }
   if (isCommentBreak(chunk, nextChunk)) {

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -323,7 +323,6 @@ function chunkListToChoices(chunkList: Chunk[]): Choice[] {
 export function buffersToFormattedString(
   chunkList: Chunk[],
 ): FinalResultWithPos {
-  let formatted = '';
   let cursorPos = 0;
   const choices: Choice[] = chunkListToChoices(chunkList);
   const initialState: State = {
@@ -337,12 +336,13 @@ export function buffersToFormattedString(
   };
   const decisions = computeFormattingDecisions(initialState, choices);
   const formattingResult = decisionsToFormatted(decisions);
+  let formatted = '';
   // Cursor is not in this chunkList
-  if (typeof formattingResult === 'string') {
-    formatted += formattingResult + '\n';
-  } else {
+  if (typeof formattingResult !== 'string') {
     cursorPos = formatted.length + formattingResult.cursorPos;
-    formatted += formattingResult.formattedString + '\n';
+    formatted = formattingResult.formattedString;
+  } else {
+    formatted = formattingResult;
   }
   return { formattedString: formatted.trimEnd(), cursorPos: cursorPos };
 }

--- a/packages/language-support/src/formatting/formattingSolutionSearch.ts
+++ b/packages/language-support/src/formatting/formattingSolutionSearch.ts
@@ -52,10 +52,6 @@ interface State {
   choiceIndex: number;
 }
 
-interface Result {
-  decisions: Decision[];
-}
-
 interface FinalResultWithPos {
   formattedString: string;
   cursorPos: number;
@@ -241,7 +237,7 @@ function endGroups(state: State, choice: Choice) {
 function computeFormattingDecisions(
   startingState: State,
   choiceList: Choice[],
-): Result {
+): Decision[] {
   let state = startingState;
   const decisions: Decision[] = [];
   for (const choice of choiceList) {
@@ -256,9 +252,7 @@ function computeFormattingDecisions(
   ) {
     throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
   }
-  return {
-    decisions,
-  };
+  return decisions;
 }
 
 // Used for debugging only; it's very convenient to know where groups start and end
@@ -341,8 +335,8 @@ export function buffersToFormattedString(
     column: 0,
     choiceIndex: 0,
   };
-  const result = computeFormattingDecisions(initialState, choices);
-  const formattingResult = decisionsToFormatted(result.decisions);
+  const decisions = computeFormattingDecisions(initialState, choices);
+  const formattingResult = decisionsToFormatted(decisions);
   // Cursor is not in this chunkList
   if (typeof formattingResult === 'string') {
     formatted += formattingResult + '\n';

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -810,16 +810,18 @@ END`;
 MATCH (n)
 RETURN
   CASE
-    WHEN EXISTS {
-      MATCH (person)-[:HAS_DOG]->(dog:Dog)
-      WHERE person.name = 'Chris'
-      WITH dog
-      RETURN
-        CASE
-          WHEN dog.name = 'Ozzy' THEN true
-          ELSE false
-        END
-    } THEN 'Relationship'
+    WHEN
+      EXISTS {
+        MATCH (person)-[:HAS_DOG]->(dog:Dog)
+        WHERE person.name = 'Chris'
+        WITH dog
+        RETURN
+          CASE
+            WHEN dog.name = 'Ozzy' THEN true
+            ELSE false
+          END
+      }
+      THEN 'Relationship'
   END`.trimStart();
     verifyFormatting(query, expected);
   });
@@ -841,16 +843,18 @@ END
 MATCH (n)
 RETURN
   CASE
-    WHEN EXISTS {
-      MATCH (person)-[:HAS_DOG]->(dog:Dog)
-      WHERE person.name = 'Chris'
-      WITH dog
-      RETURN
-        CASE
-          WHEN dog.name = 'Ozzy' THEN true
-          ELSE false
-        END
-    } THEN 'Relationship'
+    WHEN
+      EXISTS {
+        MATCH (person)-[:HAS_DOG]->(dog:Dog)
+        WHERE person.name = 'Chris'
+        WITH dog
+        RETURN
+          CASE
+            WHEN dog.name = 'Ozzy' THEN true
+            ELSE false
+          END
+      }
+      THEN 'Relationship'
   END`.trimStart();
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -859,9 +859,6 @@ RETURN
     verifyFormatting(query, expected);
   });
 
-  /**
-   * TODO: v3 Nested EXISTS / CASE expressions do not get entirely correct indentation yet
-   * (though it is close.)
   test('extremely complex expressions with nested exist and case', () => {
     const query = `
 MATCH (n)
@@ -898,59 +895,71 @@ END
 END`.trimStart();
     const expected = `
 MATCH (n)
-RETURN 5 +
+RETURN
+  5 +
   CASE
-    WHEN (n)--() THEN
-      CASE
-        WHEN EXISTS {
-          MATCH (person)-[:HAS_DOG]->(dog:Dog)
-          WHERE
-            person.name = 'Chris' OR
-            person.name = 'Chris' OR
-            person.name = 'Chris' OR
-            person.name = 'Chris' OR
-            person.name = 'Chris' OR
-            person.name = 'Chris'
-          WITH dog
-          WHERE dog.name = 'Ozzy'
-        } THEN 'Relationship'
-        WHEN (n {prop: 42}) THEN
-          CASE
-            WHEN
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--() OR
-              (n)--()
-              THEN 'Relationship'
-            WHEN (n {prop: 42}) THEN
+    WHEN
+      (n)--()
+      THEN
+        CASE
+          WHEN
+            EXISTS {
+              MATCH (person)-[:HAS_DOG]->(dog:Dog)
+              WHERE
+                person.name = 'Chris' OR
+                person.name = 'Chris' OR
+                person.name = 'Chris' OR
+                person.name = 'Chris' OR
+                person.name = 'Chris' OR
+                person.name = 'Chris'
+              WITH dog
+              WHERE dog.name = 'Ozzy'
+            }
+            THEN 'Relationship'
+          WHEN
+            (n {prop: 42})
+            THEN
               CASE
-                WHEN EXISTS {
-                  MATCH (person)-[:HAS_DOG]->(dog:Dog)
-                  WHERE person.name = 'Chris'
-                  WITH dog
-                  WHERE dog.name = 'Ozzy'
-                } THEN 'Relationship'
-                WHEN (n {prop: 42}) THEN 'Node'
+                WHEN
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--() OR
+                  (n)--()
+                  THEN 'Relationship'
+                WHEN
+                  (n {prop: 42})
+                  THEN
+                    CASE
+                      WHEN
+                        EXISTS {
+                          MATCH (person)-[:HAS_DOG]->(dog:Dog)
+                          WHERE person.name = 'Chris'
+                          WITH dog
+                          WHERE dog.name = 'Ozzy'
+                        }
+                        THEN 'Relationship'
+                      WHEN (n {prop: 42}) THEN 'Node'
+                    END
               END
-          END
-      END
-    WHEN (n {prop: 42}) THEN
-      CASE
-        WHEN (n)--() THEN 'Relationship'
-        WHEN (n {prop: 42}) THEN 'Node'
-      END
+        END
+    WHEN
+      (n {prop: 42})
+      THEN
+        CASE
+          WHEN (n)--() THEN 'Relationship'
+          WHEN (n {prop: 42}) THEN 'Node'
+        END
   END`.trimStart();
     verifyFormatting(query, expected);
   });
-  */
 
   test('else statements for CASE needs to align its expression', () => {
     const query = `MATCH (u:User)

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -980,8 +980,7 @@ RETURN
         ' likes and interests: ' + toString(interestList)
       END
   END AS userProfile;`;
-    // TODO: the THENs below the EXISTS should get put on the next line (?) and get extra indentation.
-    // This doesn't work yet because we haven't moved to a single chunkList yet.
+    // TODO: should perhaps the likeCount > 10 part remain on the same line?
     const expected = `MATCH (u:User)
 WITH
   u,
@@ -989,25 +988,32 @@ WITH
   collect(DISTINCT u.interests) AS interestList
 RETURN
   CASE
-    WHEN EXISTS {
-      MATCH (u)-[:OWNS]->(:Device {type: 'Smartphone'})
-    } AND likeCount > 10 THEN
-      CASE p.name
-        WHEN
-          size(interestList) > 3
-          THEN
-            'Active smartphone user with diverse interests: ' +
+    WHEN
+      EXISTS {
+        MATCH (u)-[:OWNS]->(:Device {type: 'Smartphone'})
+      } AND
+      likeCount > 10
+      THEN
+        CASE p.name
+          WHEN
+            size(interestList) > 3
+            THEN
+              'Active smartphone user with diverse interests: ' +
+              toString(interestList)
+          ELSE
+            'Active smartphone user with few interests: ' +
             toString(interestList)
-        ELSE
-          'Active smartphone user with few interests: ' + toString(interestList)
-      END
+        END
     ELSE
       CASE
-        WHEN NOT EXISTS {
-          MATCH (u)-[:OWNS]->(:Device {type: 'Smartphone'})
-        } AND likeCount <= 10 THEN
-          'Less active user without a smartphone, interests: ' +
-          toString(interestList)
+        WHEN
+          NOT EXISTS {
+            MATCH (u)-[:OWNS]->(:Device {type: 'Smartphone'})
+          } AND
+          likeCount <= 10
+          THEN
+            'Less active user without a smartphone, interests: ' +
+            toString(interestList)
         ELSE
           'User with moderate activity, ' +
           toString(likeCount) +

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1104,10 +1104,13 @@ and not x.to = left(j.node_STNAME, size(x.to))
 return x.to,  left(j.node_STNAME, size(x.to))
 limit "g68S0y7w";`;
     const expected = `MATCH (i:Node)-[s:STREET]->(j:Node)
-WHERE s.TrafDir = "K8c0Ceds" AND EXISTS {
-  (i)-[x]-(j)
-  WHERE type(x) <> "laGrU2e1"
-}
+WHERE
+  s.TrafDir = "K8c0Ceds" AND
+  EXISTS {
+    (i)-[x]-
+    (j)
+    WHERE type(x) <> "laGrU2e1"
+  }
 WITH i, j
 MATCH p = (i)-[x]->(j)
 WHERE type(x) <> "vDCx6qeK" AND NOT x.to = left(j.node_STNAME, size(x.to))

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -613,9 +613,6 @@ RETURN [r IN relationships(path) | r.distance] AS distances`.trimStart();
     verifyFormatting(query, expected);
   });
 
-  /**
-   * TODO: v3 Nested EXISTS / CASE expressions do not get entirely correct indentation yet
-   * (though it is close.)
   test('test for nested exists cases', () => {
     const query = `MATCH (user:Actor {actor_type:"EFXxFHob"})
 WHERE(
@@ -642,31 +639,45 @@ WHERE approval.status<>"granted"
 }AND user.last_login>datetime()-duration({days:30})
 )`;
     const expected = `MATCH (user:Actor {actor_type: "EFXxFHob"})
-WHERE ((size(apoc.coll.intersection(labels(user), idp_label_list)) = "3INQ6teR"
-        OR user.service_type = "UlAAMmmD") AND NOT EXISTS {
-        MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
-        WITH group, apoc.coll.intersection(labels(group), idp_label_list)
-                    AS group_idp_labels
-        WHERE (size(group_idp_labels) = "7SOM63mX" OR
-               group.service_type = "11gaOJfr") AND EXISTS {
-                MATCH (group)-[:HAS_ACCESS]->(resource:Resource)
-                WHERE resource.sensitivity > 7 AND NOT EXISTS {
-                        MATCH (resource)-[:PROTECTED_BY]->(policy:Policy)
-                        WHERE policy.enforcement = "strict"
-                      } AND resource.type IN ["confidential", "restricted"]
-              } OR group.created_at < datetime("2023-01-01") OR
-              group.created_at < datetime("2023-01-01") OR
-              group.created_at < datetime("2023-01-01")
-      }) OR (user.active = true AND EXISTS {
-        MATCH (user)-[:HAS_ROLE]->(role:Role)
-        WHERE role.type IN role_types AND NOT EXISTS {
-                MATCH (role)-[:REQUIRES]->(approval:Approval)
-                WHERE approval.status <> "granted"
-              } AND (role.expiry_date > datetime() OR role.permanent = true)
-      } AND user.last_login > datetime() - duration({days: 30}))`;
+WHERE
+  ((size(apoc.coll.intersection(labels(user), idp_label_list)) = "3INQ6teR" OR
+      user.service_type = "UlAAMmmD") AND
+    NOT EXISTS {
+      MATCH (user)-[:PART_OF]->(group:Actor {actor_type: "A0cFHwrB"})
+      WITH
+        group,
+        apoc.coll.intersection(labels(group), idp_label_list) AS
+          group_idp_labels
+      WHERE
+        (size(group_idp_labels) = "7SOM63mX" OR group.service_type = "11gaOJfr") AND
+        EXISTS {
+          MATCH (group)-[:HAS_ACCESS]->(resource:Resource)
+          WHERE
+            resource.sensitivity > 7 AND
+            NOT EXISTS {
+              MATCH (resource)-[:PROTECTED_BY]->(policy:Policy)
+              WHERE policy.enforcement = "strict"
+            } AND
+            resource.type IN ["confidential", "restricted"]
+        } OR
+        group.created_at < datetime("2023-01-01") OR
+        group.created_at < datetime("2023-01-01") OR
+        group.created_at < datetime("2023-01-01")
+    }) OR
+  (user.active = true AND
+    EXISTS {
+      MATCH (user)-[:HAS_ROLE]->(role:Role)
+      WHERE
+        role.type IN role_types AND
+        NOT EXISTS {
+          MATCH (role)-[:REQUIRES]->(approval:Approval)
+          WHERE approval.status <> "granted"
+        } AND
+        (role.expiry_date > datetime() OR role.permanent = true)
+    } AND
+    user.last_login > datetime() - duration({days: 30}))`;
     verifyFormatting(query, expected);
   });
-   */
 
   test('test that clause under collect gets properly indented', () => {
     const query = `MATCH (person:Person)
@@ -1079,7 +1090,6 @@ RETURN n`;
 }`;
     verifyFormatting(query, expected);
   });
-
   test('exists should break its expressions', () => {
     const query = `MATCH (i:Node)-[s:STREET ]->(j:Node)
 where s.TrafDir = "K8c0Ceds"

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -670,11 +670,13 @@ WHERE ((size(apoc.coll.intersection(labels(user), idp_label_list)) = "3INQ6teR"
 
   test('test that clause under collect gets properly indented', () => {
     const query = `MATCH (person:Person)
-RETURN person.name AS name, COLLECT {
-  MATCH (person)-[r:HAS_DOG]->(dog:Dog)
-  WHERE r.since > 2017
-  RETURN dog.name
-} AS youngDogs`;
+RETURN
+  person.name AS name,
+  COLLECT {
+    MATCH (person)-[r:HAS_DOG]->(dog:Dog)
+    WHERE r.since > 2017
+    RETURN dog.name
+  } AS youngDogs`;
     const expected = query;
     verifyFormatting(query, expected);
   });
@@ -688,13 +690,15 @@ RETURN person.name AS name`;
   });
   test('count expression with regular query', () => {
     const query = `MATCH (person:Person)
-RETURN person.name AS name, COUNT {
-  MATCH (person)-[:HAS_DOG]->(dog:Dog)
-  RETURN dog.name AS petName
-    UNION
-  MATCH (person)-[:HAS_CAT]->(cat:Cat)
-  RETURN cat.name AS petName
-} AS numPets`;
+RETURN
+  person.name AS name,
+  COUNT {
+    MATCH (person)-[:HAS_DOG]->(dog:Dog)
+    RETURN dog.name AS petName
+      UNION
+    MATCH (person)-[:HAS_CAT]->(cat:Cat)
+    RETURN cat.name AS petName
+  } AS numPets`;
     const expected = query;
     verifyFormatting(query, expected);
   });

--- a/packages/language-support/src/tests/formatting/styleguide.test.ts
+++ b/packages/language-support/src/tests/formatting/styleguide.test.ts
@@ -22,10 +22,11 @@ RETURN a.prop`;
     const query = `MATCH (a:A) WHERE EXISTS {MATCH (a)-->(b:B) WHERE b.prop = 'yellow'} RETURN a.foo`;
 
     const expected = `MATCH (a:A)
-WHERE EXISTS {
-  MATCH (a)-->(b:B)
-  WHERE b.prop = 'yellow'
-}
+WHERE
+  EXISTS {
+    MATCH (a)-->(b:B)
+    WHERE b.prop = 'yellow'
+  }
 RETURN a.foo`;
     verifyFormatting(query, expected);
   });
@@ -332,9 +333,10 @@ CALL (c, c2, trxs, avgTrx, totalSum) {
 
 ;`;
     const expected = `MATCH (c:Cuenta)-[:REALIZA]->(m:Movimiento)-[:HACIA]->(c2:Cuenta)
-WHERE NOT EXISTS {
-  MATCH (c)-[:TRANSFIERE]->(c2)
-}
+WHERE
+  NOT EXISTS {
+    MATCH (c)-[:TRANSFIERE]->(c2)
+  }
 WITH c, c2, count(m) AS trxs, avg(m.monto) AS avgTrx, sum(m.monto) AS totalSum
 LIMIT 1000
 CALL (c, c2, trxs, avgTrx, totalSum) {


### PR DESCRIPTION
## Description
As noted in the original V3 pr (#460), we no longer need multiple chunk lists. Previously, we separated the problem of formatting between each clause, such that we formatted a list of chunks one clause at a time, and then put the result together for the full formatted output. This was necessary because otherwise the search space for the solution search would be way too large. Since we now no longer do a solution search, this can be dropped, which is what this PR does.

This also enables us to format things that contain nested queries, such as EXISTS expressions. Some of those were left commented out in the original PR, but they are now reenabled. An example would be this one:

```
MATCH (person:Person)
RETURN
  person.name AS name,
  COLLECT {
    MATCH (person)-[r:HAS_DOG]->(dog:Dog)
    WHERE r.since > 2017
    RETURN dog.name
  } AS youngDogs
```
This is the correct output according to the Prettier style; we split between every item in the return list (the COLLECT expression counts as one item). It was not possible to do this previously, as we had to end all groups at the start of the subquery in COLLECT. Now, all clauses are formatted like any other language construct.
 

## Testing
Uncommented a few of the older complicated EXISTS / CASE tests that now look good as a result of this