### PR TITLE
Improves inline comments

### DIFF
--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -165,7 +165,11 @@ export function fillInRegularChunkGroupSizes(
       group.size++;
       group.dbgText += ' ';
     }
-    if (chunk.comment && !groupsEnding.has(group.id)) {
+    if (
+      chunk.comment &&
+      !groupsEnding.has(group.id) &&
+      !chunk.comment.startsWith('/*')
+    ) {
       group.shouldBreak = true;
     }
   }

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -158,15 +158,19 @@ export function fillInRegularChunkGroupSizes(
     }
     group.size += chunk.text.length;
     if (chunk.comment && chunk.comment.startsWith('/*')) {
-      group.size += chunk.comment.length;
-      group.dbgText += chunk.comment;
+      group.size += chunk.comment.length + 2;
+      group.dbgText += ' ' + chunk.comment + ' ';
     }
 
     // PERF: Right now we include dbgText always, even though it's only used for debugging.
     // It does not seem to have any significant performance downsides, but only doing so
     // when e.g. a flag is set might be a more prudent choice.
     group.dbgText += chunk.text;
-    if (!chunk.noSpace && shouldAddSpace(chunk, chunk)) {
+    if (
+      !chunk.noSpace &&
+      shouldAddSpace(chunk, chunk) &&
+      !(chunk.comment && chunk.comment.startsWith('/*'))
+    ) {
       group.size++;
       group.dbgText += ' ';
     }

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -157,6 +157,11 @@ export function fillInRegularChunkGroupSizes(
       throw new Error(INTERNAL_FORMAT_ERROR_MESSAGE);
     }
     group.size += chunk.text.length;
+    if (chunk.comment && chunk.comment.startsWith('/*')) {
+      group.size += chunk.comment.length;
+      group.dbgText += chunk.comment;
+    }
+
     // PERF: Right now we include dbgText always, even though it's only used for debugging.
     // It does not seem to have any significant performance downsides, but only doing so
     // when e.g. a flag is set might be a more prudent choice.
@@ -174,7 +179,6 @@ export function fillInRegularChunkGroupSizes(
     }
   }
 }
-
 export function verifyGroupSizes(chunkList: Chunk[]) {
   for (const chunk of chunkList) {
     for (const group of chunk.groupsStarting) {

--- a/packages/language-support/src/formatting/layoutEngine.ts
+++ b/packages/language-support/src/formatting/layoutEngine.ts
@@ -109,7 +109,19 @@ function appendChunkText(state: State, chunk: Chunk) {
 
 function handleComments(state: State, chunk: Chunk) {
   if (chunk.comment) {
-    state.pendingComments.push(chunk.comment);
+    if (chunk.comment.startsWith('/*')) {
+      // Inline comment - append directly
+      state.formatted += ' ';
+      state.formatted += chunk.comment;
+      state.column += chunk.comment.length;
+      if (chunk.type === 'REGULAR' && chunk.noSpace) {
+        state.formatted += ' ';
+        state.column++;
+      }
+    } else {
+      // For regular comments, we store them to append later
+      state.pendingComments.push(chunk.comment);
+    }
   }
 }
 

--- a/packages/language-support/src/tests/formatting/comments.test.ts
+++ b/packages/language-support/src/tests/formatting/comments.test.ts
@@ -569,4 +569,13 @@ RETURN m, n`;
 RETURN m, n`;
     verifyFormatting(query, expected);
   });
+  test('long inline comment within a chunk', () => {
+    const query = `MATCH (m/*commentcommentcommentcommentcommentcommentcommentcomment*/)-[:RELATION]->(n)
+RETURN m, n`;
+    const expected = `MATCH
+  (m)- /*commentcommentcommentcommentcommentcommentcommentcomment*/ [:RELATION]->
+  (n)
+RETURN m, n`;
+    verifyFormatting(query, expected);
+  });
 });

--- a/packages/language-support/src/tests/formatting/comments.test.ts
+++ b/packages/language-support/src/tests/formatting/comments.test.ts
@@ -48,19 +48,11 @@ RETURN n`;
   });
 
   test('weird inline comments', () => {
-    const inlinemultiline = `MERGE (n) /* Ensuring the node exists */ 
+    const inlinemultiline = `MERGE /* Ensuring the node exists */ (n)
   ON CREATE SET n.prop = 0 /* Set default property */
-MERGE (a:A) /* Create or match 'a:A' */
-  -[:T]-> (b:B) /* Link 'a' to 'b' */
-RETURN a.prop /* Return the property of 'a' */
-`;
-    const expected = `MERGE (n) /* Ensuring the node exists */
-  ON CREATE SET n.prop = 0 /* Set default property */
-MERGE
-  (a:A)- /* Create or match 'a:A' */
-    [:T]->
-  (b:B) /* Link 'a' to 'b' */
+MERGE /* Create or match 'a:A' */ (a:A)-[:T]->(b:B) // test
 RETURN a.prop /* Return the property of 'a' */`;
+    const expected = inlinemultiline;
     verifyFormatting(inlinemultiline, expected);
   });
 
@@ -302,12 +294,8 @@ RETURN n`;
     const query = `
 MATCH (a:Node) // first match
 WITH a, /* intermediate comment */ a.property AS prop
-RETURN prop; // final return`;
-    const expected = `MATCH (a:Node) // first match
-WITH
-  a, /* intermediate comment */
-  a.property AS prop
-RETURN prop; // final return`;
+RETURN prop; // final return`.trimStart();
+    const expected = query;
     verifyFormatting(query, expected);
   });
 
@@ -565,6 +553,20 @@ MATCH // One comment.
   (m)-[:RELATION]->(n)
 RETURN m, n`.trim();
     const expected = query;
+    verifyFormatting(query, expected);
+  });
+  test('inline comment', () => {
+    const query = `
+MATCH /* One comment. */ (m)-[:RELATION]->(n)
+RETURN m, n`.trim();
+    const expected = query;
+    verifyFormatting(query, expected);
+  });
+  test('inline comment within a chunk', () => {
+    const query = `MATCH (m/*comment*/)-[:RELATION]->(n)
+RETURN m, n`;
+    const expected = `MATCH (m)- /*comment*/ [:RELATION]->(n)
+RETURN m, n`;
     verifyFormatting(query, expected);
   });
 });

--- a/packages/language-support/src/tests/formatting/comments.test.ts
+++ b/packages/language-support/src/tests/formatting/comments.test.ts
@@ -545,7 +545,6 @@ UNWIND // Expands lists into multiple rows
     const expected = query.trim();
     verifyFormatting(query, expected);
   });
-
   test('two comments after a clause should not break alignment', () => {
     const query = `
 MATCH // One comment.
@@ -570,10 +569,19 @@ RETURN m, n`;
     verifyFormatting(query, expected);
   });
   test('long inline comment within a chunk', () => {
-    const query = `MATCH (m/*commentcommentcommentcommentcommentcommentcommentcomment*/)-[:RELATION]->(n)
+    const query = `MATCH (m/*commentcommentcommentcommentcommentcommentcommentcom*/)-[:RELATION]->(n)
 RETURN m, n`;
     const expected = `MATCH
-  (m)- /*commentcommentcommentcommentcommentcommentcommentcomment*/ [:RELATION]->
+  (m)- /*commentcommentcommentcommentcommentcommentcommentcom*/ [:RELATION]->(n)
+RETURN m, n`;
+    verifyFormatting(query, expected);
+  });
+  test('long inline comment within a chunk should break everything', () => {
+    // See the extra m at the end of the comment compared to above test, that m makes it over 80 characters
+    const query = `MATCH (m/*commentcommentcommentcommentcommentcommentcommentcomm*/)-[:RELATION]->(n)
+RETURN m, n`;
+    const expected = `MATCH
+  (m)- /*commentcommentcommentcommentcommentcommentcommentcomm*/ [:RELATION]->
   (n)
 RETURN m, n`;
     verifyFormatting(query, expected);


### PR DESCRIPTION
### Description
This PR fixes the tech debt on inline comments from PR #460 by fixes that inline comment, `/* comment*/`should not be treated as regular comments (`// Comment`).

## How it works
In comparison to a regular comment which should be appended before a new line, an inline comment can be inserted basically anywhere. It can not split a chunk however, meaning an inline comment will be placed first after a chunk. The inline comment also counts towards the group size, I took this from Prettier which seems to be doing similar thing. 

## Tests
 - I have modified existing tests which used inline comments
 - Added 4 tests 