### PR TITLE
Fixes the VSCode CI job, second attempt

### DIFF
--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -27,11 +27,11 @@ jobs:
         run: |
           cd packages/vscode-extension
           pnpm package
-          pnpm vsce publish
+          pnpm vsce publish --no-dependencies
 
       - name: Publish to OpenVSX
         env:
           VSX_PAT: ${{ secrets.VSX_PAT }}
         run: |
           cd packages/vscode-extension
-          pnpx ovsx publish -p $VSX_PAT
+          pnpm ovsx publish -p $VSX_PAT --no-dependencies


### PR DESCRIPTION
* We fixed the `vsce` command for packaging, but not for publishing.
* The command `ovsx` has the same problem than the `vsce` one (it doesn't support pnpm). In this issue https://github.com/eclipse/openvsx/issues/368 they suggest passing the `--yarn` flag to it, but that doesn't seem very trustworthy, I've used the same `--no-dependencies` flag than for `vsce`.