### PR TITLE
Removes switch database command from the palette

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -176,6 +176,10 @@
         {
           "command": "neo4j.editParameter",
           "when": "false"
+        },
+        {
+          "command": "neo4j.switchDatabase",
+          "when": "false"
         }
       ],
       "view/title": [


### PR DESCRIPTION
It shouldn't be there, it will fail from the palette because it requires the database item as an input.