### PR TITLE
Improve CI speed

### DIFF
--- a/.github/actions/setup-and-build/action.yaml
+++ b/.github/actions/setup-and-build/action.yaml
@@ -1,0 +1,69 @@
+name: 'Setup and build project'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup antlr
+      shell: bash
+      run: |
+        curl https://www.antlr.org/download/antlr-4.13.0-complete.jar --output antlr4.jar
+        mkdir -p $HOME/.local/bin
+        echo -e "#bin/bash\njava -jar $PWD/antlr4.jar \$@" > $HOME/.local/bin/antlr4
+        chmod a+x $HOME/.local/bin/antlr4
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Setup node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies with frozen lock file
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Check for cached build
+      id: restore-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          # Build artifacts only (not node_modules), based on .gitignore
+          # Generaged parsers from us and vendor
+          **/generated-parser
+          **/generated
+          # Build outputs
+          **/*.vsix
+          **/*.tsbuildinfo
+          **/dist
+          **/build
+          **/out
+
+        key: build-${{ github.sha }}
+        restore-keys: |
+          build-${{ github.sha }}
+
+    - name: Setup and build project
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        NODE_OPTIONS: '--max_old_space_size=4096'
+      run: pnpm build
+
+    - name: Cache build output
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
+      with:
+        # Same paths as above
+        path: |
+          **/generated-parser
+          **/generated
+          **/*.vsix
+          **/*.tsbuildinfo
+          **/dist
+          **/build
+          **/out
+
+        key: build-${{ github.sha }}

--- a/.github/workflows/archive-vscode-artifacts.yaml
+++ b/.github/workflows/archive-vscode-artifacts.yaml
@@ -16,8 +16,8 @@ jobs:
         with:
           lfs: true
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - name: Setup project
+        uses: ./.github/actions/setup-and-build
 
       - name: Generate VSCode plugin package
         run: |

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - name: Setup and build project
+        uses: ./.github/actions/setup-and-build
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --only-shell --with-deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,18 +7,28 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NODE_OPTIONS: '--max_old_space_size=8192'
 
 jobs:
-  lint-and-format:
-    name: Run eslint and check formatting
+  build:
+    name: Setup and build project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-and-build
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+  lint-and-format:
+    name: Run eslint and check formatting
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-and-build
 
       - name: Check there are no linting errors
         run: pnpm lint
@@ -30,38 +40,60 @@ jobs:
 
   unit-test:
     name: Unit tests
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - uses: ./.github/actions/setup-and-build
 
       - name: Run tests
         run: pnpm test
 
-  e2e-test:
-    name: E2E tests
-    timeout-minutes: 60
+  react-codemirror-e2e-test:
+    name: React Codemirror E2E tests
+    needs: build
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - uses: ./.github/actions/setup-and-build
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --only-shell --with-deps
+        run: pnpm exec playwright install --only-shell --with-deps chromium
         working-directory: packages/react-codemirror
 
       - name: Run e2e test
-        # We need a graphics server to run integration tests with VSCode
-        # https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
-        run: xvfb-run -a pnpm test:e2e
+        run: pnpm --filter react-codemirror test:e2e
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
           path: packages/react-codemirror/playwright-report/
           retention-days: 30
+
+  vscode-webview-test:
+    name: VSCode Webview tests
+    needs: build
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-and-build
+
+      - name: Run e2e test
+        # We need a graphics server to run integration tests with VSCode
+        run: xvfb-run -a pnpm --filter neo4j-for-vscode test:webviews
+
+  vscode-api-and-unit-tests:
+    name: VSCode API and Unit tests
+    needs: build
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-and-build
+
+      - name: Run tests
+        run: xvfb-run -a pnpm --filter neo4j-for-vscode test:apiAndUnit

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - name: Setup and build project
+        uses: ./.github/actions/setup-and-build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/formatting-integrity-check.yaml
+++ b/.github/workflows/formatting-integrity-check.yaml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - name: Setup and build project
+        uses: ./.github/actions/setup-and-build
 
       - name: Run formatting check
         run: pnpm test:formattingIntegrity

--- a/.github/workflows/publish-npm-packages.yaml
+++ b/.github/workflows/publish-npm-packages.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      - name: Setup and build project
+        uses: ./.github/actions/setup-and-build
 
       - name: Build and release canary package to npm
-        run: pnpm snapshot-release
+        run: pnpm release-snapshot
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -17,8 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build project
-        uses: ./.github/actions/build-project
+      # todo verify caching works well here too
+      - name: Setup and build project
+        uses: ./.github/actions/setup-and-build
 
       - name: Publish to VSCode Marketplace
         env:

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -32,6 +32,9 @@ export type {
   Neo4jProcedure,
 } from './types';
 export { cypher25Supported } from './version';
-export { CypherLexer, CypherParser };
+export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
+
 import CypherLexer from './generated-parser/CypherCmdLexer';
 import CypherParser from './generated-parser/CypherCmdParser';
+import CypherParserListener from './generated-parser/CypherCmdParserListener';
+import CypherParserVisitor from './generated-parser/CypherCmdParserVisitor';

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -32,9 +32,6 @@ export type {
   Neo4jProcedure,
 } from './types';
 export { cypher25Supported } from './version';
-export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
-
+export { CypherLexer, CypherParser };
 import CypherLexer from './generated-parser/CypherCmdLexer';
 import CypherParser from './generated-parser/CypherCmdParser';
-import CypherParserListener from './generated-parser/CypherCmdParserListener';
-import CypherParserVisitor from './generated-parser/CypherCmdParserVisitor';

--- a/packages/react-codemirror/package.json
+++ b/packages/react-codemirror/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test -c playwright-ct.config.ts",
     "test:e2e-ui": "playwright test -c playwright-ct.config.ts --ui",
-    "benchmark": "BENCHMARKING=true npx playwright test -c playwright-ct.config.ts -g \"benchmarking & performance test session\""
+    "benchmark": "BENCHMARKING=true playwright test -c playwright-ct.config.ts -g \"benchmarking & performance test session\""
   },
   "repository": {
     "type": "git",

--- a/packages/react-codemirror/playwright-ct.config.ts
+++ b/packages/react-codemirror/playwright-ct.config.ts
@@ -8,9 +8,9 @@ export default defineConfig({
   /* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot and toHaveScreenshot. */
   snapshotDir: './__snapshots__',
   /* Maximum time one test can run for. */
-  timeout: 20 * 1000,
+  timeout: 30 * 1000,
   /* Run tests in files in parallel */
-  fullyParallel: false,
+  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -42,16 +42,7 @@ export default defineConfig({
   },
 
   // Glob patterns or regular expressions that match test files.
-  testMatch: '*.spec.tsx',
+  testMatch: '**/*.spec.tsx',
 
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-  ],
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -426,8 +426,8 @@
     "build:dev": "tsc -b && pnpm gen-textmate && pnpm bundle-extension:dev && pnpm bundle-language-server && pnpm bundle-webview-controllers",
     "clean": "rm -rf dist",
     "test:e2e": "pnpm build:dev && pnpm test:apiAndUnit && pnpm test:webviews",
-    "test:apiAndUnit": "pnpm build:dev && rm -rf .vscode-test/user-data && node ./dist/tests/runApiAndUnitTests.js",
-    "test:webviews": "pnpm build:dev && wdio run ./dist/tests/runWebviewTests.js"
+    "test:apiAndUnit": "rm -rf .vscode-test/user-data && node ./dist/tests/runApiAndUnitTests.js",
+    "test:webviews": "wdio run ./dist/tests/runWebviewTests.js"
   },
   "dependencies": {
     "@neo4j-cypher/language-server": "workspace:*",

--- a/packages/vscode-extension/src/commandHandlers/connection.ts
+++ b/packages/vscode-extension/src/commandHandlers/connection.ts
@@ -226,9 +226,10 @@ export async function cypherFileFromSelection(): Promise<void> {
 
 export async function forceDisconnect(): Promise<void> {
   const activeConnection = getActiveConnection();
-  const { result, connection } =
-    await toggleConnectionAndUpdateDatabaseConnection(activeConnection);
-  displayMessageForConnectionResult(connection, result);
+
+  await toggleConnectionAndUpdateDatabaseConnection(activeConnection);
+
+  void window.showInformationMessage(CONSTANTS.MESSAGES.DISCONNECTED_MESSAGE);
 }
 
 export async function forceConnect(i: number): Promise<void> {

--- a/packages/vscode-extension/src/commandHandlers/params.ts
+++ b/packages/vscode-extension/src/commandHandlers/params.ts
@@ -54,6 +54,14 @@ export async function addParameter(defaultParamName?: string): Promise<void> {
     return;
   }
 
+  const db = getCurrentDatabase();
+  if (db.type === 'system') {
+    void window.showErrorMessage(
+      'Parameters cannot be added when on the system database. Please connect to a user database.',
+    );
+    return;
+  }
+
   const paramName =
     defaultParamName ??
     (await window.showInputBox({
@@ -103,6 +111,15 @@ export async function editParameter(paramItem: ParameterItem): Promise<void> {
     );
     return;
   }
+
+  const db = getCurrentDatabase();
+  if (db.type === 'system') {
+    void window.showErrorMessage(
+      'Parameters cannot be edited when on the system database. Please connect to a user database.',
+    );
+    return;
+  }
+
   const existingParam = getParameter(paramItem.id);
   if (!existingParam) {
     return;

--- a/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/autoCompletion.spec.ts
@@ -246,45 +246,6 @@ suite('Auto completion spec', () => {
     });
   });
 
-  test('Parameters are available in completions even when disconnected from neo4j', async () => {
-    await vscode.commands.executeCommand(
-      CONSTANTS.COMMANDS.INTERNAL.EVAL_PARAMETER,
-      'a',
-      '"charmander"',
-    );
-
-    await vscode.commands.executeCommand(
-      CONSTANTS.COMMANDS.INTERNAL.EVAL_PARAMETER,
-      'b',
-      '"pikachu"',
-    );
-    await vscode.commands.executeCommand(
-      CONSTANTS.COMMANDS.INTERNAL.FORCE_DISCONNECT,
-    );
-    const textDocument = await newUntitledFileWithContent(`RETURN `);
-    const position = new vscode.Position(0, 7);
-    const expecations: vscode.CompletionItem[] = [
-      {
-        label: '$a',
-        kind: vscode.CompletionItemKind.Variable,
-      },
-      {
-        label: '$b',
-        kind: vscode.CompletionItemKind.Variable,
-      },
-    ];
-    await testCompletionContains({
-      textFile: textDocument.uri,
-      position: position,
-      expected: expecations,
-    });
-
-    await vscode.commands.executeCommand(
-      CONSTANTS.COMMANDS.INTERNAL.FORCE_CONNECT,
-      0,
-    );
-  });
-
   test('Parameters are backticked correctly', async () => {
     await vscode.commands.executeCommand(
       CONSTANTS.COMMANDS.INTERNAL.EVAL_PARAMETER,
@@ -332,5 +293,44 @@ suite('Auto completion spec', () => {
         },
       ],
     });
+  });
+
+  test('Parameters are available in completions even when disconnected from neo4j', async () => {
+    await vscode.commands.executeCommand(
+      CONSTANTS.COMMANDS.INTERNAL.EVAL_PARAMETER,
+      'a',
+      '"charmander"',
+    );
+
+    await vscode.commands.executeCommand(
+      CONSTANTS.COMMANDS.INTERNAL.EVAL_PARAMETER,
+      'b',
+      '"pikachu"',
+    );
+    await vscode.commands.executeCommand(
+      CONSTANTS.COMMANDS.INTERNAL.FORCE_DISCONNECT,
+    );
+    const textDocument = await newUntitledFileWithContent(`RETURN `);
+    const position = new vscode.Position(0, 7);
+    const expecations: vscode.CompletionItem[] = [
+      {
+        label: '$a',
+        kind: vscode.CompletionItemKind.Variable,
+      },
+      {
+        label: '$b',
+        kind: vscode.CompletionItemKind.Variable,
+      },
+    ];
+    await testCompletionContains({
+      textFile: textDocument.uri,
+      position: position,
+      expected: expecations,
+    });
+
+    await vscode.commands.executeCommand(
+      CONSTANTS.COMMANDS.INTERNAL.FORCE_CONNECT,
+      0,
+    );
   });
 });

--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -4,6 +4,7 @@ import { Workbench } from 'wdio-vscode-service';
 import { Key } from 'webdriverio';
 import {
   checkResultsContent,
+  ensureNotificationsAreDismissed,
   executeFile,
   waitUntilNotification,
 } from '../../webviewUtils';
@@ -68,10 +69,11 @@ suite('Params panel testing', () => {
   }
 
   async function forceDisconnect() {
-    await browser.executeWorkbench(async (vscode) => {
+    void browser.executeWorkbench((vscode) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      await vscode.commands.executeCommand('neo4j.internal.forceDisconnect');
+      void vscode.commands.executeCommand('neo4j.internal.forceDisconnect');
     });
+    await waitUntilNotification(browser, 'Disconnected from Neo4j.');
   }
 
   async function forceSwitchDatabase(database: string) {
@@ -82,13 +84,15 @@ suite('Params panel testing', () => {
         database,
       );
     }, database);
+    await waitUntilNotification(browser, `Switched to database '${database}'.`);
   }
 
   async function forceConnect(i: number) {
-    await browser.executeWorkbench(async (vscode, i) => {
+    void browser.executeWorkbench((vscode, i) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      await vscode.commands.executeCommand('neo4j.internal.forceConnect', i);
+      void vscode.commands.executeCommand('neo4j.internal.forceConnect', i);
     }, i);
+    await waitUntilNotification(browser, 'Connected to Neo4j.');
   }
 
   test('Should correctly set and clear cypher parameters', async function () {
@@ -118,6 +122,31 @@ suite('Params panel testing', () => {
         'Error executing query RETURN $a, $b, $`some param`, $`some-param`, $a + $b;:\nExpected parameter(s): a, b, some param, some-param',
       );
     });
+  });
+
+  test('Cannot set parameters when disconnected from the database', async function () {
+    await ensureNotificationsAreDismissed(browser);
+    await forceDisconnect();
+    // This tries to add the params with the window prompts we cannot manipulate in the tests
+    // but it will fail before showing those prompts because we are not connected to the database
+    void addParamWithInputBox();
+    await waitUntilNotification(
+      browser,
+      'You need to be connected to neo4j to set parameters.',
+    );
+
+    await ensureNotificationsAreDismissed(browser);
+    await forceConnect(1);
+  });
+
+  test('Parameters cannot be set when connected to system', async function () {
+    await forceSwitchDatabase('system');
+    void addParamWithInputBox();
+    await waitUntilNotification(
+      browser,
+      'Parameters cannot be added when on the system database. Please connect to a user database.',
+    );
+    await forceSwitchDatabase('neo4j');
   });
 
   test('Should correctly modify cypher parameters', async function () {
@@ -178,38 +207,30 @@ suite('Params panel testing', () => {
     });
   });
 
-  test('Cannot set parameters when disconnected from the database', async function () {
-    await forceDisconnect();
-    // This tries to add the params with the window prompts we cannot manipulate in the tests
-    // but it will fail before showing those prompts because we are not connected to the database
-    void addParamWithInputBox();
-    await waitUntilNotification(
-      browser,
-      'You need to be connected to neo4j to set parameters.',
-    );
-    await forceConnect(1);
-  });
-
-  test('Parameters cannot be set when connected to system', async function () {
-    await forceSwitchDatabase('system');
+  test('Should trigger parameter add pop-up when running a query with an unknown parameter', async () => {
     await clearParams();
-
-    void forceAddParam('a', '"charmander"');
-    void forceAddParam('b', '"caterpie"');
-    void forceAddParam('some param', '"pikachu"');
-    void forceAddParam('some-param', '"bulbasur"');
-
-    // to execute the file we need to be on the user database
-    await forceSwitchDatabase('neo4j');
+    await forceAddParam('a', '1998');
     await executeFile(workbench, 'params.cypher');
 
-    await escapeModal(4);
+    // initial pop-up for param b
+    await browser.pause(1000);
+    await browser.keys(['1', '2', Key.Enter]);
+
+    // initial pop-up for param `some param`
+    await browser.pause(1000);
+    await browser.keys(['f', 'a', 'l', 's', 'e', Key.Enter]);
+
+    // initial pop-up for param `some-param`
+    await browser.pause(1000);
+    await browser.keys(['5', Key.Enter]);
 
     await checkResultsContent(workbench, async () => {
-      const text = await (await $('#query-error')).getText();
-      await expect(text).toContain(
-        'Error executing query RETURN $a, $b, $`some param`, $`some-param`, $a + $b;:\nExpected parameter(s): a, b',
-      );
+      const queryResult = await (await $('#query-result')).getText();
+      await expect(queryResult).toContain('1998');
+      await expect(queryResult).toContain('12');
+      await expect(queryResult).toContain('false');
+      await expect(queryResult).toContain('5');
+      await expect(queryResult).toContain('2010');
     });
   });
 

--- a/packages/vscode-extension/tests/webviewUtils.ts
+++ b/packages/vscode-extension/tests/webviewUtils.ts
@@ -25,7 +25,11 @@ export async function waitUntilNotification(
         await found.notification.dismiss();
         return true;
       } else {
-        return false;
+        throw new Error(
+          `Notification ${notification} not found. Found: \n${notificationsAndMsgs
+            .map((n) => n.msg)
+            .join('\n')}`,
+        );
       }
     },
     { timeout: 20000 },
@@ -211,4 +215,19 @@ export async function executeFile(
 ) {
   await openFixtureFile(browser, fileName, opts);
   await workbench.executeCommand('neo4j.runCypher');
+}
+
+export async function ensureNotificationsAreDismissed(
+  browser: WebdriverIO.Browser,
+): Promise<void> {
+  const wb = await browser.getWorkbench();
+  const notifications = await wb.getNotifications();
+  for (const notification of notifications) {
+    await notification.dismiss();
+  }
+
+  const remainingNotifications = await wb.getNotifications();
+  if (remainingNotifications.length > 0) {
+    return ensureNotificationsAreDismissed(browser);
+  }
 }


### PR DESCRIPTION
Based on #461

- Splits e2e jobs to run in parallel
- Adds cache on commit to avoid rebuilding
- Cancel old jobs on the same pull request
- Fixes parameter can't be set on system flaky test by improving the UX. We not instantly give the error (same as when disconnected), instead of letting the user fill in all the values and then giving an error ✨ 


On flakyness:
- [Ideally each test should be as isolated as possible](https://playwright.dev/docs/best-practices#make-tests-as-isolated-as-possible). This is so they can run / re-run in parallel, etc. This means they need to ensure their own connection etc in a `beforeEach`. I'm not sure if this applies to the vscode tests though as it's not got multiple browser windows like playwright tests do 🤔 
