### PR TITLE
Displays received error/warning messages in playwright

### DIFF
--- a/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
+++ b/packages/react-codemirror/src/e2e_tests/e2eUtils.ts
@@ -82,7 +82,7 @@ export class CypherEditorPage {
     await expect(this.page.locator('.cm-tooltip-hover').last()).toBeVisible({
       timeout: 10000,
     });
-    await expect(this.page.getByText(expectedMsg)).toBeVisible();
+    await this.checkHoverMessage(expectedMsg);
     /* Return the mouse to the beginning of the query and
        This is because if for example we have an overlay with a 
        first interaction that covers the element we want to perform
@@ -93,5 +93,15 @@ export class CypherEditorPage {
     await expect(
       this.page.locator('.cm-tooltip-hover').last(),
     ).not.toBeVisible();
+  }
+
+  private async checkHoverMessage(expectedMsg: string) {
+    const tooltips = await this.page.locator('.cm-tooltip-hover').all();
+
+    const tooltipTexts = await Promise.all(
+      tooltips.map((t) => t.textContent()),
+    );
+
+    expect(tooltipTexts).toContain(expectedMsg);
   }
 }


### PR DESCRIPTION
Updates the helper method for testing linter notifications to display received linter notifications when expecting a specific message. This way, if for example the semantic analysis changes slightly, you can compare received message and expected message to easily find what changed.

Duplicated method from [this PR](https://github.com/neo4j/upx/pull/5950) in upx where we also do playwright testing of this type.