### PR TITLE
Fixes build step in fetch-dev-artifacts

### DIFF
--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -89,7 +89,7 @@ jobs:
         run: rm -f grammar.zip && rm -f semantic-analysis-js.zip
 
       - name: Build project
-        uses: ./.github/actions/setup-and-build-project
+        uses: ./.github/actions/setup-and-build
       
       - name: Create New Branch Name
         run: |


### PR DESCRIPTION
Looks like there was a mistake in the action folder name when adding the "build project" step.

This changes it so the step points to the intended action. Tried it in my private copy of the repo and the build step passes now.