### PR TITLE
adding a run button for cypher files to editor title

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -149,7 +149,7 @@
       "editor/title": [
         {
           "command": "neo4j.runCypher",
-          "when": "resourceExtname == .cypher",
+          "when": "resourceLangId == cypher",
           "group": "navigation"
         }
       ],


### PR DESCRIPTION
This pr is to add a run button to the top right corner of the editor when the open file has a `.cypher` extension.

<img width="894" alt="Screenshot 2025-05-19 at 16 45 58" src="https://github.com/user-attachments/assets/81f34e3d-b1e8-462a-ae57-5f22ea24b60f" />
