### PR TITLE
Changes formatQuery interface (breaking change), adds new maxColumn option

### DIFF
--- a/.changeset/true-olives-stay.md
+++ b/.changeset/true-olives-stay.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': minor
+---
+
+New interface for formatQuery, support maxColumn option

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -2279,7 +2279,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 }
 
-interface FormattingResultWithCursor {
+interface FormattingResult {
   formattedString: string;
   newCursorPos?: number;
 }
@@ -2294,11 +2294,11 @@ export function formatQuery(query: string): string;
 export function formatQuery(
   query: string,
   formattingOptions?: FormattingOptions,
-): FormattingResultWithCursor;
+): FormattingResult;
 export function formatQuery(
   query: string,
   formattingOptions?: FormattingOptions,
-): string | FormattingResultWithCursor {
+): string | FormattingResult {
   const { tree, tokens, unParseable, firstUnParseableToken } =
     getParseTreeAndTokens(query);
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -2281,7 +2281,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
 interface FormattingResult {
   formattedString: string;
-  newCursorPos?: number;
+  newCursorPos?: number; // Only set if cursorPosition is provided
 }
 
 export interface FormattingOptions {
@@ -2290,15 +2290,10 @@ export interface FormattingOptions {
   cursorPosition?: number;
 }
 
-export function formatQuery(query: string): string;
 export function formatQuery(
   query: string,
   formattingOptions?: FormattingOptions,
-): FormattingResult;
-export function formatQuery(
-  query: string,
-  formattingOptions?: FormattingOptions,
-): string | FormattingResult {
+): FormattingResult {
   const { tree, tokens, unParseable, firstUnParseableToken } =
     getParseTreeAndTokens(query);
 
@@ -2311,7 +2306,7 @@ export function formatQuery(
     unParseable,
     firstUnParseableToken,
   );
-  if (!formattingOptions) return visitor.format();
+  if (!formattingOptions) return { formattedString: visitor.format() };
 
   const cursorPosition = formattingOptions?.cursorPosition;
   if (cursorPosition === undefined) {

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -2281,7 +2281,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
 interface FormattingResultWithCursor {
   formattedString: string;
-  newCursorPos: number;
+  newCursorPos?: number;
 }
 
 export interface FormattingOptions {
@@ -2311,10 +2311,14 @@ export function formatQuery(
     unParseable,
     firstUnParseableToken,
   );
+  if (!formattingOptions) return visitor.format();
 
   const cursorPosition = formattingOptions?.cursorPosition;
-
-  if (cursorPosition === undefined) return visitor.format();
+  if (cursorPosition === undefined) {
+    return {
+      formattedString: visitor.format(),
+    };
+  }
 
   if (cursorPosition >= query.length || cursorPosition <= 0) {
     const result = visitor.format();

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -2280,7 +2280,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 }
 
 interface FormattingResult {
-  formattedString: string;
+  formattedQuery: string;
   newCursorPos?: number; // Only set if cursorPosition is provided
 }
 
@@ -2306,19 +2306,19 @@ export function formatQuery(
     unParseable,
     firstUnParseableToken,
   );
-  if (!formattingOptions) return { formattedString: visitor.format() };
+  if (!formattingOptions) return { formattedQuery: visitor.format() };
 
   const cursorPosition = formattingOptions?.cursorPosition;
   if (cursorPosition === undefined) {
     return {
-      formattedString: visitor.format(),
+      formattedQuery: visitor.format(),
     };
   }
 
   if (cursorPosition >= query.length || cursorPosition <= 0) {
     const result = visitor.format();
     return {
-      formattedString: result,
+      formattedQuery: result,
       newCursorPos: cursorPosition === 0 ? 0 : result.length,
     };
   }
@@ -2326,7 +2326,7 @@ export function formatQuery(
   const targetToken = findTargetToken(tokens.tokens, cursorPosition);
   if (!targetToken) {
     return {
-      formattedString: visitor.format(),
+      formattedQuery: visitor.format(),
       newCursorPos: 0,
     };
   }
@@ -2334,7 +2334,7 @@ export function formatQuery(
   visitor.targetToken = targetToken.tokenIndex;
 
   return {
-    formattedString: visitor.format(),
+    formattedQuery: visitor.format(),
     newCursorPos: visitor.cursorPos + relativePosition,
   };
 }

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -13,10 +13,10 @@ along with your input on GitHub:
 https://github.com/neo4j/cypher-language-support.`.trim();
 
 /**
- * The maximum column width for the formatter. Not a hard limit as overflow
+ * The (default) maximum column width for the formatter. Not a hard limit as overflow
  * is unavoidable in some cases, but we always prefer a solution that doesn't overflow.
  */
-export const MAX_COL = 80;
+export const DEFAULT_MAX_COL = 80;
 
 export interface Group {
   id: number;

--- a/packages/language-support/src/formatting/layoutEngine.ts
+++ b/packages/language-support/src/formatting/layoutEngine.ts
@@ -3,7 +3,6 @@ import {
   Group,
   IndentationModifier,
   INTERNAL_FORMAT_ERROR_MESSAGE,
-  MAX_COL,
   shouldAddSpace,
 } from './formattingHelpers';
 
@@ -38,9 +37,14 @@ function shouldBreak(chunk: Chunk, state: State): boolean {
   );
 }
 
-function updateActiveGroups(state: State, chunk: Chunk): void {
+function updateActiveGroups(
+  state: State,
+  chunk: Chunk,
+  maxColumn: number,
+): void {
   for (const group of chunk.groupsStarting) {
-    const breaksAll = state.column + group.size > MAX_COL || group.shouldBreak;
+    const breaksAll =
+      state.column + group.size > maxColumn || group.shouldBreak;
     state.activeGroups.push({ ...group, shouldBreak: breaksAll });
   }
   for (const group of chunk.groupsEnding) {
@@ -150,6 +154,7 @@ function validateFinalState(state: State) {
 
 export function chunksToFormattedString(
   chunkList: Chunk[],
+  maxColumn: number,
 ): FinalResultWithPos {
   const state = createInitialState();
 
@@ -159,7 +164,7 @@ export function chunksToFormattedString(
 
     applyIndentationIfNeeded(state);
     checkAndSetCursorPosition(state, chunk);
-    updateActiveGroups(state, chunk);
+    updateActiveGroups(state, chunk, maxColumn);
     appendChunkText(state, chunk);
     updateIndentationState(state, chunk);
     handleComments(state, chunk);

--- a/packages/language-support/src/tests/formatting/cursorpos.test.ts
+++ b/packages/language-support/src/tests/formatting/cursorpos.test.ts
@@ -10,7 +10,7 @@ describe('tests for correct cursor position', () => {
   test('cursor at end', () => {
     const query = 'RETURN -1, -2, -3';
     const result = formatQuery(query, { cursorPosition: query.length - 1 });
-    expect(result.newCursorPos).toEqual(result.formattedString.length - 1);
+    expect(result.newCursorPos).toEqual(result.formattedQuery.length - 1);
   });
   test('cursor at newline', () => {
     const query = `MATCH (n:Person)

--- a/packages/language-support/src/tests/formatting/cursorpos.test.ts
+++ b/packages/language-support/src/tests/formatting/cursorpos.test.ts
@@ -4,12 +4,12 @@ import { formatQuery } from '../../formatting/formatting';
 describe('tests for correct cursor position', () => {
   test('cursor at beginning', () => {
     const query = 'RETURN -1, -2, -3';
-    const result = formatQuery(query, 0);
+    const result = formatQuery(query, { cursorPosition: 0 });
     expect(result.newCursorPos).toEqual(0);
   });
   test('cursor at end', () => {
     const query = 'RETURN -1, -2, -3';
-    const result = formatQuery(query, query.length - 1);
+    const result = formatQuery(query, { cursorPosition: query.length - 1 });
     expect(result.newCursorPos).toEqual(result.formattedString.length - 1);
   });
   test('cursor at newline', () => {
@@ -17,8 +17,8 @@ describe('tests for correct cursor position', () => {
 WHERE n.name = "Steve" 
 RETURN n 
 @LIMIT 12;`;
-    const cursorPos = query.search('@');
-    const result = formatQuery(query.replace('@', ''), cursorPos);
+    const cursorPosition = query.search('@');
+    const result = formatQuery(query.replace('@', ''), { cursorPosition });
     const formated = `MATCH (n:Person)
 WHERE n.name = "Steve" 
 RETURN n@LIMIT 12;`;
@@ -36,8 +36,8 @@ CALL {
   RETURN length(path) as l, Weight 
 } 
 RETURN count(*)`;
-    const cursorPos = query.search('@');
-    const result = formatQuery(query.replace('@', ''), cursorPos);
+    const cursorPosition = query.search('@');
+    const result = formatQuery(query.replace('@', ''), { cursorPosition });
     const formated = `UNWIND range(1, 100) AS _
 CALL {
   MATCH (source:object)
@@ -61,8 +61,8 @@ WHERE variable.property = "String"
     OR namespaced.function() = false
     OR $para@meter > 2 
 RETURN variable;`;
-    const cursorPos = query.search('@');
-    const result = formatQuery(query.replace('@', ''), cursorPos);
+    const cursorPosition = query.search('@');
+    const result = formatQuery(query.replace('@', ''), { cursorPosition });
     const formated = `MATCH (variable:Label)-[:REL_TYPE]->()
 WHERE
   variable.property = "String" OR

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -124,7 +124,7 @@ RETURN path`;
 
   test('keeps all queries within the default max column width', () => {
     queries.forEach((query) => {
-      const formatted = formatQuery(query).formattedString;
+      const formatted = formatQuery(query).formattedQuery;
       const lines = formatted.split('\n');
       lines.forEach((line) => {
         expect(line.length).toBeLessThanOrEqual(DEFAULT_MAX_COL);

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1271,7 +1271,7 @@ RETURN u`.trimStart();
     verifyFormatting(query, expected, { maxColumn: 40 });
   });
 
-  test('long chained pattern wraps within 50 columns', () => {
+  test('long pattern wraps within 50 columns', () => {
     const query = `MATCH (a:VeryLongLabelName)-[:RELTYPE]->(b:AnotherVeryLongLabelName)
 RETURN a, b, c`;
     const expected = `
@@ -1280,6 +1280,15 @@ MATCH
   (b:AnotherVeryLongLabelName)
 RETURN a, b, c`.trimStart();
     verifyFormatting(query, expected, { maxColumn: 50 });
+  });
+
+  test('long pattern does not wrap with high column limit', () => {
+    const query = `MATCH (a:VeeeeeeeeeeeeeeeeeeeeeeryLongLabelName)-[:RELTYPE]->(b:AnotherVeryLongLabelName)
+RETURN a, b, c`;
+    const expected = `
+MATCH (a:VeeeeeeeeeeeeeeeeeeeeeeryLongLabelName)-[:RELTYPE]->(b:AnotherVeryLongLabelName)
+RETURN a, b, c`.trimStart();
+    verifyFormatting(query, expected, { maxColumn: 100 });
   });
 
   test('function invocation with nested call stays within 45 columns', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1,5 +1,5 @@
 import { formatQuery } from '../../formatting/formatting';
-import { MAX_COL } from '../../formatting/formattingHelpers';
+import { DEFAULT_MAX_COL } from '../../formatting/formattingHelpers';
 import { verifyFormatting } from './testutil';
 
 describe('tests for line breaks', () => {
@@ -127,7 +127,7 @@ RETURN path`;
       const formatted = formatQuery(query);
       const lines = formatted.split('\n');
       lines.forEach((line) => {
-        expect(line.length).toBeLessThanOrEqual(MAX_COL);
+        expect(line.length).toBeLessThanOrEqual(DEFAULT_MAX_COL);
       });
     });
   });
@@ -1256,6 +1256,18 @@ SKIP
 LIMIT 100
 RETURN n`;
     verifyFormatting(query, expected);
+  });
+});
+
+describe('tests for line breaks with non-default max column width', () => {
+  test('should keep this node pattern within 40 columns', () => {
+    const query = `MATCH (u:User)-[r:IS_AA_MEMBER_OF]->(g:Group)
+RETURN u`;
+    const expected = `
+MATCH
+  (u:User)-[r:IS_AA_MEMBER_OF]->(g:Group)
+RETURN u`.trimStart();
+    verifyFormatting(query, expected, { maxColumn: 40 });
   });
 });
 

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1308,6 +1308,18 @@ RETURN
   ) AS joined`.trimStart();
     verifyFormatting(query, expected, { maxColumn: 45 });
   });
+
+  test('list literal with 10 col width', () => {
+    const query = `
+RETURN ['A','B']`;
+    const expected = `
+RETURN
+  [
+    'A',
+    'B'
+  ]`.trimStart();
+    verifyFormatting(query, expected, { maxColumn: 10 });
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -122,9 +122,9 @@ RETURN path`;
     q23,
   ];
 
-  test('keeps all queries within the max column width', () => {
+  test('keeps all queries within the default max column width', () => {
     queries.forEach((query) => {
-      const formatted = formatQuery(query);
+      const formatted = formatQuery(query).formattedString;
       const lines = formatted.split('\n');
       lines.forEach((line) => {
         expect(line.length).toBeLessThanOrEqual(DEFAULT_MAX_COL);

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1270,6 +1270,35 @@ MATCH
 RETURN u`.trimStart();
     verifyFormatting(query, expected, { maxColumn: 40 });
   });
+
+  test('long chained pattern wraps within 50 columns', () => {
+    const query = `MATCH (a:VeryLongLabelName)-[:RELTYPE]->(b:AnotherVeryLongLabelName)
+RETURN a, b, c`;
+    const expected = `
+MATCH
+  (a:VeryLongLabelName)-[:RELTYPE]->
+  (b:AnotherVeryLongLabelName)
+RETURN a, b, c`.trimStart();
+    verifyFormatting(query, expected, { maxColumn: 50 });
+  });
+
+  test('function invocation with nested call stays within 45 columns', () => {
+    const query = `RETURN apoc.text.join(['One','Two','Three', 'Four', 'Five', 'Six'],'; ') AS joined`;
+    const expected = `
+RETURN
+  apoc.text.join(
+    [
+      'One',
+      'Two',
+      'Three',
+      'Four',
+      'Five',
+      'Six'
+    ],
+    '; '
+  ) AS joined`.trimStart();
+    verifyFormatting(query, expected, { maxColumn: 45 });
+  });
 });
 
 describe('tests for respcecting user line breaks', () => {

--- a/packages/language-support/src/tests/formatting/linebreaks.test.ts
+++ b/packages/language-support/src/tests/formatting/linebreaks.test.ts
@@ -1265,7 +1265,8 @@ describe('tests for line breaks with non-default max column width', () => {
 RETURN u`;
     const expected = `
 MATCH
-  (u:User)-[r:IS_AA_MEMBER_OF]->(g:Group)
+  (u:User)-[r:IS_AA_MEMBER_OF]->
+  (g:Group)
 RETURN u`.trimStart();
     verifyFormatting(query, expected, { maxColumn: 40 });
   });

--- a/packages/language-support/src/tests/formatting/testutil.ts
+++ b/packages/language-support/src/tests/formatting/testutil.ts
@@ -1,8 +1,14 @@
-import { formatQuery } from '../../formatting/formatting';
+import { formatQuery, FormattingOptions } from '../../formatting/formatting';
 import { standardizeQuery } from '../../formatting/standardizer';
 
-export function verifyFormatting(query: string, expected: string): void {
-  const formatted = formatQuery(query);
+export function verifyFormatting(
+  query: string,
+  expected: string,
+  formattingOptions?: FormattingOptions,
+): void {
+  const formatted = formattingOptions
+    ? formatQuery(query, formattingOptions).formattedString
+    : formatQuery(query);
   expect(formatted).toEqual(expected);
   const queryStandardized = standardizeQuery(query);
   const formattedStandardized = standardizeQuery(formatted);

--- a/packages/language-support/src/tests/formatting/testutil.ts
+++ b/packages/language-support/src/tests/formatting/testutil.ts
@@ -6,9 +6,7 @@ export function verifyFormatting(
   expected: string,
   formattingOptions?: FormattingOptions,
 ): void {
-  const formatted = formattingOptions
-    ? formatQuery(query, formattingOptions).formattedString
-    : formatQuery(query);
+  const formatted = formatQuery(query, formattingOptions).formattedString;
   expect(formatted).toEqual(expected);
   const queryStandardized = standardizeQuery(query);
   const formattedStandardized = standardizeQuery(formatted);
@@ -18,8 +16,6 @@ export function verifyFormatting(
     );
   }
   // Idempotency check
-  const formattedTwice = formattingOptions
-    ? formatQuery(query, formattingOptions).formattedString
-    : formatQuery(query);
+  const formattedTwice = formatQuery(query, formattingOptions).formattedString;
   expect(formattedTwice).toEqual(formatted);
 }

--- a/packages/language-support/src/tests/formatting/testutil.ts
+++ b/packages/language-support/src/tests/formatting/testutil.ts
@@ -6,7 +6,7 @@ export function verifyFormatting(
   expected: string,
   formattingOptions?: FormattingOptions,
 ): void {
-  const formatted = formatQuery(query, formattingOptions).formattedString;
+  const formatted = formatQuery(query, formattingOptions).formattedQuery;
   expect(formatted).toEqual(expected);
   const queryStandardized = standardizeQuery(query);
   const formattedStandardized = standardizeQuery(formatted);
@@ -16,6 +16,6 @@ export function verifyFormatting(
     );
   }
   // Idempotency check
-  const formattedTwice = formatQuery(query, formattingOptions).formattedString;
+  const formattedTwice = formatQuery(query, formattingOptions).formattedQuery;
   expect(formattedTwice).toEqual(formatted);
 }

--- a/packages/language-support/src/tests/formatting/testutil.ts
+++ b/packages/language-support/src/tests/formatting/testutil.ts
@@ -18,6 +18,8 @@ export function verifyFormatting(
     );
   }
   // Idempotency check
-  const formattedTwice = formatQuery(formatted);
+  const formattedTwice = formattingOptions
+    ? formatQuery(query, formattingOptions).formattedString
+    : formatQuery(query);
   expect(formattedTwice).toEqual(formatted);
 }


### PR DESCRIPTION
### Up for debate
There are a few changes I would be happy to discuss a bit more before introducing this PR, namely:
- What should happen if the formatter gets passed a very low (or even negative) number as `maxColumn`?
  - I considered throwing in these cases, but figured that might be annoying if e.g. an editor setting it dynamically based on its width gets initialized with weird values, crashing the page. So in the PR right now it just always breaks lines
- What is the correct interface for `formatQuery`?? I've introduced a new interface which I think is reasonable, but it requires careful consideration since obviously everyone who uses the formatter has to interact with it.
- What kind of patch should this be? I made it a minor since it changes an interface which felt most appropriate.
### Background
Recently, I added a formatting button to dashboards in UPX:

https://github.com/neo4j/upx/pull/5800

But, one problem with the formatter there is that their editor is 68 columns wide, while we always assume 80 in the formatter. Generally, we avoid any configuration in the formatter, but I think an exception should be made in this case so that it's possible to configure the maximum column width for the formatter. In fact, Black and Prettier both support such a setting, despite otherwise being very anti-configuration, which to me indicates that it's fine in this case in order to be pragmatic. From what I can tell, there are multiple Neo4j tools with an editor where the column width isn't necessarily 80, so I think there's a clear need for it.

### Description
- Adds a maxColumn option to the formatter which it will adhere to
- Changes the interface for `formatQuery` (!!!) to this:
```
export function formatQuery(
  query: string,
  formattingOptions?: FormattingOptions,
): FormattingResult {
```
Rather than the previous:
```
export function formatQuery(query: string): string;
export function formatQuery(
  query: string,
  cursorPosition: number,
): FormattingResultWithCursor;
export function formatQuery(
  query: string,
  cursorPosition?: number,
): string | FormattingResultWithCursor {
```
This is obviously a breaking change, and anyone consuming the formatter will need to adapt to it. I played around with some diffferent interfaces, and this is what I think is most reasonable. It allows us to add more configurability in the future (hopefully not too much) and also add things to the result if necessary. I think that's preferable over e.g. adding a new argument, as that might just mean postponing the problem for later, when we need to add further things. 



### Testing
- Adds ~5 new tests that use non-default column widths



