### PR TITLE
Removes zero-padding of day

### DIFF
--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check date if run on schedule
         id: check_skip
         run: |
-          DAY=$(date +'%d')
+          DAY=$(date +'%-d')
           if [[ "$DAY" -ge 8 ]] && [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "Skipping fetch"
             echo "skip=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Old way to get date got them with zero padded format, which broke the day-of-month test for single-digit days, so the test would incorrectly run on fridays that are the 8th or 9th. 

Fix is to add a "-" after the % specifying what part of date you want (see [](https://linux.die.net/man/1/date))

Tried the workflow on my private copy of the repo with this fix and got 9 instead of 09 on the 9th.