### PR TITLE
Fixes cypher 25 check for semver servers

### DIFF
--- a/packages/language-support/src/version.ts
+++ b/packages/language-support/src/version.ts
@@ -1,17 +1,21 @@
 import semver from 'semver';
 
 export function cypher25Supported(serverVersion: string) {
-  const minSupportedVersion = '5.27.0-2025040';
+  const minSupportedVersion = '2025.8.0'; //TODO: set to correct value when cypher 25 is actually released
   const minSupported = semver.coerce(minSupportedVersion, {
     includePrerelease: false,
   });
-  const current = semver.coerce(serverVersion, { includePrerelease: false });
+
+  const cleanedServerVersion = serverVersion.replace(/"(\.0+)(?=\d)"/g, '.');
+  const current = semver.coerce(cleanedServerVersion, {
+    includePrerelease: false,
+  });
 
   if (minSupported && current) {
     const comparison = semver.compare(minSupported, current);
     if (comparison === 0) {
       const minPrelease = semver.prerelease(minSupportedVersion)?.at(0);
-      const currentPrelease = semver.prerelease(serverVersion)?.at(0);
+      const currentPrelease = semver.prerelease(cleanedServerVersion)?.at(0);
 
       return (
         typeof minPrelease === 'number' &&


### PR DESCRIPTION
New servers produce the following versions:
    
![Screenshot 2025-05-21 160521](https://github.com/user-attachments/assets/aec749fd-7a89-47e7-bd94-de55d906fe1f)

Since `semver.coerce(...)` expects a string without zero-padding this breaks the coercion in the check for whether the server supports Cypher 25.

This pr strips the zero padding with a regex - here's an image of what it would capture (and replace with a single period)
![image](https://github.com/user-attachments/assets/e3e3302a-ccdf-4572-8d7e-f3426b337c16)

