### PR TITLE
Fixes CALL papercuts in formatter

### DIFF
--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -96,6 +96,7 @@ import {
   SkipContext,
   StatementsOrCommandsContext,
   SubqueryClauseContext,
+  SubqueryScopeContext,
   TrimFunctionContext,
   UnionContext,
   UnwindClauseContext,
@@ -1830,6 +1831,33 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.breakLine();
     this._visit(ctx.RCURLY());
     this._visit(ctx.subqueryInTransactionsParameters());
+  };
+
+  visitSubqueryScope = (ctx: SubqueryScopeContext) => {
+    this.avoidBreakBetween();
+    const subqueryScopeGrp = this.startGroup();
+    this._visit(ctx.LPAREN());
+    const subqueryScopeIndent = this.addIndentation();
+    if (ctx.TIMES()) {
+      this._visit(ctx.TIMES());
+    } else {
+      const n = ctx.variable_list().length;
+      for (let i = 0; i < n; i++) {
+        const functionArgGrp = this.startGroup();
+        this._visit(ctx.variable(i));
+        if (i < n - 1) {
+          this._visit(ctx.COMMA(i));
+        }
+        this.endGroup(functionArgGrp);
+      }
+    }
+    this.avoidSpaceBetween();
+    this.removeIndentation(subqueryScopeIndent);
+    this._visitTerminalRaw(ctx.RPAREN(), {
+      dontConcatenate: true,
+      spacingChoice: 'SPACE_AFTER',
+    });
+    this.endGroup(subqueryScopeGrp);
   };
 
   // Handled separately because UNION wants to look a certain way

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -1821,6 +1821,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.OPTIONAL());
     this._visit(ctx.CALL());
     this._visit(ctx.subqueryScope());
+    this.avoidBreakBetween();
     this._visit(ctx.LCURLY());
     const queryIndent = this.addIndentation();
     this.breakLine();

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1319,6 +1319,30 @@ WITH
 RETURN *`;
     verifyFormatting(query, expected);
   });
+
+  test('CALL with long arguments that need to break', () => {
+    const query = `MATCH (x)-[z:QWERTY]-(y)
+CALL (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongarg, z, y) {
+  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
+  RETURN pqrstu, vwxyza, q
+  UNION
+  RETURN x AS pqrstu, y AS vwxyza, z AS q
+}
+RETURN x`;
+    const expected = `MATCH (x)-[z:QWERTY]-(y)
+CALL (
+  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongarg,
+  z,
+  y
+) {
+  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
+  RETURN pqrstu, vwxyza, q
+    UNION
+  RETURN x AS pqrstu, y AS vwxyza, z AS q
+}
+RETURN x`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1320,6 +1320,16 @@ RETURN *`;
     verifyFormatting(query, expected);
   });
 
+  test('CALL with star', () => {
+    const query = `MATCH (x)-[z:QWERTY]-(y)
+CALL (*) {
+  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
+}
+RETURN x`;
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+
   test('CALL with arguments', () => {
     const query = `MATCH (x)-[z:QWERTY]-(y)
 CALL (x, z, y) {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1257,6 +1257,68 @@ LIMIT 100
 RETURN n`;
     verifyFormatting(query, expected);
   });
+
+  test('CALL should not break between CALL and the left brace', () => {
+    const query = `MATCH
+  u0 =
+    (v3:mn:op:tuv {xy: fghij})-[s1:abc {m1: "x"}]->
+    (w2 {n5: [-8392754106, 517362948, 2073946581]})
+WITH
+  u0,
+  COLLECT {
+    MATCH x1 = (y0)
+    CALL
+    {
+      WITH w2, s1, u0
+      MATCH
+        c2 =
+          (w2)<-[t2:defg]-
+          (:wx:tuv:mn:yz:op:ab:cd:ef:gh)--
+          (z1)-[:hij*..8]->
+          (:mn:ij:ab {m1: "y"})--
+          (w2)-[:klm {pqr: 714026583}]->
+          (a5:ij {xy: fghij})
+      CALL
+      {
+        WITH w2, t2, u0, c2
+        OPTIONAL MATCH (:wx)
+        RETURN w2 AS b6
+      }
+      RETURN s1 AS e5, c2 AS d3
+    }
+    RETURN e5.stu
+  } AS uvwxyz
+RETURN *`;
+    const expected = `MATCH
+  u0 =
+    (v3:mn:op:tuv {xy: fghij})-[s1:abc {m1: "x"}]->
+    (w2 {n5: [-8392754106, 517362948, 2073946581]})
+WITH
+  u0,
+  COLLECT {
+    MATCH x1 = (y0)
+    CALL {
+      WITH w2, s1, u0
+      MATCH
+        c2 =
+          (w2)<-[t2:defg]-
+          (:wx:tuv:mn:yz:op:ab:cd:ef:gh)--
+          (z1)-[:hij*..8]->
+          (:mn:ij:ab {m1: "y"})--
+          (w2)-[:klm {pqr: 714026583}]->
+          (a5:ij {xy: fghij})
+      CALL {
+        WITH w2, t2, u0, c2
+        OPTIONAL MATCH (:wx)
+        RETURN w2 AS b6
+      }
+      RETURN s1 AS e5, c2 AS d3
+    }
+    RETURN e5.stu
+  } AS uvwxyz
+RETURN *`;
+    verifyFormatting(query, expected);
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1320,6 +1320,20 @@ RETURN *`;
     verifyFormatting(query, expected);
   });
 
+  test('CALL with arguments', () => {
+    const query = `MATCH (x)-[z:QWERTY]-(y)
+CALL (x, z, y) {
+  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
+}
+RETURN x`;
+    const expected = `MATCH (x)-[z:QWERTY]-(y)
+CALL (x, z, y) {
+  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
+}
+RETURN x`;
+    verifyFormatting(query, expected);
+  });
+
   test('CALL with long arguments that need to break', () => {
     const query = `MATCH (x)-[z:QWERTY]-(y)
 CALL (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongarg, z, y) {


### PR DESCRIPTION
## Description
For some reason, the formatter allows a break between `CALL` and `{` in `subqueryClause`s, which leads to this kind of ugly output:

```
MATCH
  u0 =
    (v3:mn:op:tuv {xy: fghij})-[s1:abc {m1: "x"}]->
    (w2 {n5: [-8392754106, 517362948, 2073946581]})
WITH
  u0,
  COLLECT {
    MATCH x1 = (y0)
    CALL
    {
      WITH w2, s1, u0
      MATCH
        c2 =
          (w2)<-[t2:defg]-
          (:wx:tuv:mn:yz:op:ab:cd:ef:gh)--
          (z1)-[:hij*..8]->
          (:mn:ij:ab {m1: "y"})--
          (w2)-[:klm {pqr: 714026583}]->
          (a5:ij {xy: fghij})
      CALL
      {
        WITH w2, t2, u0, c2
        OPTIONAL MATCH (:wx)
        RETURN w2 AS b6
      }
      RETURN s1 AS e5, c2 AS d3
    }
    RETURN e5.stu
  } AS uvwxyz
RETURN *
```
So there's simply a `avoidBreakBetween` call missing, which this PR adds. Credit to Joel from the Cypher team for noticing this and providing an example (the one above, I've anonymized it).


Also, while looking into this I noticed we don't handle `CALL` with args that well either; they should behave like regular function calls. Right now they just never split. I've added handling for that as well:

```
    const query = `MATCH (x)-[z:QWERTY]-(y)
CALL (looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongarg, z, y) {
  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
  RETURN pqrstu, vwxyza, q
  UNION
  RETURN x AS pqrstu, y AS vwxyza, z AS q
}
RETURN x`;
    const expected = `MATCH (x)-[z:QWERTY]-(y)
CALL (
  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongarg,
  z,
  y
) {
  MATCH (pqrstu)-[q:QWER|ZXCVB {pr_keyxy: "AbC123xY"}]-(vwxyza)
  RETURN pqrstu, vwxyza, q
    UNION
  RETURN x AS pqrstu, y AS vwxyza, z AS q
}
RETURN x`;
```



## Testing
- Test for the case described above
- Tests for `CALL` with function arguments, one where they need to break and one where they don't, and one with STAR
- Looked through a few sample queries including CALL with args, and they looked reasonable:

```
    const re = /CALL\s*\(\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*\)\s*\{[\s\S]*?\}/g;
    // If the query doesn't match the regex somewhere, skip
    if (!re.test(originalQuery)) {
      showRandomQuery();
      return;
    }
```
