### PR TITLE
Fixes npm publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yaml
+++ b/.github/workflows/publish-npm-packages.yaml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@3de3850952bec538fde60aac71731376e57b9b57 # v1.4.8
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
For some reason when we go through the changeset action we cannot publish npm packages (whereas the canary releases job is working fine):

<img width="1306" src="https://github.com/user-attachments/assets/8dc46652-a1eb-463d-9cb1-342cdfa285c0" />

@OskarDamkjaer found this that might fix it: https://github.com/changesets/action/issues/98#issuecomment-2519457411

where they suggest adding the `NODE_AUTH_TOKEN` to the job, which makes sense because that's the only difference in setup I could find with respect to the canary releases job (although that one doesn't use the changeset action)