### PR TITLE
Download lint worker

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -41,7 +41,9 @@
     "neo4j-driver": "catalog:",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",
-    "workerpool": "^9.0.4"
+    "workerpool": "^9.0.4",
+    "languageSupport-next.13": "npm:@neo4j-cypher/language-support@2.0.0-next.13",
+    "languageSupport-next.3": "npm:@neo4j-cypher/language-support@2.0.0-next.3"
   },
   "scripts": {
     "build": "tsc -b && pnpm bundle && pnpm make-executable && pnpm copy-lint-worker",

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -11,18 +11,21 @@ let pool = workerpool.pool(join(__dirname, 'lintWorker.cjs'), {
   minWorkers: 2,
   workerTerminateTimeout: 2000,
 });
-
-export let workerPath = join(__dirname, 'lintWorker.cjs');
+const defaultWorkerPath = join(__dirname, 'lintWorker.cjs');
+export let workerPath = defaultWorkerPath;
 let lastSemanticJob: LinterTask | undefined;
 
-export async function setLintWorker(lintWorkerPath: string) {
-  await cleanupWorkers();
-  workerPath = lintWorkerPath;
-  (pool = workerpool.pool(workerPath)),
-    {
+/**Sets the lintworker to the one specified by the given path, reverting to default if the path is undefined */
+export async function setLintWorker(lintWorkerPath: string | undefined) {
+  lintWorkerPath = lintWorkerPath ? lintWorkerPath : defaultWorkerPath;
+  if (lintWorkerPath !== workerPath) {
+    await cleanupWorkers();
+    workerPath = lintWorkerPath;
+    pool = workerpool.pool(workerPath, {
       minWorkers: 2,
       workerTerminateTimeout: 2000,
-    };
+    });
+  }
 }
 
 async function rawLintDocument(

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -181,7 +181,10 @@ async function rawLintDocument(
     }
 
     const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
-    const fixedDbSchema = await convertDbSchema(dbSchema, neo4j);
+
+    const fixedDbSchema = _internalFeatureFlags.versionedLinters
+      ? await convertDbSchema(dbSchema, neo4j)
+      : dbSchema;
     lastSemanticJob = proxyWorker.lintCypherQuery(
       query,
       fixedDbSchema,

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -7,12 +7,23 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import workerpool from 'workerpool';
 import type { LinterTask, LintWorker } from '@neo4j-cypher/lint-worker';
 
-const pool = workerpool.pool(join(__dirname, 'lintWorker.cjs'), {
+let pool = workerpool.pool(join(__dirname, 'lintWorker.cjs'), {
   minWorkers: 2,
   workerTerminateTimeout: 2000,
 });
 
+export let workerPath = join(__dirname, 'lintWorker.cjs');
 let lastSemanticJob: LinterTask | undefined;
+
+export async function setLintWorker(lintWorkerPath: string) {
+  await cleanupWorkers();
+  workerPath = lintWorkerPath;
+  (pool = workerpool.pool(workerPath)),
+    {
+      minWorkers: 2,
+      workerTerminateTimeout: 2000,
+    };
+}
 
 async function rawLintDocument(
   document: TextDocument,
@@ -56,6 +67,6 @@ export const lintDocument: typeof rawLintDocument = debounce(
   },
 );
 
-export const cleanupWorkers = () => {
-  void pool.terminate();
+export const cleanupWorkers = async () => {
+  await pool.terminate();
 };

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -1,146 +1,15 @@
-import {
-  _internalFeatureFlags,
-  compareMajorMinorVersions,
-  DbSchema,
-  Neo4jFunction,
-  Neo4jProcedure,
-  toSignatureInformation,
-} from '@neo4j-cypher/language-support';
-import { getVersion, Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
+import { _internalFeatureFlags } from '@neo4j-cypher/language-support';
+import { Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
 import debounce from 'lodash.debounce';
 import { join } from 'path';
-import { Diagnostic, SignatureInformation } from 'vscode-languageserver';
+import { Diagnostic } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import workerpool from 'workerpool';
-import { LinterTask, LintWorker } from '@neo4j-cypher/lint-worker';
-import { DbSchema as NoCyphVerSchema } from 'languageSupport-next.13';
-import { DbSchema as FuncOnlySigSchema } from 'languageSupport-next.3';
-
-export function serverVersionToLinter(serverVersion: string) {
-  //This can be made into an array (the key is not needed) but having it this way helps see what lang-supp release we would use
-  const availableLinters: Record<string, string> = {
-    //We should probably have version comparison where patches are lumped in with the original release
-    '2.0.0-next.20': '2025.4.0', // 29/4 - 2025.04.0=30/4
-    //"2.0.0-next.19": "", // 22/4 - maybe SKIP
-    //"2.0.0-next.18": "", // 7/4  - skip because next release is 2025.04.0
-    '2.0.0-next.17': '2025.3.0', // 25/3 - 2025.03.0=27/3
-    '2.0.0-next.16': '2025.2.0', // 17/2 - 2025.02.0=27/2
-    //"2.0.0-next.15": "", // 10/2 - maybe SKIP
-    '2.0.0-next.14': '2025.1.0', // 4/2  - 2025.01.0=6/2
-    //"2.0.0-next.13": "", // 23/12 2024 - skip, next is 01.0
-    '2.0.0-next.12': '5.26.0', // 13/12 - 5.26(.x)=9/12 (very close to initial 5.26, if after)
-    //"2.0.0-next.11": "", // 13/11 - SKIP
-    //"2.0.0-next.10": "", // 13/11 - SKIP
-    '2.0.0-next.9': '5.25.0', // 28/10 - 5.25 = 31/10
-    '2.0.0-next.8': '5.24.0', // 14/9 - 5.24 = 27/9
-    '2.0.0-next.7': '5.23.0', // 29/7 - 5.23 = 22/8
-    '2.0.0-next.6': '5.20.0', // 3/5 - 5.20 = 23/5
-    '2.0.0-next.5': '5.19.0', // 2/4 - 5.19 = 12/4
-    '2.0.0-next.4': '5.18.0', // 6/3 - 5.18 = 13/3
-    '2.0.0-next.3': '5.17.0', // 7/2 - 5.17 = 23/2
-    '2.0.0-next.2': '5.14.0', // 24/11 2023 - 5.14 = 24/11
-    //"2.0.0-next.1": "",  // 22/11 - SKIP
-    '2.0.0-next.0': '5.13.0', // 25/10 - 5.13 = 23/10
-  };
-  let candidate: string = undefined;
-  for (const x in availableLinters) {
-    if (compareMajorMinorVersions(serverVersion, availableLinters[x]) <= 0) {
-      candidate = availableLinters[x];
-    } else {
-      break;
-    }
-  }
-  return candidate;
-}
-
-export async function getServerVersion(
-  neo4j: Neo4jSchemaPoller,
-): Promise<string> {
-  if (neo4j.serverVersion) {
-    return neo4j.serverVersion;
-  } else {
-    const { query: versionQuery, queryConfig: versionQueryConfig } =
-      getVersion();
-    const driver = neo4j.driver;
-    if (driver) {
-      const { serverVersion } = await driver.executeQuery(
-        versionQuery,
-        {},
-        versionQueryConfig,
-      );
-      neo4j.serverVersion = serverVersion;
-      return serverVersion;
-    }
-  }
-}
-
-async function convertDbSchema(
-  originalSchema: DbSchema,
-  neo4j: Neo4jSchemaPoller,
-): Promise<DbSchema | NoCyphVerSchema | FuncOnlySigSchema> {
-  let oldFunctions: Record<string, Neo4jFunction> = {};
-  let oldProcedures: Record<string, Neo4jProcedure> = {};
-  if (!originalSchema) {
-    return originalSchema;
-  }
-  if (
-    originalSchema.functions['CYPHER 5'] &&
-    originalSchema.procedures['CYPHER 5']
-  ) {
-    oldFunctions = originalSchema.functions['CYPHER 5'];
-    oldProcedures = originalSchema.procedures['CYPHER 5'];
-  }
-
-  const serverVersion = await getServerVersion(neo4j);
-  const linterVersion = serverVersionToLinter(serverVersion);
-
-  //Todo: remove always true on tested condition first
-  if (compareMajorMinorVersions(linterVersion, '5.18.0') < 0) {
-    let oldFunctions: Record<string, Neo4jFunction> = {};
-    let oldProcedures: Record<string, Neo4jProcedure> = {};
-    if (!originalSchema) {
-      return originalSchema;
-    }
-    if (
-      originalSchema.functions['CYPHER 5'] &&
-      originalSchema.procedures['CYPHER 5']
-    ) {
-      oldFunctions = originalSchema.functions['CYPHER 5'];
-      oldProcedures = originalSchema.procedures['CYPHER 5'];
-    }
-    const functionSignatures: Record<string, SignatureInformation> =
-      Object.fromEntries(
-        Object.entries(oldFunctions).map(([key, func]) => [
-          key,
-          toSignatureInformation(func),
-        ]),
-      );
-
-    const procedureSignatures: Record<string, SignatureInformation> =
-      Object.fromEntries(
-        Object.entries(oldProcedures).map(([key, proc]) => [
-          key,
-          toSignatureInformation(proc),
-        ]),
-      );
-
-    const dbSchemaOld = {
-      ...originalSchema,
-      functionSignatures,
-      procedureSignatures,
-    };
-    return dbSchemaOld;
-  } else if (compareMajorMinorVersions(linterVersion, '2025.1.0') < 0) {
-    const dbSchemaOld: NoCyphVerSchema = {
-      ...originalSchema,
-      functions: oldFunctions,
-      procedures: oldProcedures,
-    };
-    return dbSchemaOld;
-  } else {
-    return originalSchema;
-  }
-}
+import {
+  convertDbSchema,
+  LinterTask,
+  LintWorker,
+} from '@neo4j-cypher/lint-worker';
 
 let pool = workerpool.pool(join(__dirname, 'lintWorker.cjs'), {
   minWorkers: 2,

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -1,11 +1,146 @@
-import { _internalFeatureFlags } from '@neo4j-cypher/language-support';
-import { Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
+import {
+  _internalFeatureFlags,
+  compareMajorMinorVersions,
+  DbSchema,
+  Neo4jFunction,
+  Neo4jProcedure,
+  toSignatureInformation,
+} from '@neo4j-cypher/language-support';
+import { getVersion, Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
 import debounce from 'lodash.debounce';
 import { join } from 'path';
-import { Diagnostic } from 'vscode-languageserver';
+import { Diagnostic, SignatureInformation } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import workerpool from 'workerpool';
-import type { LinterTask, LintWorker } from '@neo4j-cypher/lint-worker';
+import { LinterTask, LintWorker } from '@neo4j-cypher/lint-worker';
+import { DbSchema as NoCyphVerSchema } from 'languageSupport-next.13';
+import { DbSchema as FuncOnlySigSchema } from 'languageSupport-next.3';
+
+export function serverVersionToLinter(serverVersion: string) {
+  //This can be made into an array (the key is not needed) but having it this way helps see what lang-supp release we would use
+  const availableLinters: Record<string, string> = {
+    //We should probably have version comparison where patches are lumped in with the original release
+    '2.0.0-next.20': '2025.4.0', // 29/4 - 2025.04.0=30/4
+    //"2.0.0-next.19": "", // 22/4 - maybe SKIP
+    //"2.0.0-next.18": "", // 7/4  - skip because next release is 2025.04.0
+    '2.0.0-next.17': '2025.3.0', // 25/3 - 2025.03.0=27/3
+    '2.0.0-next.16': '2025.2.0', // 17/2 - 2025.02.0=27/2
+    //"2.0.0-next.15": "", // 10/2 - maybe SKIP
+    '2.0.0-next.14': '2025.1.0', // 4/2  - 2025.01.0=6/2
+    //"2.0.0-next.13": "", // 23/12 2024 - skip, next is 01.0
+    '2.0.0-next.12': '5.26.0', // 13/12 - 5.26(.x)=9/12 (very close to initial 5.26, if after)
+    //"2.0.0-next.11": "", // 13/11 - SKIP
+    //"2.0.0-next.10": "", // 13/11 - SKIP
+    '2.0.0-next.9': '5.25.0', // 28/10 - 5.25 = 31/10
+    '2.0.0-next.8': '5.24.0', // 14/9 - 5.24 = 27/9
+    '2.0.0-next.7': '5.23.0', // 29/7 - 5.23 = 22/8
+    '2.0.0-next.6': '5.20.0', // 3/5 - 5.20 = 23/5
+    '2.0.0-next.5': '5.19.0', // 2/4 - 5.19 = 12/4
+    '2.0.0-next.4': '5.18.0', // 6/3 - 5.18 = 13/3
+    '2.0.0-next.3': '5.17.0', // 7/2 - 5.17 = 23/2
+    '2.0.0-next.2': '5.14.0', // 24/11 2023 - 5.14 = 24/11
+    //"2.0.0-next.1": "",  // 22/11 - SKIP
+    '2.0.0-next.0': '5.13.0', // 25/10 - 5.13 = 23/10
+  };
+  let candidate: string = undefined;
+  for (const x in availableLinters) {
+    if (compareMajorMinorVersions(serverVersion, availableLinters[x]) <= 0) {
+      candidate = availableLinters[x];
+    } else {
+      break;
+    }
+  }
+  return candidate;
+}
+
+export async function getServerVersion(
+  neo4j: Neo4jSchemaPoller,
+): Promise<string> {
+  if (neo4j.serverVersion) {
+    return neo4j.serverVersion;
+  } else {
+    const { query: versionQuery, queryConfig: versionQueryConfig } =
+      getVersion();
+    const driver = neo4j.driver;
+    if (driver) {
+      const { serverVersion } = await driver.executeQuery(
+        versionQuery,
+        {},
+        versionQueryConfig,
+      );
+      neo4j.serverVersion = serverVersion;
+      return serverVersion;
+    }
+  }
+}
+
+async function convertDbSchema(
+  originalSchema: DbSchema,
+  neo4j: Neo4jSchemaPoller,
+): Promise<DbSchema | NoCyphVerSchema | FuncOnlySigSchema> {
+  let oldFunctions: Record<string, Neo4jFunction> = {};
+  let oldProcedures: Record<string, Neo4jProcedure> = {};
+  if (!originalSchema) {
+    return originalSchema;
+  }
+  if (
+    originalSchema.functions['CYPHER 5'] &&
+    originalSchema.procedures['CYPHER 5']
+  ) {
+    oldFunctions = originalSchema.functions['CYPHER 5'];
+    oldProcedures = originalSchema.procedures['CYPHER 5'];
+  }
+
+  const serverVersion = await getServerVersion(neo4j);
+  const linterVersion = serverVersionToLinter(serverVersion);
+
+  //Todo: remove always true on tested condition first
+  if (compareMajorMinorVersions(linterVersion, '5.18.0') < 0) {
+    let oldFunctions: Record<string, Neo4jFunction> = {};
+    let oldProcedures: Record<string, Neo4jProcedure> = {};
+    if (!originalSchema) {
+      return originalSchema;
+    }
+    if (
+      originalSchema.functions['CYPHER 5'] &&
+      originalSchema.procedures['CYPHER 5']
+    ) {
+      oldFunctions = originalSchema.functions['CYPHER 5'];
+      oldProcedures = originalSchema.procedures['CYPHER 5'];
+    }
+    const functionSignatures: Record<string, SignatureInformation> =
+      Object.fromEntries(
+        Object.entries(oldFunctions).map(([key, func]) => [
+          key,
+          toSignatureInformation(func),
+        ]),
+      );
+
+    const procedureSignatures: Record<string, SignatureInformation> =
+      Object.fromEntries(
+        Object.entries(oldProcedures).map(([key, proc]) => [
+          key,
+          toSignatureInformation(proc),
+        ]),
+      );
+
+    const dbSchemaOld = {
+      ...originalSchema,
+      functionSignatures,
+      procedureSignatures,
+    };
+    return dbSchemaOld;
+  } else if (compareMajorMinorVersions(linterVersion, '2025.1.0') < 0) {
+    const dbSchemaOld: NoCyphVerSchema = {
+      ...originalSchema,
+      functions: oldFunctions,
+      procedures: oldProcedures,
+    };
+    return dbSchemaOld;
+  } else {
+    return originalSchema;
+  }
+}
 
 let pool = workerpool.pool(join(__dirname, 'lintWorker.cjs'), {
   minWorkers: 2,
@@ -46,9 +181,10 @@ async function rawLintDocument(
     }
 
     const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
+    const fixedDbSchema = await convertDbSchema(dbSchema, neo4j);
     lastSemanticJob = proxyWorker.lintCypherQuery(
       query,
-      dbSchema,
+      fixedDbSchema,
       _internalFeatureFlags,
     );
     const result = await lastSemanticJob;

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -19,7 +19,7 @@ import {
 import { Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
 import { doAutoCompletion } from './autocompletion';
 import { formatDocument } from './formatting';
-import { cleanupWorkers, lintDocument } from './linting';
+import { cleanupWorkers, lintDocument, setLintWorker } from './linting';
 import { doSignatureHelp } from './signatureHelp';
 import { applySyntaxColouringForDocument } from './syntaxColouring';
 import {
@@ -128,6 +128,14 @@ connection.onSignatureHelp(doSignatureHelp(documents, neo4jSchemaPoller));
 connection.onCompletion(doAutoCompletion(documents, neo4jSchemaPoller));
 
 connection.onNotification(
+  'updateLintWorker',
+  (connectionSettings: Neo4jConnectionSettings) => {
+    const lintWorkerPath = connectionSettings.lintWorkerPath;
+    void (async () => await setLintWorker(lintWorkerPath))();
+  },
+);
+
+connection.onNotification(
   'connectionUpdated',
   (connectionSettings: Neo4jConnectionSettings) => {
     changeConnection(connectionSettings);
@@ -154,7 +162,7 @@ documents.listen(connection);
 connection.listen();
 
 connection.onExit(() => {
-  cleanupWorkers();
+  void cleanupWorkers();
 });
 
 const changeConnection = (connectionSettings: Neo4jConnectionSettings) => {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -131,7 +131,10 @@ connection.onNotification(
   'updateLintWorker',
   (connectionSettings: Neo4jConnectionSettings) => {
     const lintWorkerPath = connectionSettings.lintWorkerPath;
-    void (async () => await setLintWorker(lintWorkerPath))();
+    void (async () => {
+      await setLintWorker(lintWorkerPath);
+      relintAllDocuments();
+    })();
   },
 );
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -11,7 +11,6 @@ import {
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-
 import {
   _internalFeatureFlags,
   syntaxColouringLegend,
@@ -131,6 +130,7 @@ connection.onNotification(
   'updateLintWorker',
   (connectionSettings: Neo4jConnectionSettings) => {
     const lintWorkerPath = connectionSettings.lintWorkerPath;
+    _internalFeatureFlags.versionedLinters = true;
     void (async () => {
       await setLintWorker(lintWorkerPath);
       relintAllDocuments();
@@ -141,6 +141,7 @@ connection.onNotification(
 connection.onNotification(
   'connectionUpdated',
   (connectionSettings: Neo4jConnectionSettings) => {
+    _internalFeatureFlags.versionedLinters = false;
     changeConnection(connectionSettings);
     neo4jSchemaPoller.events.once('schemaFetched', relintAllDocuments);
   },

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -5,6 +5,7 @@ export type Neo4jConnectionSettings = {
   password?: string;
   connectURL?: string;
   database?: string;
+  lintWorkerPath?: string;
 };
 
 export type Neo4jSettings = {

--- a/packages/language-support/src/featureFlags.ts
+++ b/packages/language-support/src/featureFlags.ts
@@ -1,6 +1,7 @@
 interface FeatureFlags {
   consoleCommands: boolean;
   cypher25: boolean;
+  versionedLinters: boolean;
 }
 
 export const _internalFeatureFlags: FeatureFlags = {
@@ -13,4 +14,5 @@ export const _internalFeatureFlags: FeatureFlags = {
   */
   consoleCommands: false,
   cypher25: false,
+  versionedLinters: false,
 };

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -31,11 +31,7 @@ export type {
   Neo4jFunction,
   Neo4jProcedure,
 } from './types';
-export {
-  cypher25Supported,
-  compareVersions,
-  compareMajorMinorVersions,
-} from './version';
+export { compareVersions, compareMajorMinorVersions } from './version';
 export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
 
 import CypherLexer from './generated-parser/CypherCmdLexer';

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -31,7 +31,11 @@ export type {
   Neo4jFunction,
   Neo4jProcedure,
 } from './types';
-export { compareVersions } from './version';
+export {
+  cypher25Supported,
+  compareVersions,
+  compareMajorMinorVersions,
+} from './version';
 export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
 
 import CypherLexer from './generated-parser/CypherCmdLexer';

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -31,6 +31,7 @@ export type {
   Neo4jFunction,
   Neo4jProcedure,
 } from './types';
+export { compareVersions } from './version';
 export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
 
 import CypherLexer from './generated-parser/CypherCmdLexer';

--- a/packages/language-support/src/version.ts
+++ b/packages/language-support/src/version.ts
@@ -1,11 +1,6 @@
 import semver from 'semver';
 import { integer } from 'vscode-languageserver-types';
 
-export function cypher25Supported(serverVersion: string) {
-  const minSupportedVersion = '2025.8.0';
-  return compareVersions(minSupportedVersion, serverVersion) <= 0;
-}
-
 /**Like semver.compare - Returns:
  *  - -1 if v1 < v2
  *  -  0 if v1 === v2
@@ -41,8 +36,8 @@ export function compareMajorMinorVersions(
  *  -  1 if  v1 > v2
  *  But if versions are of incorrect format, returns undefined
  *
- *  But taking only numerical prerelease versions into account,
- *  ignoring ones that are strings */
+ *  If major- minor- and patch versions are equal,
+ *  compares prerelease versions too, provided that they are numerical. */
 export function compareVersions(
   version1: string,
   version2: string,

--- a/packages/language-support/src/version.ts
+++ b/packages/language-support/src/version.ts
@@ -2,7 +2,7 @@ import semver from 'semver';
 import { integer } from 'vscode-languageserver-types';
 
 export function cypher25Supported(serverVersion: string) {
-  const minSupportedVersion = '5.27.0-2025040';
+  const minSupportedVersion = '2025.8.0';
   return compareVersions(minSupportedVersion, serverVersion) <= 0;
 }
 
@@ -10,18 +10,58 @@ export function cypher25Supported(serverVersion: string) {
  *  - -1 if v1 < v2
  *  -  0 if v1 === v2
  *  -  1 if  v1 > v2
+ *  But ignores patch version,
+ *  and returns undefined if versions are of incorrect format */
+export function compareMajorMinorVersions(
+  version1: string,
+  version2: string,
+): integer | undefined {
+  let semVer1: semver.SemVer;
+  let semVer2: semver.SemVer;
+  try {
+    semVer1 = semver.coerce(version1, {
+      includePrerelease: false,
+    });
+    semVer2 = semver.coerce(version2, {
+      includePrerelease: false,
+    });
+  } catch (e) {
+    return undefined;
+  }
+  if (semVer1 && semVer2) {
+    semVer1.patch = 0;
+    semVer2.patch = 0;
+    return semver.compare(semVer1, semVer2);
+  }
+}
+
+/**Like semver.compare - Returns:
+ *  - -1 if v1 < v2
+ *  -  0 if v1 === v2
+ *  -  1 if  v1 > v2
+ *  But if versions are of incorrect format, returns undefined
  *
  *  But taking only numerical prerelease versions into account,
  *  ignoring ones that are strings */
-export function compareVersions(version1: string, version2: string): integer {
-  const v1 = semver.coerce(version1, {
-    includePrerelease: false,
-  });
-  const v2 = semver.coerce(version2, {
-    includePrerelease: false,
-  });
-  if (v1 && v2) {
-    const comparison = semver.compare(v1, v2);
+export function compareVersions(
+  version1: string,
+  version2: string,
+): integer | undefined {
+  let semVer1: semver.SemVer;
+  let semVer2: semver.SemVer;
+  try {
+    semVer1 = semver.coerce(version1, {
+      includePrerelease: false,
+    });
+    semVer2 = semver.coerce(version2, {
+      includePrerelease: false,
+    });
+  } catch (e) {
+    return undefined;
+  }
+
+  if (semVer1 && semVer2) {
+    const comparison = semver.compare(semVer1, semVer2);
     const prerelease1 = semver.prerelease(version1)?.at(0);
     const prerelease2 = semver.prerelease(version2)?.at(0);
     if (

--- a/packages/language-support/src/version.ts
+++ b/packages/language-support/src/version.ts
@@ -1,0 +1,38 @@
+import semver from 'semver';
+import { integer } from 'vscode-languageserver-types';
+
+export function cypher25Supported(serverVersion: string) {
+  const minSupportedVersion = '5.27.0-2025040';
+  return compareVersions(minSupportedVersion, serverVersion) <= 0;
+}
+
+/**Like semver.compare - Returns:
+ *  - -1 if v1 < v2
+ *  -  0 if v1 === v2
+ *  -  1 if  v1 > v2
+ *
+ *  But taking only numerical prerelease versions into account,
+ *  ignoring ones that are strings */
+export function compareVersions(version1: string, version2: string): integer {
+  const v1 = semver.coerce(version1, {
+    includePrerelease: false,
+  });
+  const v2 = semver.coerce(version2, {
+    includePrerelease: false,
+  });
+  if (v1 && v2) {
+    const comparison = semver.compare(v1, v2);
+    const prerelease1 = semver.prerelease(version1)?.at(0);
+    const prerelease2 = semver.prerelease(version2)?.at(0);
+    if (
+      comparison === 0 &&
+      typeof prerelease1 === 'number' &&
+      typeof prerelease2 === 'number'
+    ) {
+      return semver.compare(prerelease1.toString(), prerelease2.toString());
+    } else {
+      return comparison;
+    }
+  }
+  return -1;
+}

--- a/packages/lint-worker/package.json
+++ b/packages/lint-worker/package.json
@@ -17,7 +17,7 @@
     "cypher",
     "lint worker"
   ],
-  "version": "2025.6.0",
+  "version": "2025.7.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/neo4j/cypher-language-support.git"

--- a/packages/lint-worker/package.json
+++ b/packages/lint-worker/package.json
@@ -31,25 +31,31 @@
   },
   "dependencies": {
     "@neo4j-cypher/language-support": "workspace:*",
-    "workerpool": "^9.0.4"
+    "languageSupport-next.13": "npm:@neo4j-cypher/language-support@2.0.0-next.13",
+    "languageSupport-next.3": "npm:@neo4j-cypher/language-support@2.0.0-next.3",
+    "@neo4j-cypher/query-tools": "workspace:*",
+    "workerpool": "^9.0.4",
+    "vscode-languageserver": "^8.1.0"
   },
   "scripts": {
-    "build": "pnpm build-types && pnpm build-esm && pnpm build-commonjs",
-    "build-commonjs": "esbuild ./src/lintWorker.ts --bundle --platform=node --conditions=require --outfile=dist/cjs/lintWorker.cjs --format=cjs --minify",
-    "build-esm": "esbuild ./src/lintWorker.ts --bundle --platform=node --conditions=require --outfile=dist/esm/lintWorker.mjs --format=esm --minify",
+    "build": "pnpm build-types && pnpm build-lintworker-esm && pnpm build-lintworker-commonjs && pnpm build-commonjs && pnpm build-esm",
+    "build-lintworker-commonjs": "esbuild ./src/lintWorker.ts --bundle --platform=node --conditions=require --outfile=dist/cjs/lintWorker.cjs --format=cjs --minify",
+    "build-lintworker-esm": "esbuild ./src/lintWorker.ts --bundle --platform=node --conditions=require --outfile=dist/esm/lintWorker.mjs --format=esm --minify",
+    "build-commonjs": "esbuild ./src/index.ts --bundle --platform=node --conditions=require --outfile=dist/cjs/index.cjs --format=cjs --minify",
+    "build-esm": "esbuild ./src/index.ts --bundle --platform=node --conditions=require --outfile=dist/esm/index.mjs --format=esm --minify",
     "clean": "rm -rf dist",
     "build-types": "tsc --emitDeclarationOnly --outDir dist/types"
   },
   "devDependencies": {
     "@types/lodash.debounce": "^4.0.9"
   },
-  "types": "./dist/types/src/lintWorker.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/src/lintWorker.d.ts",
-      "require": "./dist/cjs/lintWorker.cjs",
-      "import": "./dist/esm/lintWorker.mjs",
-      "default": "./dist/esm/lintWorker.mjs"
+      "types": "./dist/esm/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "default": "./dist/esm/index.mjs"
     }
   }
 }

--- a/packages/lint-worker/package.json
+++ b/packages/lint-worker/package.json
@@ -17,7 +17,7 @@
     "cypher",
     "lint worker"
   ],
-  "version": "2025.4.0",
+  "version": "2025.6.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/neo4j/cypher-language-support.git"

--- a/packages/lint-worker/src/helpers.ts
+++ b/packages/lint-worker/src/helpers.ts
@@ -1,0 +1,137 @@
+import {
+  compareMajorMinorVersions,
+  DbSchema,
+  Neo4jFunction,
+  Neo4jProcedure,
+  toSignatureInformation,
+} from '@neo4j-cypher/language-support';
+import { getVersion, Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
+import { SignatureInformation } from 'vscode-languageserver';
+import { DbSchema as NoCyphVerSchema } from 'languageSupport-next.13';
+import { DbSchema as FuncOnlySigSchema } from 'languageSupport-next.3';
+
+export async function convertDbSchema(
+  originalSchema: DbSchema,
+  neo4j: Neo4jSchemaPoller,
+): Promise<DbSchema | NoCyphVerSchema | FuncOnlySigSchema> {
+  let oldFunctions: Record<string, Neo4jFunction> = {};
+  let oldProcedures: Record<string, Neo4jProcedure> = {};
+  if (!originalSchema) {
+    return originalSchema;
+  }
+  if (
+    originalSchema.functions['CYPHER 5'] &&
+    originalSchema.procedures['CYPHER 5']
+  ) {
+    oldFunctions = originalSchema.functions['CYPHER 5'];
+    oldProcedures = originalSchema.procedures['CYPHER 5'];
+  }
+
+  const serverVersion = await getServerVersion(neo4j);
+  const linterVersion = serverVersionToLinter(serverVersion);
+
+  //Todo: remove always true on tested condition first
+  if (compareMajorMinorVersions(linterVersion, '5.18.0') < 0) {
+    let oldFunctions: Record<string, Neo4jFunction> = {};
+    let oldProcedures: Record<string, Neo4jProcedure> = {};
+    if (!originalSchema) {
+      return originalSchema;
+    }
+    if (
+      originalSchema.functions['CYPHER 5'] &&
+      originalSchema.procedures['CYPHER 5']
+    ) {
+      oldFunctions = originalSchema.functions['CYPHER 5'];
+      oldProcedures = originalSchema.procedures['CYPHER 5'];
+    }
+    const functionSignatures: Record<string, SignatureInformation> =
+      Object.fromEntries(
+        Object.entries(oldFunctions).map(([key, func]) => [
+          key,
+          toSignatureInformation(func),
+        ]),
+      );
+
+    const procedureSignatures: Record<string, SignatureInformation> =
+      Object.fromEntries(
+        Object.entries(oldProcedures).map(([key, proc]) => [
+          key,
+          toSignatureInformation(proc),
+        ]),
+      );
+
+    const dbSchemaOld = {
+      ...originalSchema,
+      functionSignatures,
+      procedureSignatures,
+    };
+    return dbSchemaOld;
+  } else if (compareMajorMinorVersions(linterVersion, '2025.1.0') < 0) {
+    const dbSchemaOld: NoCyphVerSchema = {
+      ...originalSchema,
+      functions: oldFunctions,
+      procedures: oldProcedures,
+    };
+    return dbSchemaOld;
+  } else {
+    return originalSchema;
+  }
+}
+
+export async function getServerVersion(
+  neo4j: Neo4jSchemaPoller,
+): Promise<string> {
+  if (neo4j.serverVersion) {
+    return neo4j.serverVersion;
+  } else {
+    const { query: versionQuery, queryConfig: versionQueryConfig } =
+      getVersion();
+    const driver = neo4j.driver;
+    if (driver) {
+      const { serverVersion } = await driver.executeQuery(
+        versionQuery,
+        {},
+        versionQueryConfig,
+      );
+      neo4j.serverVersion = serverVersion;
+      return serverVersion;
+    }
+  }
+}
+
+export function serverVersionToLinter(serverVersion: string) {
+  //This can be made into an array (the key is not needed) but having it this way helps see what lang-supp release we would use
+  const availableLinters: Record<string, string> = {
+    //We should probably have version comparison where patches are lumped in with the original release
+    '2.0.0-next.20': '2025.4.0', // 29/4 - 2025.04.0=30/4
+    //"2.0.0-next.19": "", // 22/4 - maybe SKIP
+    //"2.0.0-next.18": "", // 7/4  - skip because next release is 2025.04.0
+    '2.0.0-next.17': '2025.3.0', // 25/3 - 2025.03.0=27/3
+    '2.0.0-next.16': '2025.2.0', // 17/2 - 2025.02.0=27/2
+    //"2.0.0-next.15": "", // 10/2 - maybe SKIP
+    '2.0.0-next.14': '2025.1.0', // 4/2  - 2025.01.0=6/2
+    //"2.0.0-next.13": "", // 23/12 2024 - skip, next is 01.0
+    '2.0.0-next.12': '5.26.0', // 13/12 - 5.26(.x)=9/12 (very close to initial 5.26, if after)
+    //"2.0.0-next.11": "", // 13/11 - SKIP
+    //"2.0.0-next.10": "", // 13/11 - SKIP
+    '2.0.0-next.9': '5.25.0', // 28/10 - 5.25 = 31/10
+    '2.0.0-next.8': '5.24.0', // 14/9 - 5.24 = 27/9
+    '2.0.0-next.7': '5.23.0', // 29/7 - 5.23 = 22/8
+    '2.0.0-next.6': '5.20.0', // 3/5 - 5.20 = 23/5
+    '2.0.0-next.5': '5.19.0', // 2/4 - 5.19 = 12/4
+    '2.0.0-next.4': '5.18.0', // 6/3 - 5.18 = 13/3
+    '2.0.0-next.3': '5.17.0', // 7/2 - 5.17 = 23/2
+    '2.0.0-next.2': '5.14.0', // 24/11 2023 - 5.14 = 24/11
+    //"2.0.0-next.1": "",  // 22/11 - SKIP
+    '2.0.0-next.0': '5.13.0', // 25/10 - 5.13 = 23/10
+  };
+  let candidate: string = undefined;
+  for (const x in availableLinters) {
+    if (compareMajorMinorVersions(serverVersion, availableLinters[x]) <= 0) {
+      candidate = availableLinters[x];
+    } else {
+      break;
+    }
+  }
+  return candidate;
+}

--- a/packages/lint-worker/src/helpers.ts
+++ b/packages/lint-worker/src/helpers.ts
@@ -30,7 +30,6 @@ export async function convertDbSchema(
   const serverVersion = await getServerVersion(neo4j);
   const linterVersion = serverVersionToLinter(serverVersion);
 
-  //Todo: remove always true on tested condition first
   if (compareMajorMinorVersions(linterVersion, '5.18.0') < 0) {
     let oldFunctions: Record<string, Neo4jFunction> = {};
     let oldProcedures: Record<string, Neo4jProcedure> = {};

--- a/packages/lint-worker/src/helpers.ts
+++ b/packages/lint-worker/src/helpers.ts
@@ -101,7 +101,6 @@ export async function getServerVersion(
 export function serverVersionToLinter(serverVersion: string) {
   //This can be made into an array (the key is not needed) but having it this way helps see what lang-supp release we would use
   const availableLinters: Record<string, string> = {
-    //We should probably have version comparison where patches are lumped in with the original release
     '2.0.0-next.20': '2025.4.0', // 29/4 - 2025.04.0=30/4
     //"2.0.0-next.19": "", // 22/4 - maybe SKIP
     //"2.0.0-next.18": "", // 7/4  - skip because next release is 2025.04.0

--- a/packages/lint-worker/src/index.ts
+++ b/packages/lint-worker/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lintWorker';
+export * from './helpers';

--- a/packages/lint-worker/src/lintWorker.ts
+++ b/packages/lint-worker/src/lintWorker.ts
@@ -1,14 +1,16 @@
 import {
-  DbSchema,
-  lintCypherQuery as _lintCypherQuery,
   _internalFeatureFlags,
   SyntaxDiagnostic,
+} from '@neo4j-cypher/language-support';
+import {
+  DbSchema,
+  lintCypherQuery as _lintCypherQuery,
 } from '@neo4j-cypher/language-support';
 import workerpool from 'workerpool';
 
 function lintCypherQuery(
   query: string,
-  dbSchema: DbSchema,
+  dbSchema,
   featureFlags: { consoleCommands?: boolean; cypher25?: boolean } = {},
 ): SyntaxDiagnostic[] {
   // We allow to override the consoleCommands feature flag
@@ -18,7 +20,8 @@ function lintCypherQuery(
   if (featureFlags.cypher25 !== undefined) {
     _internalFeatureFlags.cypher25 = featureFlags.cypher25;
   }
-  return _lintCypherQuery(query, dbSchema);
+  //cast to appease git lint check
+  return _lintCypherQuery(query, dbSchema as DbSchema);
 }
 
 workerpool.worker({ lintCypherQuery });

--- a/packages/query-tools/src/index.ts
+++ b/packages/query-tools/src/index.ts
@@ -19,3 +19,4 @@ export type { Database } from './queries/databases';
 export { Neo4jSchemaPoller } from './schemaPoller';
 export type { ConnnectionResult } from './schemaPoller';
 export type { CypherDataType } from './types/cypher-data-types';
+export { getVersion } from './queries/version';

--- a/packages/query-tools/src/queries/version.ts
+++ b/packages/query-tools/src/queries/version.ts
@@ -7,7 +7,7 @@ import { ExecuteQueryArgs } from '../types/sdkTypes';
 export function getVersion(): ExecuteQueryArgs<{
   serverVersion: string | undefined;
 }> {
-  const query = 'CALL dbms.components() YIELD versions';
+  const query = 'CALL dbms.components() YIELD name, versions';
 
   const resultTransformer = resultTransformers.mappedResultTransformer({
     map(record) {
@@ -17,11 +17,12 @@ export function getVersion(): ExecuteQueryArgs<{
       return { name, versions };
     },
     collect(rows, summary) {
-      rows.forEach((row) => {
+      for (const row of rows) {
         if (row.name === 'Neo4j Kernel') {
-          return { serverVersion: row.versions, summary };
+          return { serverVersion: row.versions[0], summary };
         }
-      });
+      }
+
       //We should not reach this unless the "name" field changes
       return { serverVersion: undefined, summary };
     },
@@ -46,11 +47,12 @@ export function getCypherVersions(): ExecuteQueryArgs<{
       return { name, versions };
     },
     collect(rows, summary) {
-      rows.forEach((row) => {
+      for (const row of rows) {
         if (row.name === 'Cypher') {
           return { serverCypherVersions: row.versions, summary };
         }
-      });
+      }
+
       return { serverCypherVersions: ['5'], summary };
     },
   });

--- a/packages/query-tools/src/schemaPoller.ts
+++ b/packages/query-tools/src/schemaPoller.ts
@@ -28,7 +28,7 @@ export class Neo4jSchemaPoller {
   public connection?: Neo4jConnection;
   public metadata?: MetadataPoller;
   public events: EventEmitter = new EventEmitter();
-  private driver?: Driver;
+  public driver?: Driver;
   private reconnectionTimeout?: ReturnType<typeof setTimeout>;
   private retries = MAX_RETRY_ATTEMPTS;
   private lastError?: ConnectionError;

--- a/packages/query-tools/src/schemaPoller.ts
+++ b/packages/query-tools/src/schemaPoller.ts
@@ -29,7 +29,7 @@ export class Neo4jSchemaPoller {
   public metadata?: MetadataPoller;
   public events: EventEmitter = new EventEmitter();
   public driver?: Driver;
-  public serverVersion?: string; //TODO - decide if we want this as an attribute of poller or something else
+  public serverVersion?: string;
   private reconnectionTimeout?: ReturnType<typeof setTimeout>;
   private retries = MAX_RETRY_ATTEMPTS;
   private lastError?: ConnectionError;

--- a/packages/query-tools/src/schemaPoller.ts
+++ b/packages/query-tools/src/schemaPoller.ts
@@ -29,6 +29,7 @@ export class Neo4jSchemaPoller {
   public metadata?: MetadataPoller;
   public events: EventEmitter = new EventEmitter();
   public driver?: Driver;
+  public serverVersion?: string; //TODO - decide if we want this as an attribute of poller or something else
   private reconnectionTimeout?: ReturnType<typeof setTimeout>;
   private retries = MAX_RETRY_ATTEMPTS;
   private lastError?: ConnectionError;
@@ -102,6 +103,8 @@ export class Neo4jSchemaPoller {
           config,
           database,
         );
+
+        this.serverVersion = undefined; //So when checking serverversion, we dont use the one from the last connection
 
         return this.handleSuccessfulConnection();
       } catch (error) {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -470,6 +470,7 @@
     "@neo4j-cypher/language-server": "workspace:*",
     "@neo4j-cypher/language-support": "workspace:*",
     "@neo4j-cypher/query-tools": "workspace:*",
+    "@neo4j-cypher/lint-worker": "workspace:*",
     "@neo4j-ndl/base": "3.4.2",
     "@neo4j-ndl/react": "3.5.5",
     "@neo4j-nvl/base": "0.3.8",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -477,7 +477,9 @@
     "neo4j-driver": "catalog:",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "vscode-languageclient": "^8.1.0"
+    "vscode-languageclient": "^8.1.0",
+    "tar": "^7.4.3",
+    "axios": "^1.9.0"
   },
   "devDependencies": {
     "@testcontainers/neo4j": "^10.4.0",

--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -522,13 +522,15 @@ async function connectToDatabaseAndNotifyLanguageClient(
     ? 'error'
     : 'inactive';
 
-  if (result.success) {
-    await checkNeo4jServerVersion();
-  }
-
   result.success
     ? await sendNotificationToLanguageClient('connectionUpdated', settings)
     : await sendNotificationToLanguageClient('connectionDisconnected');
+
+  const config = vscode.workspace.getConfiguration('neo4j.features');
+  const versionedLintersEnabled = config.get('useVersionedLinters', false);
+  if (result.success && versionedLintersEnabled) {
+    await checkNeo4jServerVersion();
+  }
 
   await saveConnection({
     ...connection,

--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -12,13 +12,15 @@ import * as schemaPollerEventHandlers from './schemaPollerEventHandlers';
 import { connectionTreeDataProvider } from './treeviews/connectionTreeDataProvider';
 import { databaseInformationTreeDataProvider } from './treeviews/databaseInformationTreeDataProvider';
 import { displayMessageForConnectionResult } from './uiUtils';
-import { getVersion } from '@neo4j-cypher/query-tools';
-import { compareMajorMinorVersions } from '@neo4j-cypher/language-support';
 import * as tar from 'tar';
 import * as path from 'path';
 import { pipeline } from 'stream/promises';
 import axios from 'axios';
 import * as vscode from 'vscode';
+import {
+  getServerVersion,
+  serverVersionToLinter,
+} from '@neo4j-cypher/language-server/src/linting';
 
 export type Scheme =
   | 'neo4j'
@@ -422,7 +424,8 @@ async function downloadLintWorker(
   serverVersion: string,
 ): Promise<void> {
   const filePath = path.join(destDir, fileName);
-  const downloadUrl = `http://localhost:4873/@neo4j-cypher/lint-worker/-/lint-worker-${serverVersion}.tgz`; //`http://localhost:4873/@neo4j-cypher/lint-worker/-/lint-worker-2025.3.0.tgz`;
+  //TODO: Set this to proper npm registry when package is published.
+  const downloadUrl = `http://localhost:4873/@neo4j-cypher/lint-worker/-/lint-worker-${serverVersion}.tgz`;
   const response = await axios.get(downloadUrl, { responseType: 'stream' });
   await pipeline(
     response.data,
@@ -464,20 +467,23 @@ async function getDestDir(
 }
 
 export async function checkNeo4jServerVersion(): Promise<void> {
-  const { query: versionQuery, queryConfig: versionQueryConfig } = getVersion();
   const poller = getSchemaPoller();
   const driver = poller.driver;
   if (driver) {
-    const { serverVersion } = await driver.executeQuery(
-      versionQuery,
-      {},
-      versionQueryConfig,
-    );
+    const serverVersion = await getServerVersion(poller);
+
+    poller.serverVersion = serverVersion;
+
     //removes zero padding on month of new versions
-    const sanitizedServerVersion = serverVersion.replace(/(\.0+)(?=\d)/g, '.');
+    //TODO Handle nicely serverVersion being undefined
+    const sanitizedServerVersion = serverVersion
+      ? serverVersion.replace(/(\.0+)(?=\d)/g, '.')
+      : undefined;
 
     //since not every release has a linter release
-    const linterVersion = serverVersionToLinter(sanitizedServerVersion);
+    const linterVersion = serverVersion
+      ? serverVersionToLinter(sanitizedServerVersion)
+      : undefined;
 
     //If the server is newer than the latest published package on npm, use default linter
     if (!linterVersion) {
@@ -494,43 +500,6 @@ export async function checkNeo4jServerVersion(): Promise<void> {
       await switchWorkerOnLanguageServer(fileName, destDir);
     }
   }
-}
-
-function serverVersionToLinter(serverVersion: string) {
-  //This can be made into an array (the key is not needed) but having it this way helps see what lang-supp release we would use
-  const availableLinters: Record<string, string> = {
-    //We should probably have version comparison where patches are lumped in with the original release
-    '2.0.0-next.20': '2025.4.0', // 29/4 - 2025.04.0=30/4
-    //"2.0.0-next.19": "", // 22/4 - maybe SKIP
-    //"2.0.0-next.18": "", // 7/4  - skip because next release is 2025.04.0
-    '2.0.0-next.17': '2025.3.0', // 25/3 - 2025.03.0=27/3
-    '2.0.0-next.16': '2025.2.0', // 17/2 - 2025.02.0=27/2
-    //"2.0.0-next.15": "", // 10/2 - maybe SKIP
-    '2.0.0-next.14': '2025.1.0', // 4/2  - 2025.01.0=6/2
-    //"2.0.0-next.13": "", // 23/12 2024 - skip, next is 01.0
-    '2.0.0-next.12': '5.26.0', // 13/12 - 5.26(.x)=9/12 (very close to initial 5.26, if after)
-    //"2.0.0-next.11": "", // 13/11 - SKIP
-    //"2.0.0-next.10": "", // 13/11 - SKIP
-    '2.0.0-next.9': '5.25.0', // 28/10 - 5.25 = 31/10
-    '2.0.0-next.8': '5.24.0', // 14/9 - 5.24 = 27/9
-    '2.0.0-next.7': '5.23', // 29/7 - 5.23 = 22/8
-    '2.0.0-next.6': '5.20', // 3/5 - 5.20 = 23/5
-    '2.0.0-next.5': '5.19', // 2/4 - 5.19 = 12/4
-    '2.0.0-next.4': '5.18', // 6/3 - 5.18 = 13/3
-    '2.0.0-next.3': '5.17', // 7/2 - 5.17 = 23/2
-    '2.0.0-next.2': '5.14', // 24/11 2023 - 5.14 = 24/11
-    //"2.0.0-next.1": "",  // 22/11 - SKIP
-    '2.0.0-next.0': '5.13', // 25/10 - 5.13 = 23/10
-  };
-  let candidate: string = undefined;
-  for (const x in availableLinters) {
-    if (compareMajorMinorVersions(serverVersion, availableLinters[x]) <= 0) {
-      candidate = availableLinters[x];
-    } else {
-      break;
-    }
-  }
-  return candidate;
 }
 
 /**

--- a/packages/vscode-extension/src/connectionService.ts
+++ b/packages/vscode-extension/src/connectionService.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 import {
   getServerVersion,
   serverVersionToLinter,
-} from '@neo4j-cypher/language-server/src/linting';
+} from '@neo4j-cypher/lint-worker';
 
 export type Scheme =
   | 'neo4j'

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: ExtensionContext) {
     debug: {
       module: debugServer,
       transport: TransportKind.ipc,
-      options: { env: { CYPHER_25: 'true' } },
+      options: { env: { CYPHER_25: 'false' } }, //TODO: Do we even need this feature flag at all?
     },
   };
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: ExtensionContext) {
     debug: {
       module: debugServer,
       transport: TransportKind.ipc,
-      options: { env: { CYPHER_25: 'false' } }, //TODO: Do we even need this feature flag at all?
+      options: { env: { CYPHER_25: 'false' } },
     },
   };
 

--- a/packages/vscode-extension/src/languageClientService.ts
+++ b/packages/vscode-extension/src/languageClientService.ts
@@ -4,7 +4,8 @@ import { getLanguageClient } from './contextService';
 export type MethodName =
   | 'connectionUpdated'
   | 'connectionDisconnected'
-  | 'updateParameters';
+  | 'updateParameters'
+  | 'updateLintWorker';
 
 /**
  * Communicates to the language client that a connection has been updated or disconnected and needs to take action.

--- a/packages/vscode-extension/tests/specs/api/formatting.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/formatting.spec.ts
@@ -2,8 +2,6 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { newUntitledFileWithContent } from '../../helpers';
 
-const normalizeLineEndings = (str: string) => str.replace(/\r\n/g, '\n');
-
 suite('Formatting', () => {
   test('tests that formatting document works', async () => {
     const query = `match (p:   Person)  where  p.name = "John Doe" reTUrn p lIMIt 25`;
@@ -14,9 +12,6 @@ suite('Formatting', () => {
 WHERE p.name = "John Doe"
 RETURN p
 LIMIT 25`;
-    assert.equal(
-      normalizeLineEndings(formattedText),
-      normalizeLineEndings(expected),
-    );
+    assert.equal(formattedText, expected);
   });
 });

--- a/packages/vscode-extension/tests/specs/api/formatting.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/formatting.spec.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { newUntitledFileWithContent } from '../../helpers';
 
+const normalizeLineEndings = (str: string) => str.replace(/\r\n/g, '\n');
+
 suite('Formatting', () => {
   test('tests that formatting document works', async () => {
     const query = `match (p:   Person)  where  p.name = "John Doe" reTUrn p lIMIt 25`;
@@ -12,6 +14,9 @@ suite('Formatting', () => {
 WHERE p.name = "John Doe"
 RETURN p
 LIMIT 25`;
-    assert.equal(formattedText, expected);
+    assert.equal(
+      normalizeLineEndings(formattedText),
+      normalizeLineEndings(expected),
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,14 +326,8 @@ importers:
         specifier: 3.4.2
         version: 3.4.2
       '@neo4j-ndl/react':
-        specifier: 3.5.5
-        version: 3.5.5(@neo4j-ndl/base@3.4.2)(@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@neo4j-nvl/base':
-        specifier: 0.3.8
-        version: 0.3.8(neo4j-driver@5.12.0)
-      '@neo4j-nvl/react':
-        specifier: 0.3.8
-        version: 0.3.8(neo4j-driver@5.12.0)
+        specifier: ^2.16.5
+        version: 2.16.23(@heroicons/react@2.0.18(react@18.3.1))(@lezer/common@1.2.1)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       neo4j-driver:
         specifier: 'catalog:'
         version: 5.12.0
@@ -343,6 +337,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
       vscode-languageclient:
         specifier: ^8.1.0
         version: 8.1.0
@@ -1307,6 +1304,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
@@ -2822,6 +2823,9 @@ packages:
   avvio@8.4.0:
     resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
 
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
 
@@ -3110,6 +3114,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromium-bidi@0.5.8:
     resolution: {integrity: sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==}
@@ -5221,6 +5229,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
@@ -5233,6 +5245,11 @@ packages:
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6577,6 +6594,10 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -7238,6 +7259,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -8188,6 +8213,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -10461,6 +10490,14 @@ snapshots:
       '@fastify/error': 3.4.1
       fastq: 1.17.1
 
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.15.8
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   azure-devops-node-api@12.5.0:
     dependencies:
       tunnel: 0.0.6
@@ -10793,6 +10830,8 @@ snapshots:
       readdirp: 4.1.1
 
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   chromium-bidi@0.5.8(devtools-protocol@0.0.1232444):
     dependencies:
@@ -13213,6 +13252,10 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
   mitt@3.0.1: {}
 
   mkdirp-classic@0.5.3: {}
@@ -13222,6 +13265,8 @@ snapshots:
       minimist: 1.2.8
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   mnemonist@0.39.6:
     dependencies:
@@ -14838,6 +14883,15 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.0
 
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
   term-size@2.2.1: {}
 
   testcontainers@10.13.0:
@@ -15511,6 +15565,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@1.10.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,18 @@ importers:
       '@neo4j-cypher/language-support':
         specifier: workspace:*
         version: link:../language-support
+      '@neo4j-cypher/query-tools':
+        specifier: workspace:*
+        version: link:../query-tools
+      languageSupport-next.13:
+        specifier: npm:@neo4j-cypher/language-support@2.0.0-next.13
+        version: '@neo4j-cypher/language-support@2.0.0-next.13'
+      languageSupport-next.3:
+        specifier: npm:@neo4j-cypher/language-support@2.0.0-next.3
+        version: '@neo4j-cypher/language-support@2.0.0-next.3'
+      vscode-languageserver:
+        specifier: ^8.1.0
+        version: 8.1.0
       workerpool:
         specifier: ^9.0.4
         version: 9.0.4
@@ -325,6 +337,9 @@ importers:
       '@neo4j-cypher/language-support':
         specifier: workspace:*
         version: link:../language-support
+      '@neo4j-cypher/lint-worker':
+        specifier: workspace:*
+        version: link:../lint-worker
       '@neo4j-cypher/query-tools':
         specifier: workspace:*
         version: link:../query-tools

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1719,36 +1719,26 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/checkbox@3.6.13':
-    resolution: {integrity: sha512-b8+bkOhobzuJ5bAA16JpYg1tM973eNXD3U4h/8+dckLndKHRjIwPvrL25tzKN7NcQp2LKVCauFesgI+Z+/2FJg==}
   '@react-stately/checkbox@3.6.14':
     resolution: {integrity: sha512-eGl0GP/F/nUrA33gDCYikyXK+Yer7sFOx8T4EU2AF4E8n1VQIRiVNaxDg7Ar6L3CMKor01urppFHFJsBUnSgyw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/collections@3.12.3':
-    resolution: {integrity: sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==}
   '@react-stately/collections@3.12.4':
     resolution: {integrity: sha512-H+47fRkwYX2/BdSA+NLTzbR+8QclZXyBgC7tHH3dzljyxNimhrMDnbmk520nvGCebNf3nuxtFHq9iVTLpazSVA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/color@3.8.4':
-    resolution: {integrity: sha512-LXmfnJPWnL5q1/Z8Pn2d+9efrClLWCiK6c3IGXN8ZWcdR/cMJ/w9SY9f7evyXvmeUmdU1FTGgoSVqGfup3tSyA==}
   '@react-stately/color@3.8.5':
     resolution: {integrity: sha512-yi1MQAbYuAYKu0AtMO+mWQWlWk6OzGMa9j4PGtQN2PI5Uv1NylWOvdquxbUJ4GUAuSYNopYG8Ci9MZMwtito8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/combobox@3.10.4':
-    resolution: {integrity: sha512-sgujLhukIGKskLDrOL4SAbO7WOgLsD7gSdjRQZ0f/e8bWMmUOWEp22T+X1hMMcuVRkRdXlEF1kH2/E6BVanXYw==}
   '@react-stately/combobox@3.10.5':
     resolution: {integrity: sha512-27SkClMqbMAKuVnmXhYzYisbLfzV7MO/DEiqWO4/3l+PZ+whL7Wi/Ek7Wqlfluid/y4pN4EkHCKNt4HJ2mhORQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/data@3.12.3':
-    resolution: {integrity: sha512-JYPNV1gd9OZm8xPay0exx5okFNgiwESNvdBHsfDC+f8BifRyFLdrvoaUGF0enKIeSQMB1oReFAxTAXtDZd27rA==}
   '@react-stately/data@3.13.0':
     resolution: {integrity: sha512-7LYPxVbWB6tvmLYKO19H5G5YtXV6eKCSXisOUiL9fVnOcGOPDK5z310sj9TP5vaX7zVPtwy0lDBUrZuRfhvQIQ==}
     peerDependencies:
@@ -2160,11 +2150,11 @@ packages:
     resolution: {integrity: sha512-NEwvIq4iSiDQozEyvbdiSdCOiLa+g5xHmdEnvwDb98FObcK6YkBOkRrs/CNqrKdDy+/lqoIllIWHk+M80GW6+g==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=16'
+      react-dom: '>=16'
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+  '@tanstack/table-core@8.11.8':
+    resolution: {integrity: sha512-DECHvtq4YW4U/gqg6etup7ydt/RB1Bi1pJaMpHUXl65ooW1d71Nv7BzD66rUdHrBSNdyiW3PLTPUQlpXjAgDeA==}
     engines: {node: '>=12'}
 
   '@testcontainers/neo4j@10.13.0':
@@ -9048,10 +9038,6 @@ snapshots:
 
   '@react-stately/calendar@3.8.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/calendar': 3.7.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@internationalized/date': 3.8.1
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/calendar': 3.7.1(react@18.3.1)
@@ -9059,13 +9045,8 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/checkbox@3.6.13(react@18.3.1)':
   '@react-stately/checkbox@3.6.14(react@18.3.1)':
     dependencies:
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@react-stately/form': 3.1.4(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/checkbox': 3.9.4(react@18.3.1)
@@ -9073,25 +9054,14 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/collections@3.12.3(react@18.3.1)':
   '@react-stately/collections@3.12.4(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/color@3.8.4(react@18.3.1)':
   '@react-stately/color@3.8.5(react@18.3.1)':
     dependencies:
-      '@internationalized/number': 3.6.1
-      '@internationalized/string': 3.2.6
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/numberfield': 3.9.11(react@18.3.1)
-      '@react-stately/slider': 3.6.3(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/color': 3.0.4(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@internationalized/number': 3.6.2
       '@internationalized/string': 3.2.6
       '@react-stately/form': 3.1.4(react@18.3.1)
@@ -9103,17 +9073,8 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/combobox@3.10.4(react@18.3.1)':
   '@react-stately/combobox@3.10.5(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-stately/select': 3.6.12(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/combobox': 3.13.4(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@react-stately/collections': 3.12.4(react@18.3.1)
       '@react-stately/form': 3.1.4(react@18.3.1)
       '@react-stately/list': 3.12.2(react@18.3.1)
@@ -9125,24 +9086,14 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/data@3.12.3(react@18.3.1)':
   '@react-stately/data@3.13.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/datepicker@3.14.0(react@18.3.1)':
   '@react-stately/datepicker@3.14.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@internationalized/string': 3.2.6
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/datepicker': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@internationalized/date': 3.8.1
       '@internationalized/string': 3.2.6
       '@react-stately/form': 3.1.4(react@18.3.1)
@@ -9153,7 +9104,6 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/dnd@3.5.3(react@18.3.1)':
   '@react-stately/dnd@3.5.4(react@18.3.1)':
     dependencies:
       '@react-stately/selection': 3.20.2(react@18.3.1)
@@ -9302,9 +9252,6 @@ snapshots:
 
   '@react-stately/utils@3.10.6(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
@@ -9434,7 +9381,6 @@ snapshots:
 
   '@react-types/tabs@3.3.15(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
       '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
@@ -9613,7 +9559,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/table-core@8.11.8': {}
 
   '@testcontainers/neo4j@10.13.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@neo4j-cypher/query-tools':
         specifier: workspace:*
         version: link:../query-tools
+      languageSupport-next.13:
+        specifier: npm:@neo4j-cypher/language-support@2.0.0-next.13
+        version: '@neo4j-cypher/language-support@2.0.0-next.13'
+      languageSupport-next.3:
+        specifier: npm:@neo4j-cypher/language-support@2.0.0-next.3
+        version: '@neo4j-cypher/language-support@2.0.0-next.3'
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -1384,6 +1390,14 @@ packages:
 
   '@neo4j-bloom/dagre@0.8.14':
     resolution: {integrity: sha512-FW1hbtbEr1FmJzGdbLxGOcn2SYZPhM1kGCs8RlMkqrjcXpcueTmEDZzGhZJx7KLbT15VSzEM6/sK4CaVsXdhkQ==}
+
+  '@neo4j-cypher/language-support@2.0.0-next.13':
+    resolution: {integrity: sha512-csi1nmY3PfEJEpGrxALmSi6LU8fewgTCMRHYk5yGWT5IFUh2q/b2Q3XqAIblbgAkRoggzkA/9dRoiGq76Ug6eA==}
+    engines: {node: '>=18.18.2'}
+
+  '@neo4j-cypher/language-support@2.0.0-next.3':
+    resolution: {integrity: sha512-/8D1de+E1ndl7XoBKdBXLF1eRGYZAgEbYStUH/Ex9HLU1dmoRS0VBxDE86FwgeHqBLy//DYlA3OKpcSp/XUUrw==}
+    engines: {node: '>=18.18.2'}
 
   '@neo4j-ndl/base@3.2.10':
     resolution: {integrity: sha512-Bpdxeg13hiOk4pw1t0CYKuvyfB1yAZBGE2B4X0Rxa3zR2CsGrEtfXAy3qRomJJMn5UpIPIcbiBj6IRp7MVBVWw==}
@@ -2725,9 +2739,15 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  antlr4-c3@3.4.4:
+    resolution: {integrity: sha512-ixp1i17ypbRzZnffdarIfCVEXJwPydtDt61SHMGkc+UCD7rrbfvHESTMTgx8jFhUgKAgcHyt9060kQ8nU3vlxA==}
+
   antlr4@4.13.2:
     resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
     engines: {node: '>=16'}
+
+  antlr4ng@3.0.16:
+    resolution: {integrity: sha512-DQuJkC7kX3xunfF4K2KsWTSvoxxslv+FQp/WHQZTJSsH2Ec3QfFmrxC3Nky2ok9yglXn6nHM4zUaVDxcN5f6kA==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -8319,6 +8339,20 @@ snapshots:
       graphlib: 2.1.8
       lodash: 4.17.21
 
+  '@neo4j-cypher/language-support@2.0.0-next.13':
+    dependencies:
+      antlr4: 4.13.2
+      antlr4-c3: 3.4.4
+      fastest-levenshtein: 1.0.16
+      vscode-languageserver-types: 3.17.5
+
+  '@neo4j-cypher/language-support@2.0.0-next.3':
+    dependencies:
+      antlr4: 4.13.2
+      antlr4-c3: 3.4.4
+      fastest-levenshtein: 1.0.16
+      vscode-languageserver-types: 3.17.5
+
   '@neo4j-ndl/base@3.2.10': {}
 
   '@neo4j-ndl/base@3.4.2': {}
@@ -10410,7 +10444,13 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  antlr4-c3@3.4.4:
+    dependencies:
+      antlr4ng: 3.0.16
+
   antlr4@4.13.2: {}
+
+  antlr4ng@3.0.16: {}
 
   any-promise@1.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,17 @@ importers:
         specifier: 3.4.2
         version: 3.4.2
       '@neo4j-ndl/react':
-        specifier: ^2.16.5
-        version: 2.16.23(@heroicons/react@2.0.18(react@18.3.1))(@lezer/common@1.2.1)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.5.5
+        version: 3.5.5(@neo4j-ndl/base@3.4.2)(@tanstack/react-table@8.11.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@neo4j-nvl/base':
+        specifier: 0.3.8
+        version: 0.3.8(neo4j-driver@5.12.0)
+      '@neo4j-nvl/react':
+        specifier: 0.3.8
+        version: 0.3.8(neo4j-driver@5.12.0)
+      axios:
+        specifier: ^1.9.0
+        version: 1.9.0
       neo4j-driver:
         specifier: 'catalog:'
         version: 5.12.0
@@ -1289,14 +1298,14 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@internationalized/date@3.8.0':
-    resolution: {integrity: sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==}
+  '@internationalized/date@3.8.1':
+    resolution: {integrity: sha512-PgVE6B6eIZtzf9Gu5HvJxRK3ufUFz9DhspELuhW/N0GuMGMTLvPQNRkHP2hTuP9lblOk+f+1xi96sPiPXANXAA==}
 
   '@internationalized/message@3.1.7':
     resolution: {integrity: sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==}
 
-  '@internationalized/number@3.6.1':
-    resolution: {integrity: sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==}
+  '@internationalized/number@3.6.2':
+    resolution: {integrity: sha512-E5QTOlMg9wo5OrKdHD6edo1JJlIoOsylh0+mbf0evi1tHJwMZfJSaBpGtnJV9N7w3jeiioox9EG/EWRWPh82vg==}
 
   '@internationalized/string@3.2.6':
     resolution: {integrity: sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==}
@@ -1442,110 +1451,110 @@ packages:
     engines: {node: '>=16.3.0'}
     hasBin: true
 
-  '@react-aria/breadcrumbs@3.5.23':
-    resolution: {integrity: sha512-4uLxuAgPfXds8sBc/Cg0ml7LKWzK+YTwHL7xclhQUkPO32rzlHDl+BJ5cyWhvZgGUf8JJXbXhD5VlJJzbbl8Xg==}
+  '@react-aria/breadcrumbs@3.5.24':
+    resolution: {integrity: sha512-CRheGyyM8afPJvDHLXn/mmGG/WAr/z2LReK3DlPdxVKcsOn7g3NIRxAcAIAJQlDLdOiu1SXHiZe6uu2jPhHrxA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/button@3.13.0':
-    resolution: {integrity: sha512-BEcTQb7Q8ZrAtn0scPDv/ErZoGC1FI0sLk0UTPGskuh/RV9ZZGFbuSWTqOwV8w5CS6VMvPjH6vaE8hS7sb5DIw==}
+  '@react-aria/button@3.13.1':
+    resolution: {integrity: sha512-E49qcbBRgofXYfWbli50bepWVNtQBq7qewL9XsX7nHkwPPUe1IRwJOnWZqYMgwwhUBOXfnsR6/TssiXqZsrJdw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/calendar@3.8.0':
-    resolution: {integrity: sha512-9vms/fWjJPZkJcMxciwWWOjGy/Q0nqI6FV0pYbMZbqepkzglEaVd98kl506r/4hLhWKwLdTfqCgbntRecj8jBg==}
+  '@react-aria/calendar@3.8.1':
+    resolution: {integrity: sha512-S931yi8jJ6CgUQJk+h/PEl+V0n1dUYr9n6nKXmZeU3940to4DauqwvmD9sg67hFHJ0QGroHT/s29yIfa5MfQcg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/checkbox@3.15.4':
-    resolution: {integrity: sha512-ZkDJFs2EfMBXVIpBSo4ouB+NXyr2LRgZNp2x8/v+7n3aTmMU8j2PzT+Ra2geTQbC0glMP7UrSg4qZblqrxEBcQ==}
+  '@react-aria/checkbox@3.15.5':
+    resolution: {integrity: sha512-b9c76DBSYTdacSogbsvjkdZomTo5yhBNMmR5ufO544HQ718Ry8q8JmVbtmF/+dkZN7KGnBQCltzGLzXH0Vc0Zg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/color@3.0.6':
-    resolution: {integrity: sha512-ik4Db9hrN1yIT0CQMB888ktBmrwA/kNhkfiDACtoUHv8Ev+YEpmagnmih9vMyW2vcnozYJpnn/aCMl59J5uMew==}
+  '@react-aria/color@3.0.7':
+    resolution: {integrity: sha512-3DcYxEWBrcuHSBq0OqCs6GySuy6eOue8/ngC31j/8aMXR+O4mGpXi0wo3rSQGFmGq/4Ri986cI2iGwZOkzpMHg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/combobox@3.12.2':
-    resolution: {integrity: sha512-EgddiF8VnAjB4EynJERPn4IoDMUabI8GiKOQZ6Ar3MlRWxQnUfxPpZwXs8qWR3dPCzYUt2PhBinhBMjyR1yRIw==}
+  '@react-aria/combobox@3.12.3':
+    resolution: {integrity: sha512-nCLFSQjOR3r3tB1AURtZKSZhi2euBMw0QxsIjnMVF73BQOfwfHMrIFctNULbL070gEnXofzeBd3ykJQpnsGH+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/datepicker@3.14.2':
-    resolution: {integrity: sha512-O7fdzcqIJ7i/+8SGYvx4tloTZgK4Ws8OChdbFcd2rZoRPqxM50M6J+Ota8hTet2wIhojUXnM3x2na3EvoucBXA==}
+  '@react-aria/datepicker@3.14.3':
+    resolution: {integrity: sha512-gDc+bM0EaY3BuIW8IJu/ARJV78bRpOaHp+B08EW4N2qJvc7Bs+EmGLnxMrB6Ny+YxNxsYdQRA/FqiytVYOEk8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/dialog@3.5.24':
-    resolution: {integrity: sha512-tw0WH89gVpHMI5KUQhuzRE+IYCc9clRfDvCppuXNueKDrZmrQKbeoU6d0b5WYRsBur2+d7ErtvpLzHVqE1HzfA==}
+  '@react-aria/dialog@3.5.25':
+    resolution: {integrity: sha512-hVP/TvjUnPgckg4qibc/TDH54O+BzW95hxApxBw1INyViRm95PxdCQDqBdQ/ZW7Gv6J2aUBCGihX7kINPf70ow==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/dnd@3.9.2':
-    resolution: {integrity: sha512-pPYygmJTjSPV2K/r48TvF75WuddG8d8nlIxAXSW22++WKqZ0z+eun6gDUXoKeB2rgY7sVfLqpRdnPV52AnBX+Q==}
+  '@react-aria/dnd@3.9.3':
+    resolution: {integrity: sha512-Sjb+UQxG58/paOZXsVKiqLautV4FyILr3tLxMG4Q04QOUzatqlz91APt7RsVMdizk6bVB7Lg74AEypHbXVzhDQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/focus@3.20.2':
-    resolution: {integrity: sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==}
+  '@react-aria/focus@3.20.3':
+    resolution: {integrity: sha512-rR5uZUMSY4xLHmpK/I8bP1V6vUNHFo33gTvrvNUsAKKqvMfa7R2nu5A6v97dr5g6tVH6xzpdkPsOJCWh90H2cw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/form@3.0.15':
-    resolution: {integrity: sha512-kk8AnLz+EOgnn3sTaXYmtw+YzVDc1of/+xAkuOupQi6zQFnNRjc99JlDbKHoUZ39urMl+8lsp/1b9VPPhNrBNw==}
+  '@react-aria/form@3.0.16':
+    resolution: {integrity: sha512-N1bDsJfmnyDesayK0Ii6UPH6JWiF6Wz8WSveQ2y5004XHoIWn5LpWmOqnRedvyw4Yedw33schlvrY7ENEwMdpg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/grid@3.13.0':
-    resolution: {integrity: sha512-RcuJYA4fyJ83MH3SunU+P5BGkx3LJdQ6kxwqwWGIuI9eUKc7uVbqvN9WN3fI+L0QfxqBFmh7ffRxIdQn7puuzw==}
+  '@react-aria/grid@3.14.0':
+    resolution: {integrity: sha512-/tJB7xnSruORJ8tlFHja4SfL8/EW5v4cBLiyD5z48m7IdG33jXR8Cv4Pi5uQqs8zKdnpqZ1wDG3GQxNDwZavpg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/gridlist@3.12.0':
-    resolution: {integrity: sha512-KSpnSBYQ7ozGQNaRR2NGq7Fl2zIv5w9KNyO9V/IE2mxUNfX6fwqUPoANFcy9ySosksE7pPnFtuYIB+TQtUjYqQ==}
+  '@react-aria/gridlist@3.13.0':
+    resolution: {integrity: sha512-RHURMo063qbbA8WXCJxGL+5xmSx6yW7Z/V2jycrVcZFOYqj2EgU953aVjpaT/FSyH8/AEioU9oE64YmiEfWUUA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/i18n@3.12.8':
-    resolution: {integrity: sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==}
+  '@react-aria/i18n@3.12.9':
+    resolution: {integrity: sha512-Fim0FLfY05kcpIILdOtqcw58c3sksvmVY8kICSwKCuSek4wYfwJdU28p/sRptw4adJhqN8Cbssvkf/J8zL2GgA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/interactions@3.25.0':
-    resolution: {integrity: sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==}
+  '@react-aria/interactions@3.25.1':
+    resolution: {integrity: sha512-ntLrlgqkmZupbbjekz3fE/n3eQH2vhncx8gUp0+N+GttKWevx7jos11JUBjnJwb1RSOPgRUFcrluOqBp0VgcfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/label@3.7.17':
-    resolution: {integrity: sha512-Fz7IC2LQT2Y/sAoV+gFEXoULtkznzmK2MmeTv5shTNjeTxzB1BhQbD4wyCypi7eGsnD/9Zy+8viULCsIUbvjWw==}
+  '@react-aria/label@3.7.18':
+    resolution: {integrity: sha512-Ht9D+xkI2Aysn+JNiHE+UZT4FUOGPF7Lfrmp7xdJCA/tEqqF3xW/pAh+UCNOnnWmH8jTYnUg3bCp4G6GQUxKCQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/link@3.8.0':
-    resolution: {integrity: sha512-gpDD6t3FqtFR9QjSIKNpmSR3tS4JG2anVKx2wixuRDHO6Ddexxv4SBzsE1+230p+FlFGjftFa2lEgQ7RNjZrmA==}
+  '@react-aria/link@3.8.1':
+    resolution: {integrity: sha512-ujq7+XIP7OXHu7m2NObvHsl41B/oIBAYI0D+hsxEQo3+x6Q/OUxp9EX2sX4d7TBWvchFmhr6jJdER0QMmeSO/A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/listbox@3.14.3':
-    resolution: {integrity: sha512-wzelam1KENUvKjsTq8gfrOW2/iab8SyIaSXfFvGmWW82XlDTlW+oQeA39tvOZktMVGspr+xp8FySY09rtz6UXw==}
+  '@react-aria/listbox@3.14.4':
+    resolution: {integrity: sha512-bW3D7KcnQIF77F3zDRMIGQ6e5e1wHTNUtbKJLE423u1Dhc7K2x0pksir0gLGwElhiBW544lY1jv3kFLOeKa6ng==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -1553,74 +1562,74 @@ packages:
   '@react-aria/live-announcer@3.4.2':
     resolution: {integrity: sha512-6+yNF9ZrZ4YJ60Oxy2gKI4/xy6WUv1iePDCFJkgpNVuOEYi8W8czff8ctXu/RPB25OJx5v2sCw9VirRogTo2zA==}
 
-  '@react-aria/menu@3.18.2':
-    resolution: {integrity: sha512-90k+Ke1bhFWhR2zuRI6OwKWQrCpOD99n+9jhG96JZJZlNo5lB+5kS+ufG1LRv5GBnCug0ciLQmPMAfguVsCjEQ==}
+  '@react-aria/menu@3.18.3':
+    resolution: {integrity: sha512-D0C4CM/QaxhCo2pLWNP+nfgnAeaSZWOdPMo9pnH/toRsoeTbnD6xO1hLhYsOx5ge+hrzjQvthjUrsjPB1AM/BQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/meter@3.4.22':
-    resolution: {integrity: sha512-A/30vrtJO0xqctS/ngE1Lp/w3Aq3MPcpdRHU5E06EUYotzRzHFE9sNmezWslkZ3NfYwA/mxLvgmrsOJSR0Hx6A==}
+  '@react-aria/meter@3.4.23':
+    resolution: {integrity: sha512-FgmB/+cTE/sz+wTpTSmj9hFXw4nzfMUJGvXIePnF6f5Gx6J/U7aLEvNk7sXCp76apOu8k7ccma1nCsEvj74x7w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/numberfield@3.11.13':
-    resolution: {integrity: sha512-F73BVdIRV8VvKl0omhGaf0E7mdJ7pdPjDP3wYNf410t55BXPxmndItUKpGfxSbl8k6ZYLvQyOqkD6oWSfZXpZw==}
+  '@react-aria/numberfield@3.11.14':
+    resolution: {integrity: sha512-UvhPlRwVmbNEBBqfgL41P10H1jL4C7P2hWqsVw72tZQJl5k5ujeOzRWk8mkmg+D4FCZvv4iSPJhmyEP8HkgsWg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/overlays@3.27.0':
-    resolution: {integrity: sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==}
+  '@react-aria/overlays@3.27.1':
+    resolution: {integrity: sha512-wepzwNLkgem6kVlLm6yk7zNIMAt0KPy8vAWlxdfpXWD/hBI30ULl71gL/BxRa5EYG1GMvlOwNti3whzy9lm3eQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/progress@3.4.22':
-    resolution: {integrity: sha512-wK2hath4C9HKgmjCH+iSrAs86sUKqqsYKbEKk9/Rj9rzXqHyaEK9EG0YZDnSjd8kX+N9hYcs5MfJl6AZMH4juQ==}
+  '@react-aria/progress@3.4.23':
+    resolution: {integrity: sha512-uSQBVY64k+CCey82U67KyWnjAfuuHF0fG6y76kIB8GHI8tGfd1NkXo4ioaxiY0SS+BYGqwqJYYMUzQMpOBTN1A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/radio@3.11.2':
-    resolution: {integrity: sha512-6AFJHXMewJBgHNhqkN1qjgwwx6kmagwYD+3Z+hNK1UHTsKe1Uud5/IF7gPFCqlZeKxA+Lvn9gWiqJrQbtD2+wg==}
+  '@react-aria/radio@3.11.3':
+    resolution: {integrity: sha512-o10G8RUuHnAGZYzkc5PQw7mj4LMZqmGkoihDeHF2NDa9h44Ce5oeCPwRvCKYbumZDOyDY15ZIZhTUzjHt2w6fA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/searchfield@3.8.3':
-    resolution: {integrity: sha512-t1DW3nUkPHyZhFhUbT+TdhvI8yZYvUPCuwl0FyraMRCQ4+ww5Ieu4n8JB9IGYmIUB/GWEbZlDHplu4s3efmliA==}
+  '@react-aria/searchfield@3.8.4':
+    resolution: {integrity: sha512-WnAvU9ct8+Asb8FFhGw6bggBmRaPe9qZPgYacenmRItwN+7UVTwEBVB9umO2bN3PLGm3CKgop10znd6ATiAbJA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/select@3.15.4':
-    resolution: {integrity: sha512-CipqXgdOfWsiHw/chfqd8t9IQpvehP+3uKLJx3ic4Uyj+FT/SxVmmjX0gyvVbZd00ltFCMJYO2xYKQUlbW2AtQ==}
+  '@react-aria/select@3.15.5':
+    resolution: {integrity: sha512-2v8QmcPsZzlOjc/zsLbMcKeMKZoa+FZboxfjq4koUXtuaLhgopENChkfPLaXEGxqsejANs4dAoqiOiwwrGAaLQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/selection@3.24.0':
-    resolution: {integrity: sha512-RfGXVc04zz41NVIW89/a3quURZ4LT/GJLkiajQK2VjhisidPdrAWkcfjjWJj0n+tm5gPWbi9Rs5R/Rc8mrvq8Q==}
+  '@react-aria/selection@3.24.1':
+    resolution: {integrity: sha512-nHUksgjg92iHgseH9L+krk9rX19xGJLTDeobKBX7eoAXQMqQjefu+oDwT0VYdI/qqNURNELE/KPZIVLC4PB81w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/separator@3.4.8':
-    resolution: {integrity: sha512-ncuOSTBF/qbNumnW/IRz+xyr+Ud85eCF0Expw4XWhKjAZfzJd86MxPY5ZsxE7pYLOcRWdOSIH1/obwwwSz8ALQ==}
+  '@react-aria/separator@3.4.9':
+    resolution: {integrity: sha512-5ZKVQ/5I2+fw8WyVCQLGjQKsMKlTIieLPf8NvdC24a+pmiUluyUuqfPYdI8s6lcnjG0gbOzZB+jKvDRQbIvMPQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/slider@3.7.18':
-    resolution: {integrity: sha512-GBVv5Rpvj/6JH2LnF1zVAhBmxGiuq7R8Ekqyr5kBrCc2ToF3PrTjfGc/mlh0eEtbj+NvAcnlgTx1/qosYt1sGw==}
+  '@react-aria/slider@3.7.19':
+    resolution: {integrity: sha512-GONrMMz9zsx0ySbUTebWdqRjAuu6EEW+lLf3qUzcqkIYR8QZVTS8RLPt7FmGHKCTDIaBs8D2yv9puIfKAo1QAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/spinbutton@3.6.14':
-    resolution: {integrity: sha512-oSKe9p0Q/7W39eXRnLxlwJG5dQo4ffosRT3u2AtOcFkk2Zzj+tSQFzHQ4202nrWdzRnQ2KLTgUUNnUvXf0BJcg==}
+  '@react-aria/spinbutton@3.6.15':
+    resolution: {integrity: sha512-dVKaRgrSU2utxCd4kqAA8BPrC1PVI1eiJ8gvlVbg25LbwK4dg1WPXQUK+80TbrJc9mOEooPiJvzw59IoQLMNRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -1631,186 +1640,196 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/switch@3.7.2':
-    resolution: {integrity: sha512-vaREbp1gFjv+jEMXoXpNK7JYFO/jhwnSYAwEINNWnwf54IGeHvTPaB2NwolYSFvP4HAj8TKYbGFUSz7RKLhLgw==}
+  '@react-aria/switch@3.7.3':
+    resolution: {integrity: sha512-tFdJmcHaLgW23cS2R713vcJdVbsjDTRk8OLdG/sMziPBY3C00/exuSIb57xTS7KrE0hBYfnLJQTcmDNqdM8+9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/table@3.17.2':
-    resolution: {integrity: sha512-wsF3JqiAKcol1sfeNqTxyzH6+nxu0sAfyuh+XQfp1tvSGx15NifYeNKovNX4EPpUVkAI7jL5Le+eYeYYGELfnw==}
+  '@react-aria/table@3.17.3':
+    resolution: {integrity: sha512-hs3akyNMeeAPIfa+YKMxJyupSjywW5OGzJtOw/Z0j6pV8KXSeMEXNYkSuJY+m5Q1mdunoiiogs0kE3B0r2izQA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/tabs@3.10.2':
-    resolution: {integrity: sha512-rpEgh//Gnew3le49tQVFOQ6ZyacJdaNUDXHt0ocguXb+2UrKtH54M8oIAE7E8KaB1puQlFXRs+Rjlr1rOlmjEQ==}
+  '@react-aria/tabs@3.10.3':
+    resolution: {integrity: sha512-TYfwaRrI0mQMefmoHeTKXdczpb53qpPr+3nnveGl+BocG94wmjIqK6kncboVbPdykgQCIAMd2d9GFpK01+zXrA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/tag@3.5.2':
-    resolution: {integrity: sha512-xZ5Df0x+xcDg6UTDvnjP4pu+XrmYVaYcqzF7RGoCD1KyRCHU5Czg9p+888NB0K+vnJHfNsQh6rmMhDUydXu9eg==}
+  '@react-aria/tag@3.6.0':
+    resolution: {integrity: sha512-OkLyFYTFVUYB339eugw2r6vIcrWq47O15x4sKNkDUo6YBx9ci9tdoib4DlzwuiiKVr/vmw1WMow6VK4zOtuLng==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/textfield@3.17.2':
-    resolution: {integrity: sha512-4KINB0HueYUHUgvi/ThTP27hu4Mv5ujG55pH3dmSRD4Olu/MRy1m/Psq72o8LTf4bTOM9ZP1rKccUg6xfaMidA==}
+  '@react-aria/textfield@3.17.3':
+    resolution: {integrity: sha512-p/Z0fyE0CnzIrnCf42gxeSCNYon7//XkcbPwUS4U9dz2VLk2GnEn9NZXPYgTp+08ebQEn0pB1QIchX79yFEguw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/toggle@3.11.2':
-    resolution: {integrity: sha512-JOg8yYYCjLDnEpuggPo9GyXFaT/B238d3R8i/xQ6KLelpi3fXdJuZlFD6n9NQp3DJbE8Wj+wM5/VFFAi3cISpw==}
+  '@react-aria/toggle@3.11.3':
+    resolution: {integrity: sha512-S6ShToNR6TukRJh8qDdyl9b2Bcsx43eurUB5USANn4ycPov8+bIxQnxiknjssZx7jD8vX4jruuNh7BjFbNsGFw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/toolbar@3.0.0-beta.15':
-    resolution: {integrity: sha512-PNGpNIKIsCW8rxI9XXSADlLrSpikILJKKECyTRw9KwvXDRc44pezvdjGHCNinQcKsQoy5BtkK5cTSAyVqzzTXQ==}
+  '@react-aria/toolbar@3.0.0-beta.16':
+    resolution: {integrity: sha512-TnNvtxADalMzs9Et51hWPpGyiHr1dt++UYR7pIo1H7vO+HwXl6uH4HxbFDS5CyV69j2cQlcGrkj13LoWFkBECw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/tooltip@3.8.2':
-    resolution: {integrity: sha512-ctVTgh1LXvmr1ve3ehAWfvlJR7nHYZeqhl/g1qnA+983LQtc1IF9MraCs92g0m7KpBwCihuA+aYwTPsUHfKfXg==}
+  '@react-aria/tooltip@3.8.3':
+    resolution: {integrity: sha512-8JHRqffH5vUw7og6mlCRzb4h95/R5RpOxGFfEGw7aami14XMo6tZg7wMgwDUAEiVqNerRWYaw+tk7nCUQXo1Sg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/utils@3.28.2':
-    resolution: {integrity: sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==}
+  '@react-aria/utils@3.29.0':
+    resolution: {integrity: sha512-jSOrZimCuT1iKNVlhjIxDkAhgF7HSp3pqyT6qjg/ZoA0wfqCi/okmrMPiWSAKBnkgX93N8GYTLT3CIEO6WZe9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/visually-hidden@3.8.22':
-    resolution: {integrity: sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==}
+  '@react-aria/visually-hidden@3.8.23':
+    resolution: {integrity: sha512-D37GHtAcxCck8BtCiGTNDniGqtldJuN0cRlW1PJ684zM4CdmkSPqKbt5IUKUfqheS9Vt7HxYsj1VREDW+0kaGA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/calendar@3.8.0':
-    resolution: {integrity: sha512-YAuJiR9EtVThX91gU2ay/6YgPe0LvZWEssu4BS0Atnwk5cAo32gvF5FMta9ztH1LIULdZFaypU/C1mvnayMf+Q==}
+  '@react-stately/calendar@3.8.1':
+    resolution: {integrity: sha512-pTPRmPRD/0JeKhCRvXhVIH/yBimtIHnZGUxH12dcTl3MLxjXQDTn6/LWK0s4rzJcjsC+EzGUCVBBXgESb7PUlw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/checkbox@3.6.13':
     resolution: {integrity: sha512-b8+bkOhobzuJ5bAA16JpYg1tM973eNXD3U4h/8+dckLndKHRjIwPvrL25tzKN7NcQp2LKVCauFesgI+Z+/2FJg==}
+  '@react-stately/checkbox@3.6.14':
+    resolution: {integrity: sha512-eGl0GP/F/nUrA33gDCYikyXK+Yer7sFOx8T4EU2AF4E8n1VQIRiVNaxDg7Ar6L3CMKor01urppFHFJsBUnSgyw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/collections@3.12.3':
     resolution: {integrity: sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==}
+  '@react-stately/collections@3.12.4':
+    resolution: {integrity: sha512-H+47fRkwYX2/BdSA+NLTzbR+8QclZXyBgC7tHH3dzljyxNimhrMDnbmk520nvGCebNf3nuxtFHq9iVTLpazSVA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/color@3.8.4':
     resolution: {integrity: sha512-LXmfnJPWnL5q1/Z8Pn2d+9efrClLWCiK6c3IGXN8ZWcdR/cMJ/w9SY9f7evyXvmeUmdU1FTGgoSVqGfup3tSyA==}
+  '@react-stately/color@3.8.5':
+    resolution: {integrity: sha512-yi1MQAbYuAYKu0AtMO+mWQWlWk6OzGMa9j4PGtQN2PI5Uv1NylWOvdquxbUJ4GUAuSYNopYG8Ci9MZMwtito8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/combobox@3.10.4':
     resolution: {integrity: sha512-sgujLhukIGKskLDrOL4SAbO7WOgLsD7gSdjRQZ0f/e8bWMmUOWEp22T+X1hMMcuVRkRdXlEF1kH2/E6BVanXYw==}
+  '@react-stately/combobox@3.10.5':
+    resolution: {integrity: sha512-27SkClMqbMAKuVnmXhYzYisbLfzV7MO/DEiqWO4/3l+PZ+whL7Wi/Ek7Wqlfluid/y4pN4EkHCKNt4HJ2mhORQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/data@3.12.3':
     resolution: {integrity: sha512-JYPNV1gd9OZm8xPay0exx5okFNgiwESNvdBHsfDC+f8BifRyFLdrvoaUGF0enKIeSQMB1oReFAxTAXtDZd27rA==}
+  '@react-stately/data@3.13.0':
+    resolution: {integrity: sha512-7LYPxVbWB6tvmLYKO19H5G5YtXV6eKCSXisOUiL9fVnOcGOPDK5z310sj9TP5vaX7zVPtwy0lDBUrZuRfhvQIQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/datepicker@3.14.0':
-    resolution: {integrity: sha512-JSkQfKW0+WpPQyOOeRPBLwXkVfpTUwgZJDnHBCud5kEuQiFFyeAIbL57RNXc4AX2pzY3piQa6OHnjDGTfqClxQ==}
+  '@react-stately/datepicker@3.14.1':
+    resolution: {integrity: sha512-ad3IOrRppy/F8FZpznGacsaWWHdzUGZ4vpymD+y6TYeQ+RQvS9PLA5Z1TanH9iqLZgkf6bvVggJFg/hhDh2hmg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/dnd@3.5.3':
-    resolution: {integrity: sha512-e4IodPF7fv9hR6jqSjiyrrFQ/6NbHNM5Ft1MJzCu6tJHvT+sl6qxIP5A+XR3wkjMpi4QW2WhVUmoFNbS/6ZAug==}
+  '@react-stately/dnd@3.5.4':
+    resolution: {integrity: sha512-YkvkehpsSeGZPH7S7EYyLchSxZPhzShdf9Zjh6UAsM7mAcxjRsChMqsf6zuM+l0jgMo40Ka1mvwDYegz92Qkyg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-stately/flags@3.1.1':
     resolution: {integrity: sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==}
 
-  '@react-stately/form@3.1.3':
-    resolution: {integrity: sha512-Jisgm0facSS3sAzHfSgshoCo3LxfO0wmQj98MOBCGXyVL+MSwx2ilb38eXIyBCzHJzJnPRTLaK/E4T49aph47A==}
+  '@react-stately/form@3.1.4':
+    resolution: {integrity: sha512-A6GOaZ9oEIo5/XOE+JT9Z8OBt0osIOfes4EcIxGS1C9ght/Smg0gNcIJ2/Wle8qmro4RoJcza2yJ+EglVOuE0w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/grid@3.11.1':
-    resolution: {integrity: sha512-xMk2YsaIKkF8dInRLUFpUXBIqnYt88hehhq2nb65RFgsFFhngE/OkaFudSUzaYPc1KvHpW+oHqvseC+G1iDG2w==}
+  '@react-stately/grid@3.11.2':
+    resolution: {integrity: sha512-P0vfK5B1NW8glYD6QMrR2X/7UMXx2J8v48QIQV6KgLZjFbyXhzRb+MY0BoIy4tUfJL0yQU2GKbKKVSUIQxbv0g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/list@3.12.1':
-    resolution: {integrity: sha512-N+YCInNZ2OpY0WUNvJWUTyFHtzE5yBtZ9DI4EHJDvm61+jmZ2s3HszOfa7j+7VOKq78VW3m5laqsQNWvMrLFrQ==}
+  '@react-stately/list@3.12.2':
+    resolution: {integrity: sha512-XPGvdPidOV4hnpmaUNc4C/1jX7ZhBwmAI9p6bEXDA3du3XrWess6MWcaQvPxXbrZ6ZX8/OyOC2wp7ixJoJRGyA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/menu@3.9.3':
-    resolution: {integrity: sha512-9x1sTX3Xq2Q3mJUHV+YN9MR36qNzgn8eBSLa40eaFDaOOtoJ+V10m7OriUfpjey7WzLBpq00Sfda54/PbQHZ0g==}
+  '@react-stately/menu@3.9.4':
+    resolution: {integrity: sha512-sqYcSBuTEtCebZuByUou2aZzwlnrrOlrvmGwFNJy49N3LXXXPENCcCERuWa8TE9eBevIVTQorBZlID6rFG+wdQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/numberfield@3.9.11':
-    resolution: {integrity: sha512-gAFSZIHnZsgIWVPgGRUUpfW6zM7TCV5oS1SCY90ay5nrS7JCXurQbMrWJLOWHTdM5iSeYMgoyt68OK5KD0KHMw==}
+  '@react-stately/numberfield@3.9.12':
+    resolution: {integrity: sha512-E56RuRRdu/lzd8e5aEifP4n8CL/as0sZqIQFSyMv/ZUIIGeksqy+zykzo01skaHKY8u2NixrVHPVDtvPcRuooA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/overlays@3.6.15':
-    resolution: {integrity: sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==}
+  '@react-stately/overlays@3.6.16':
+    resolution: {integrity: sha512-+Ve/TBlUNg3otVC4ZfCq1a8q8FwC7xNebWkVOCGviTqiYodPCGqBwR9Z1xonuFLF/HuQYqALHHTOZtxceU+nVQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/radio@3.10.12':
-    resolution: {integrity: sha512-hFH45CXVa7uyXeTYQy7LGR0SnmGnNRx7XnEXS25w4Ch6BpH8m8SAbhKXqysgcmsE3xrhRas7P9zWw7wI24G28Q==}
+  '@react-stately/radio@3.10.13':
+    resolution: {integrity: sha512-q7UKcVYY7rqpxKfYRzvKVEqFhxElDFX2c+xliZQtjXuSexhxRb2xjEh+bDkhzbXzrJkrBT6VmE/rSYPurC3xTw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/searchfield@3.5.11':
-    resolution: {integrity: sha512-vOgK3kgkYcyjTLsBABVzoQL9w6qBamnWAQICcw5OkA6octnF7NZ5DqdjkwnMY95KOGchiTlD5tNNHrz0ekeGiw==}
+  '@react-stately/searchfield@3.5.12':
+    resolution: {integrity: sha512-RC3QTEPVNUbgtuqzpwPUfbV9UkUC1j4XkHoynWDbMt0bE0tPe2Picnl0/r/kq6MO527idV6Ur4zuOF4x9a97LQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/select@3.6.12':
-    resolution: {integrity: sha512-5o/NAaENO/Gxs1yui5BHLItxLnDPSQJ5HDKycuD0/gGC17BboAGEY/F9masiQ5qwRPe3JEc0QfvMRq3yZVNXog==}
+  '@react-stately/select@3.6.13':
+    resolution: {integrity: sha512-saZo67CreQZPdmqvz9+P6N4kjohpwdVncH98qBi0Q2FvxGAMnpJQgx97rtfDvnSziST5Yx1JnMI4kSSndbtFwg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/selection@3.20.1':
-    resolution: {integrity: sha512-K9MP6Rfg2yvFoY2Cr+ykA7bP4EBXlGaq5Dqfa1krvcXlEgMbQka5muLHdNXqjzGgcwPmS1dx1NECD15q63NtOw==}
+  '@react-stately/selection@3.20.2':
+    resolution: {integrity: sha512-Fw6nnG+VKMsncsY4SNxGYOhnHojVFzFv+Uhy6P39QBp6AXtSaRKMg2VR4MPxQ7XgOjHh5ZuSvCY1RwocweqjwQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/slider@3.6.3':
-    resolution: {integrity: sha512-755X1jhpRD1bqf/5Ax1xuSpZbnG/0EEHGOowH28FLYKy5+1l4QVDGPFYxLB9KzXPdRAr9EF0j2kRhH2d8MCksQ==}
+  '@react-stately/slider@3.6.4':
+    resolution: {integrity: sha512-6SdG0VJZLMRIBnPjqkbIsdyQcW9zJ5Br716cl/7kLT9owiIwMJiAdjdYHab5+8ShWzU2D8Ae+LdQk8ZxIiIjkg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/table@3.14.1':
-    resolution: {integrity: sha512-7P5h4YBAv3B/7BGq/kln+xSKgJCSq4xjt4HmJA7ZkGnEksUPUokBNQdWwZsy3lX/mwunaaKR9x/YNIu7yXB02g==}
+  '@react-stately/table@3.14.2':
+    resolution: {integrity: sha512-SqE5A/Ve5H2ApnAblMGBMGRzY7cgdQmNPzXB8tGVc38NsC/STmMkq9m54gAl8dBVNbLzzd6HJBe9lqz5keYIhQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/tabs@3.8.1':
-    resolution: {integrity: sha512-1TBbt2BXbemstb/gEYw/NVt3esi5WvgWQW5Z7G8nDzLkpnMHOZXueoUkMxsdm0vhE8p0M9fsJQCMXKvCG3JzJg==}
+  '@react-stately/tabs@3.8.2':
+    resolution: {integrity: sha512-lNpby7zUVdAeqo3mjGdPBxppEskOLyqR82LWBtP8Xg4olnjA5RmDFOuoJkIFttDX689zamjN3OE+Ra6WWgJczg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/toggle@3.8.3':
-    resolution: {integrity: sha512-4T2V3P1RK4zEFz4vJjUXUXyB0g4Slm6stE6Ry20fzDWjltuW42cD2lmrd7ccTO/CXFmHLECcXQLD4GEbOj0epA==}
+  '@react-stately/toggle@3.8.4':
+    resolution: {integrity: sha512-JbKoXhkJ5P5nCrNXChMos3yNqkIeGXPDEMS/dfkHlsjQYxJfylRm4j/nWoDXxxkUmfkvXcNEMofMn9iO1+H0DQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/tooltip@3.5.3':
-    resolution: {integrity: sha512-btfy/gQ3Eccudx//4HkyQ+CRr3vxbLs74HYHthaoJ9GZbRj/3XDzfUM2X16zRoqTZVrIz/AkUj7AfGfsitU5nQ==}
+  '@react-stately/tooltip@3.5.4':
+    resolution: {integrity: sha512-HxNTqn9nMBuGbEVeeuZyhrzNbyW7sgwk+8o0mN/BrMrk7E/UBhyL2SUxXnAUQftpTjX+29hmx1sPhIprIDzR3Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/tree@3.8.9':
-    resolution: {integrity: sha512-j/LLI9UvbqcfOdl2v9m3gET3etUxoQzv3XdryNAbSkg0jTx8/13Fgi/Xp98bUcNLfynfeGW5P/fieU71sMkGog==}
+  '@react-stately/tree@3.8.10':
+    resolution: {integrity: sha512-sMqBRKAAZMiXJwlzAFpkXqUaGlNBfKnL8usAiKdoeGcLLJt2Ni9gPoPOLBJSPqLOAFCgLWtr5IYjdhel9aXRzQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -1819,133 +1838,133 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/breadcrumbs@3.7.12':
-    resolution: {integrity: sha512-+LvGEADlv11mLQjxEAZriptSYJJTP+2OIFEKx0z9mmpp+8jTlEHFhAnRVaE6I9QCxcDB5F6q/olfizSwOPOMIg==}
+  '@react-types/breadcrumbs@3.7.13':
+    resolution: {integrity: sha512-x94KEZaLIeHt9lqAkuaOopX5+rqCTMSHsciThUsBHK7QT64zrw6x2G1WKQ4zB4h52RGF5b+3sFXeR4bgX2sVLQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/button@3.12.0':
-    resolution: {integrity: sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==}
+  '@react-types/button@3.12.1':
+    resolution: {integrity: sha512-z87stl4llWTi4C5qhUK1PKcEsG59uF/ZQpkRhMzX0KfgXobJY6yiIrry2xrpnlTPIVST6K1+kARhhSDOZ8zhLw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/calendar@3.7.0':
-    resolution: {integrity: sha512-RiEfX2ZTcvfRktQc5obOJtNTgW+UwjNOUW5yf9CLCNOSM07e0w5jtC1ewsOZZbcctMrMCljjL8niGWiBv1wQ1Q==}
+  '@react-types/calendar@3.7.1':
+    resolution: {integrity: sha512-a/wGT9vZewPNL72Xni8T/gv4IS2w6iRtryqMF425OL+kaCQrxJYlkDxb74bQs9+k9ZYabrxJgz9vFcFnY7S9gw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/checkbox@3.9.3':
-    resolution: {integrity: sha512-h6wmK7CraKHKE6L13Ut+CtnjRktbMRhkCSorv7eg82M6p4PDhZ7mfDSh13IlGR4sryT8Ka+aOjOU+EvMrKiduA==}
+  '@react-types/checkbox@3.9.4':
+    resolution: {integrity: sha512-fU3Q1Nw+zbXKm68ba8V7cQzpiX0rIiAUKrBTl2BK97QiTlGBDvMCf4TfEuaNoGbJq+gx+X3n/3yr6c3IAb0ZIg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/color@3.0.4':
-    resolution: {integrity: sha512-D6Uea8kYGaoZRHgemJ0b0+iXbrvABP8RzsctL8Yp5QVyGgYJDMO8/7eZ3tdtGs/V8Iv+yCzG4yBexPA95i6tEg==}
+  '@react-types/color@3.0.5':
+    resolution: {integrity: sha512-72uZ0B3EcaC2DGOpnhwHSVxcvQ3UDNSVR2gVx7PgUCGlEjhnn9i0UErIP8ZzV2RsAvjK6MrGs7ZCwZtl+LxCcg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/combobox@3.13.4':
-    resolution: {integrity: sha512-4mX7eZ/Bv3YWzEzLEZAF/TfKM+I+SCsvnm/cHqOJq3jEE8aVU1ql4Q1+3+SvciX3pfFIfeKlu9S3oYKRT5WIgg==}
+  '@react-types/combobox@3.13.5':
+    resolution: {integrity: sha512-wqHBF0YDkrp4Ylyxpd3xhnDECe5eao27bsu+4AvjlVKtaxaoppNq2MwSzkuSSS/GEUXT6K9DDjrGFcp07ad5gA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/datepicker@3.12.0':
-    resolution: {integrity: sha512-dw/xflOdQPQ3uEABaBrZRTvjsMRu5/VZjRx9ygc64sX2N7HKIt+foMPXKJ+1jhtki2p4gigNVjcnJndJHoj9SA==}
+  '@react-types/datepicker@3.12.1':
+    resolution: {integrity: sha512-+wv57fVd6Y/+KnHNEmVzfrQtWs85Ga1Xb63AIkBk+E294aMqFYqRg0dQds6V/qrP758TWnXUrhKza1zMbjHalw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/dialog@3.5.17':
-    resolution: {integrity: sha512-rKe2WrT272xuCH13euegBGjJAORYXJpHsX2hlu/f02TmMG4nSLss9vKBnY2N7k7nci65k5wDTW6lcsvQ4Co5zQ==}
+  '@react-types/dialog@3.5.18':
+    resolution: {integrity: sha512-g18CzT5xmiX/numpS6MrOGEGln8Xp9rr+zO70Dg+jM4GBOjXZp3BeclYQr9uisxGaj2uFLnORv9gNMMKxLNF6A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/grid@3.3.1':
-    resolution: {integrity: sha512-bPDckheJiHSIzSeSkLqrO6rXRLWvciFJr9rpCjq/+wBj6HsLh2iMpkB/SqmRHTGpPlJvlu0b7AlxK1FYE0QSKA==}
+  '@react-types/grid@3.3.2':
+    resolution: {integrity: sha512-NwfydUbPc1zVi/Rp7+oRN2+vE1xMokc2J+nr0VcHwFGt1bR1psakHu45Pk/t763BDvPr/A3xIHc1rk3eWEhxJw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/link@3.6.0':
-    resolution: {integrity: sha512-BQ5Tktb+fUxvtqksAJZuP8Z/bpmnQ/Y/zgwxfU0OKmIWkKMUsXY+e0GBVxwFxeh39D77stpVxRsTl7NQrjgtSw==}
+  '@react-types/link@3.6.1':
+    resolution: {integrity: sha512-IZDSc10AuVKe7V8Te+3q8d220oANE4N43iljQe3yHg7GZOfH/51bv8FPUukreLs1t2fgtGeNAzG71Ep+j/jXIw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/listbox@3.6.0':
-    resolution: {integrity: sha512-+1ugDKTxson/WNOQZO4BfrnQ6cGDt+72mEytXMsSsd4aEC+x3RyUv6NKwdOl4n602cOreo0MHtap1X2BOACVoQ==}
+  '@react-types/listbox@3.7.0':
+    resolution: {integrity: sha512-26Lp0Gou502VJLDSrIpMg7LQuVHznxzyuSY/zzyNX9eopukXvHn682u90fwDqgmZz7dzxUOWtuwDea+bp/UjtA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/menu@3.10.0':
-    resolution: {integrity: sha512-DKMqEmUmarVCK0jblNkSlzSH53AAsxWCX9RaKZeP9EnRs2/l1oZRuiQVHlOQRgYwEigAXa2TrwcX4nnxZ+U36Q==}
+  '@react-types/menu@3.10.1':
+    resolution: {integrity: sha512-wkyWzIqaCbUYiD7YXr8YvdimB1bxQHqgj6uE4MKzryCbVqb4L8fRUM0V6AHkQS1TxBYNkNn1h4g7XNd5Vmyf3Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/meter@3.4.8':
-    resolution: {integrity: sha512-uXmHdUDbAo7L3EkytrUrU6DLOFUt63s9QSTcDp+vwyWoshY4/4Dm4JARdmhJU2ZP1nb2Sy45ASeMvSBw3ia2oA==}
+  '@react-types/meter@3.4.9':
+    resolution: {integrity: sha512-Jhd873zc/Bx/86NB9nasMUWc013VnURVtMYbbkuRWiFr/ZoEvZzO1uoSIXf+Sob4xpiVhT/ltvJZTK4t4B9lTg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/numberfield@3.8.10':
-    resolution: {integrity: sha512-mdb4lMC4skO8Eqd0GeU4lJgDTEvqIhtINB5WCzLVZFrFVuxgWDoU5otsu0lbWhCnUA7XWQxupGI//TC1LLppjQ==}
+  '@react-types/numberfield@3.8.11':
+    resolution: {integrity: sha512-D66Bop7M3JKzBV2vsECsVYfPrx8eRIx4/K2KLo/XjwMA7C34+Ou07f/bnD1TQQ/wr6XwiFxZTi6JsKDwnST+9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/overlays@3.8.14':
-    resolution: {integrity: sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==}
+  '@react-types/overlays@3.8.15':
+    resolution: {integrity: sha512-ppDfezvVYOJDHLZmTSmIXajxAo30l2a1jjy4G65uBYy8J8kTZU7mcfQql5Pii1TwybcNMsayf2WtPItiWmJnOA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/progress@3.5.11':
-    resolution: {integrity: sha512-CysuMld/lycOckrnlvrlsVoJysDPeBnUYBChwtqwiv4ZNRXos+wgAL1ows6dl7Nr57/FH5B4v5gf9AHEo7jUvw==}
+  '@react-types/progress@3.5.12':
+    resolution: {integrity: sha512-wvhFz6vdlfKBtnzKvD/89N+0PF3yPQ+IVFRQvZ2TBrP7nF+ZA2pNLcZVcEYbKjHzmvEZRGu//ePC9hRJD9K30w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/radio@3.8.8':
-    resolution: {integrity: sha512-QfAIp+0CnRSnoRTJVXUEPi+9AvFvRzWLIKEnE9OmgXjuvJCU3QNiwd8NWjNeE+94QBEVvAZQcqGU+44q5poxNg==}
+  '@react-types/radio@3.8.9':
+    resolution: {integrity: sha512-l4uzlxmGGuR8IkWrMYdKj1sc3Pgo/LdfEGuIgK+d8kjPu0AZcnSgp5Oz035bCosZUabY6dEWxQHIoAH2zN7YZA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/searchfield@3.6.1':
-    resolution: {integrity: sha512-XR4tYktxHxGJufpO0MTAPknIbmN5eZqXCZwTdBS4tecihf9iGDsXmrBOs+M7LEnil67GaZcFrMhKxOMVpLwZAg==}
+  '@react-types/searchfield@3.6.2':
+    resolution: {integrity: sha512-XQRQyJLNC9uLyCq+97eiqeQuM6+dCMrHu6aH6KSVt1Xh6HMmdx/TdSf6JrMkN+1xSxcW3lDE2iSf3jXDT87gag==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/select@3.9.11':
-    resolution: {integrity: sha512-uEpQCgDlrq/5fW05FgNEsqsqpvZVKfHQO9Mp7OTqGtm4UBNAbcQ6hOV7MJwQCS25Lu2luzOYdgqDUN8eAATJVQ==}
+  '@react-types/select@3.9.12':
+    resolution: {integrity: sha512-qo+9JS1kfMxuibmSmMp0faGKbeVftYnSk1f7Rh5PKi4tzMe3C0A9IAr27hUOfWeJMBOdetaoTpYmoXW6+CgW3g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/shared@3.29.0':
-    resolution: {integrity: sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==}
+  '@react-types/shared@3.29.1':
+    resolution: {integrity: sha512-KtM+cDf2CXoUX439rfEhbnEdAgFZX20UP2A35ypNIawR7/PFFPjQDWyA2EnClCcW/dLWJDEPX2U8+EJff8xqmQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/slider@3.7.10':
-    resolution: {integrity: sha512-Yb8wbpu2gS7AwvJUuz0IdZBRi6eIBZq32BSss4UHX0StA8dtR1/K4JeTsArxwiA3P0BA6t0gbR6wzxCvVA9fRw==}
+  '@react-types/slider@3.7.11':
+    resolution: {integrity: sha512-uNhNLhVrt/2teXBOJSoZXyXg308A72qe1HOmlGdJcnh8iXA35y5ZHzeK1P6ZOJ37Aeh7bYGm3/UdURmFgSlW7w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/switch@3.5.10':
-    resolution: {integrity: sha512-YyNhx4CvuJ0Rvv7yMuQaqQuOIeg+NwLV00NHHJ+K0xEANSLcICLOLPNMOqRIqLSQDz5vDI705UKk8gVcxqPX5g==}
+  '@react-types/switch@3.5.11':
+    resolution: {integrity: sha512-PJbZHwlE98OSuLzI6b1ei6Qa+FaiwlCRH3tOTdx/wPSdqmD3mRWEn7E9ftM6FC8hnxl/LrGLszQMT62yEQp5vQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/table@3.12.0':
-    resolution: {integrity: sha512-dmTzjCYwHf2HBOeTa/CEL177Aox0f0mkeLF5nQw/2z6SBolfmYoAwVTPxTaYFVu4MkEJxQTz9AuAsJvCbRJbhg==}
+  '@react-types/table@3.13.0':
+    resolution: {integrity: sha512-kn+OsEWJfUSSb4N4J0yl+tqx5grDpcaWcu2J8hA62hQCr/Leuj946ScYaKA9a/p0MAaOAaeCWx/Zcss6F8gJIQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/tabs@3.3.14':
-    resolution: {integrity: sha512-/uKsA7L2dctKU0JEaBWerlX+3BoXpKUFr3kHpRUoH66DSGvAo34vZ7kv/BHMZifJenIbF04GhDBsGp1zjrQKBg==}
+  '@react-types/tabs@3.3.15':
+    resolution: {integrity: sha512-VLgh9YLQdS4FQSk0sGTNHEVN2jeC0fZvOqEFHaEDgDyDgVOukxYuHjqVIx2IavYu1yNBrGO2b6P4M6dF+hcgwQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/textfield@3.12.1':
-    resolution: {integrity: sha512-6YTAMCKjEGuXg0A4bZA77j5QJ1a6yFviMUWsCIL6Dxq5K3TklzVsbAduSbHomPPuvkNTBSW4+TUJrVSnoTjMNA==}
+  '@react-types/textfield@3.12.2':
+    resolution: {integrity: sha512-dMm0cGLG5bkJYvt6lqXIty5HXTZjuIpa9I8jAIYua//J8tESAOE9BA285Zl43kx7cZGtgrHKHVFjITDLNUrNhA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/tooltip@3.4.16':
-    resolution: {integrity: sha512-XEyKeqR3YxqJcR0cpigLGEBeRTEzrB0cu++IaADdqXJ8dBzS6s8y9EgR5UvKZmX1CQOBvMfXyYkj7nmJ039fOw==}
+  '@react-types/tooltip@3.4.17':
+    resolution: {integrity: sha512-yjySKA1uzJAbio+xGv03DUoWIajteqtsXMd4Y3AJEdBFqSYhXbyrgAxw0oJDgRAgRxY4Rx5Hrhvbt/z7Di94QQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -2123,8 +2142,8 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+  '@tanstack/react-table@8.11.8':
+    resolution: {integrity: sha512-NEwvIq4iSiDQozEyvbdiSdCOiLa+g5xHmdEnvwDb98FObcK6YkBOkRrs/CNqrKdDy+/lqoIllIWHk+M80GW6+g==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
@@ -6916,8 +6935,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-isomorphic-layout-effect@1.2.0:
-    resolution: {integrity: sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==}
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8188,7 +8207,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@internationalized/date@3.8.0':
+  '@internationalized/date@3.8.1':
     dependencies:
       '@swc/helpers': 0.5.13
 
@@ -8197,7 +8216,7 @@ snapshots:
       '@swc/helpers': 0.5.13
       intl-messageformat: 10.5.14
 
-  '@internationalized/number@3.6.1':
+  '@internationalized/number@3.6.2':
     dependencies:
       '@swc/helpers': 0.5.13
 
@@ -8304,7 +8323,7 @@ snapshots:
 
   '@neo4j-ndl/base@3.4.2': {}
 
-  '@neo4j-ndl/react@3.5.5(@neo4j-ndl/base@3.4.2)(@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@neo4j-ndl/react@3.5.5(@neo4j-ndl/base@3.4.2)(@tanstack/react-table@8.11.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -8312,7 +8331,7 @@ snapshots:
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@heroicons/react': 2.1.5(react@18.3.1)
       '@neo4j-ndl/base': 3.4.2
-      '@tanstack/react-table': 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-table': 8.11.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames: 2.5.1
       date-fns: 4.1.0
       detect-browser: 5.3.0
@@ -8447,253 +8466,253 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-aria/breadcrumbs@3.5.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/breadcrumbs@3.5.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/link': 3.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/breadcrumbs': 3.7.12(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/link': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/breadcrumbs': 3.7.13(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/button@3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/button@3.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/toolbar': 3.0.0-beta.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.3(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/toolbar': 3.0.0-beta.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/toggle': 3.8.4(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/calendar@3.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/calendar@3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@internationalized/date': 3.8.1
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/calendar': 3.8.0(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/calendar': 3.7.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/calendar': 3.8.1(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/calendar': 3.7.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/checkbox@3.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/checkbox@3.15.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/form': 3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/toggle': 3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/checkbox': 3.6.13(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/toggle': 3.8.3(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/form': 3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/toggle': 3.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/checkbox': 3.6.14(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/toggle': 3.8.4(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/color@3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/color@3.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/numberfield': 3.11.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/slider': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/spinbutton': 3.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/textfield': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/color': 3.8.4(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-types/color': 3.0.4(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/numberfield': 3.11.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/slider': 3.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/spinbutton': 3.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/textfield': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/visually-hidden': 3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/color': 3.8.5(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-types/color': 3.0.5(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/combobox@3.12.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/combobox@3.12.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/listbox': 3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/listbox': 3.14.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/menu': 3.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/textfield': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/combobox': 3.10.4(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/combobox': 3.13.4(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/menu': 3.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/overlays': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/textfield': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/combobox': 3.10.5(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/combobox': 3.13.5(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/datepicker@3.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/datepicker@3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@internationalized/number': 3.6.1
+      '@internationalized/date': 3.8.1
+      '@internationalized/number': 3.6.2
       '@internationalized/string': 3.2.6
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/form': 3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/spinbutton': 3.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/datepicker': 3.14.0(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/calendar': 3.7.0(react@18.3.1)
-      '@react-types/datepicker': 3.12.0(react@18.3.1)
-      '@react-types/dialog': 3.5.17(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/form': 3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/spinbutton': 3.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/datepicker': 3.14.1(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/calendar': 3.7.1(react@18.3.1)
+      '@react-types/datepicker': 3.12.1(react@18.3.1)
+      '@react-types/dialog': 3.5.18(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/dialog@3.5.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/dialog@3.5.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/dialog': 3.5.17(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/overlays': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/dialog': 3.5.18(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/dnd@3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/dnd@3.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@internationalized/string': 3.2.6
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/overlays': 3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/dnd': 3.5.3(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/overlays': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/dnd': 3.5.4(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/focus@3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/focus@3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/form@3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/form@3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/grid@3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/grid@3.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/grid': 3.11.1(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/grid': 3.3.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/grid': 3.11.2(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/grid': 3.3.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/gridlist@3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/gridlist@3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/grid': 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-stately/tree': 3.8.9(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/grid': 3.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-stately/tree': 3.8.10(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/i18n@3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/i18n@3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
+      '@internationalized/date': 3.8.1
       '@internationalized/message': 3.1.7
-      '@internationalized/number': 3.6.1
+      '@internationalized/number': 3.6.2
       '@internationalized/string': 3.2.6
       '@react-aria/ssr': 3.9.8(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/interactions@3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/interactions@3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.8(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/flags': 3.1.1
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/label@3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/label@3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/link@3.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/link@3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/link': 3.6.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/link': 3.6.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/listbox@3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/listbox@3.14.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-types/listbox': 3.6.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-types/listbox': 3.7.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8702,164 +8721,164 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.13
 
-  '@react-aria/menu@3.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/menu@3.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/menu': 3.9.3(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-stately/tree': 3.8.9(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/menu': 3.10.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/overlays': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/menu': 3.9.4(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-stately/tree': 3.8.10(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/menu': 3.10.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/meter@3.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/meter@3.4.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/progress': 3.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/meter': 3.4.8(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/progress': 3.4.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/meter': 3.4.9(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/numberfield@3.11.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/numberfield@3.11.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/spinbutton': 3.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/textfield': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/numberfield': 3.9.11(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/numberfield': 3.8.10(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/spinbutton': 3.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/textfield': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/numberfield': 3.9.12(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/numberfield': 3.8.11(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/overlays@3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/overlays@3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/ssr': 3.9.8(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/visually-hidden': 3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/overlays': 3.8.15(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/progress@3.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/progress@3.4.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/progress': 3.5.11(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/progress': 3.5.12(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/radio@3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/radio@3.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/form': 3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/radio': 3.10.12(react@18.3.1)
-      '@react-types/radio': 3.8.8(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/form': 3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/radio': 3.10.13(react@18.3.1)
+      '@react-types/radio': 3.8.9(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/searchfield@3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/searchfield@3.8.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/textfield': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/searchfield': 3.5.11(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/searchfield': 3.6.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/textfield': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/searchfield': 3.5.12(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/searchfield': 3.6.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/select@3.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/select@3.15.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/form': 3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/listbox': 3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/menu': 3.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/select': 3.6.12(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/select': 3.9.11(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/form': 3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/listbox': 3.14.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/menu': 3.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/visually-hidden': 3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/select': 3.6.13(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/select': 3.9.12(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/selection@3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/selection@3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/separator@3.4.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/separator@3.4.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/slider@3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/slider@3.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/slider': 3.6.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/slider': 3.7.10(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/slider': 3.6.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/slider': 3.7.11(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/spinbutton@3.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/spinbutton@3.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8869,155 +8888,167 @@ snapshots:
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-aria/switch@3.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/switch@3.7.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/toggle': 3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/switch': 3.5.10(react@18.3.1)
+      '@react-aria/toggle': 3.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/toggle': 3.8.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/switch': 3.5.11(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/table@3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/table@3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/grid': 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/grid': 3.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.2
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/visually-hidden': 3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
       '@react-stately/flags': 3.1.1
-      '@react-stately/table': 3.14.1(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/grid': 3.3.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/table': 3.12.0(react@18.3.1)
+      '@react-stately/table': 3.14.2(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/grid': 3.3.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/table': 3.13.0(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/tabs@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/tabs@3.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/tabs': 3.8.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/tabs': 3.3.14(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/tabs': 3.8.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/tabs': 3.3.15(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/tag@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/tag@3.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/gridlist': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-types/button': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/gridlist': 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-types/button': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/textfield@3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/textfield@3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/form': 3.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
+      '@react-aria/form': 3.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/textfield': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/textfield': 3.12.2(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/toggle@3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/toggle@3.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.3(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/toggle': 3.8.4(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/toolbar@3.0.0-beta.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/toolbar@3.0.0-beta.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/tooltip@3.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/tooltip@3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/tooltip': 3.5.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/tooltip': 3.4.16(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-stately/tooltip': 3.5.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/tooltip': 3.4.17(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/utils@3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/utils@3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.8(react@18.3.1)
       '@react-stately/flags': 3.1.1
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/visually-hidden@3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/visually-hidden@3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-stately/calendar@3.8.0(react@18.3.1)':
+  '@react-stately/calendar@3.8.1(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.8.0
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/calendar': 3.7.0(react@18.3.1)
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@internationalized/date': 3.8.1
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/calendar': 3.7.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/checkbox@3.6.13(react@18.3.1)':
+  '@react-stately/checkbox@3.6.14(react@18.3.1)':
     dependencies:
       '@react-stately/form': 3.1.3(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/checkbox': 3.9.3(react@18.3.1)
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/collections@3.12.3(react@18.3.1)':
+  '@react-stately/collections@3.12.4(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/color@3.8.4(react@18.3.1)':
+  '@react-stately/color@3.8.5(react@18.3.1)':
     dependencies:
       '@internationalized/number': 3.6.1
       '@internationalized/string': 3.2.6
@@ -9027,10 +9058,19 @@ snapshots:
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/color': 3.0.4(react@18.3.1)
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@internationalized/number': 3.6.2
+      '@internationalized/string': 3.2.6
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/numberfield': 3.9.12(react@18.3.1)
+      '@react-stately/slider': 3.6.4(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/color': 3.0.5(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/combobox@3.10.4(react@18.3.1)':
+  '@react-stately/combobox@3.10.5(react@18.3.1)':
     dependencies:
       '@react-stately/collections': 3.12.3(react@18.3.1)
       '@react-stately/form': 3.1.3(react@18.3.1)
@@ -9040,16 +9080,27 @@ snapshots:
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/combobox': 3.13.4(react@18.3.1)
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-stately/select': 3.6.13(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/combobox': 3.13.5(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/data@3.12.3(react@18.3.1)':
+  '@react-stately/data@3.13.0(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/datepicker@3.14.0(react@18.3.1)':
+  '@react-stately/datepicker@3.14.1(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.8.0
       '@internationalized/string': 3.2.6
@@ -9058,13 +9109,21 @@ snapshots:
       '@react-stately/utils': 3.10.6(react@18.3.1)
       '@react-types/datepicker': 3.12.0(react@18.3.1)
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@internationalized/date': 3.8.1
+      '@internationalized/string': 3.2.6
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/datepicker': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/dnd@3.5.3(react@18.3.1)':
+  '@react-stately/dnd@3.5.4(react@18.3.1)':
     dependencies:
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
@@ -9072,284 +9131,288 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.13
 
-  '@react-stately/form@3.1.3(react@18.3.1)':
+  '@react-stately/form@3.1.4(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/grid@3.11.1(react@18.3.1)':
+  '@react-stately/grid@3.11.2(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-types/grid': 3.3.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-types/grid': 3.3.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/list@3.12.1(react@18.3.1)':
+  '@react-stately/list@3.12.2(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/menu@3.9.3(react@18.3.1)':
+  '@react-stately/menu@3.9.4(react@18.3.1)':
     dependencies:
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-types/menu': 3.10.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-types/menu': 3.10.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/numberfield@3.9.11(react@18.3.1)':
+  '@react-stately/numberfield@3.9.12(react@18.3.1)':
     dependencies:
-      '@internationalized/number': 3.6.1
-      '@react-stately/form': 3.1.3(react@18.3.1)
+      '@internationalized/number': 3.6.2
+      '@react-stately/form': 3.1.4(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/numberfield': 3.8.10(react@18.3.1)
+      '@react-types/numberfield': 3.8.11(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/overlays@3.6.15(react@18.3.1)':
-    dependencies:
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@swc/helpers': 0.5.13
-      react: 18.3.1
-
-  '@react-stately/radio@3.10.12(react@18.3.1)':
-    dependencies:
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/radio': 3.8.8(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@swc/helpers': 0.5.13
-      react: 18.3.1
-
-  '@react-stately/searchfield@3.5.11(react@18.3.1)':
+  '@react-stately/overlays@3.6.16(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/searchfield': 3.6.1(react@18.3.1)
+      '@react-types/overlays': 3.8.15(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/select@3.6.12(react@18.3.1)':
+  '@react-stately/radio@3.10.13(react@18.3.1)':
     dependencies:
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-types/select': 3.9.11(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@swc/helpers': 0.5.13
-      react: 18.3.1
-
-  '@react-stately/selection@3.20.1(react@18.3.1)':
-    dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/radio': 3.8.9(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/slider@3.6.3(react@18.3.1)':
+  '@react-stately/searchfield@3.5.12(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/slider': 3.7.10(react@18.3.1)
+      '@react-types/searchfield': 3.6.2(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/table@3.14.1(react@18.3.1)':
+  '@react-stately/select@3.6.13(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-types/select': 3.9.12(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@swc/helpers': 0.5.13
+      react: 18.3.1
+
+  '@react-stately/selection@3.20.2(react@18.3.1)':
+    dependencies:
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@swc/helpers': 0.5.13
+      react: 18.3.1
+
+  '@react-stately/slider@3.6.4(react@18.3.1)':
+    dependencies:
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/slider': 3.7.11(react@18.3.1)
+      '@swc/helpers': 0.5.13
+      react: 18.3.1
+
+  '@react-stately/table@3.14.2(react@18.3.1)':
+    dependencies:
+      '@react-stately/collections': 3.12.4(react@18.3.1)
       '@react-stately/flags': 3.1.1
-      '@react-stately/grid': 3.11.1(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
+      '@react-stately/grid': 3.11.2(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/grid': 3.3.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/table': 3.12.0(react@18.3.1)
+      '@react-types/grid': 3.3.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/table': 3.13.0(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/tabs@3.8.1(react@18.3.1)':
+  '@react-stately/tabs@3.8.2(react@18.3.1)':
     dependencies:
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/tabs': 3.3.14(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/tabs': 3.3.15(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/toggle@3.8.3(react@18.3.1)':
+  '@react-stately/toggle@3.8.4(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/checkbox': 3.9.3(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/checkbox': 3.9.4(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/tooltip@3.5.3(react@18.3.1)':
+  '@react-stately/tooltip@3.5.4(react@18.3.1)':
     dependencies:
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-types/tooltip': 3.4.16(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-types/tooltip': 3.4.17(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-stately/tree@3.8.9(react@18.3.1)':
+  '@react-stately/tree@3.8.10(react@18.3.1)':
     dependencies:
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
       '@react-stately/utils': 3.10.6(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
   '@react-stately/utils@3.10.6(react@18.3.1)':
     dependencies:
+      '@react-stately/collections': 3.12.3(react@18.3.1)
+      '@react-stately/utils': 3.10.6(react@18.3.1)
+      '@react-types/shared': 3.29.0(react@18.3.1)
       '@swc/helpers': 0.5.13
       react: 18.3.1
 
-  '@react-types/breadcrumbs@3.7.12(react@18.3.1)':
+  '@react-types/breadcrumbs@3.7.13(react@18.3.1)':
     dependencies:
-      '@react-types/link': 3.6.0(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/link': 3.6.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/button@3.12.0(react@18.3.1)':
+  '@react-types/button@3.12.1(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/calendar@3.7.0(react@18.3.1)':
+  '@react-types/calendar@3.7.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@internationalized/date': 3.8.1
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/checkbox@3.9.3(react@18.3.1)':
+  '@react-types/checkbox@3.9.4(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/color@3.0.4(react@18.3.1)':
+  '@react-types/color@3.0.5(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/slider': 3.7.10(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/slider': 3.7.11(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/combobox@3.13.4(react@18.3.1)':
+  '@react-types/combobox@3.13.5(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/datepicker@3.12.0(react@18.3.1)':
+  '@react-types/datepicker@3.12.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.8.0
-      '@react-types/calendar': 3.7.0(react@18.3.1)
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@internationalized/date': 3.8.1
+      '@react-types/calendar': 3.7.1(react@18.3.1)
+      '@react-types/overlays': 3.8.15(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/dialog@3.5.17(react@18.3.1)':
+  '@react-types/dialog@3.5.18(react@18.3.1)':
     dependencies:
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/overlays': 3.8.15(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/grid@3.3.1(react@18.3.1)':
+  '@react-types/grid@3.3.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/link@3.6.0(react@18.3.1)':
+  '@react-types/link@3.6.1(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/listbox@3.6.0(react@18.3.1)':
+  '@react-types/listbox@3.7.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/menu@3.10.0(react@18.3.1)':
+  '@react-types/menu@3.10.1(react@18.3.1)':
     dependencies:
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/overlays': 3.8.15(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/meter@3.4.8(react@18.3.1)':
+  '@react-types/meter@3.4.9(react@18.3.1)':
     dependencies:
-      '@react-types/progress': 3.5.11(react@18.3.1)
+      '@react-types/progress': 3.5.12(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/numberfield@3.8.10(react@18.3.1)':
+  '@react-types/numberfield@3.8.11(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/overlays@3.8.14(react@18.3.1)':
+  '@react-types/overlays@3.8.15(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/progress@3.5.11(react@18.3.1)':
+  '@react-types/progress@3.5.12(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/radio@3.8.8(react@18.3.1)':
+  '@react-types/radio@3.8.9(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/searchfield@3.6.1(react@18.3.1)':
+  '@react-types/searchfield@3.6.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      '@react-types/textfield': 3.12.1(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      '@react-types/textfield': 3.12.2(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/select@3.9.11(react@18.3.1)':
+  '@react-types/select@3.9.12(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/shared@3.29.0(react@18.3.1)':
+  '@react-types/shared@3.29.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@react-types/slider@3.7.10(react@18.3.1)':
+  '@react-types/slider@3.7.11(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/switch@3.5.10(react@18.3.1)':
+  '@react-types/switch@3.5.11(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/table@3.12.0(react@18.3.1)':
+  '@react-types/table@3.13.0(react@18.3.1)':
     dependencies:
-      '@react-types/grid': 3.3.1(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/grid': 3.3.2(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/tabs@3.3.14(react@18.3.1)':
-    dependencies:
-      '@react-types/shared': 3.29.0(react@18.3.1)
-      react: 18.3.1
-
-  '@react-types/textfield@3.12.1(react@18.3.1)':
+  '@react-types/tabs@3.3.15(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/tooltip@3.4.16(react@18.3.1)':
+  '@react-types/textfield@3.12.2(react@18.3.1)':
     dependencies:
-      '@react-types/overlays': 3.8.14(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
+      react: 18.3.1
+
+  '@react-types/tooltip@3.4.17(react@18.3.1)':
+    dependencies:
+      '@react-types/overlays': 3.8.15(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
   '@rollup/plugin-inject@5.0.5(rollup@4.37.0)':
@@ -9510,9 +9573,9 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/react-table@8.11.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/table-core': 8.11.8
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -13973,43 +14036,43 @@ snapshots:
   react-aria@3.35.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@internationalized/string': 3.2.6
-      '@react-aria/breadcrumbs': 3.5.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/button': 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/calendar': 3.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/checkbox': 3.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/color': 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/combobox': 3.12.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/datepicker': 3.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/dialog': 3.5.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/dnd': 3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/focus': 3.20.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/gridlist': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/link': 3.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/listbox': 3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/menu': 3.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/meter': 3.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/numberfield': 3.11.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/progress': 3.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/radio': 3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/searchfield': 3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/select': 3.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/selection': 3.24.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/separator': 3.4.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/slider': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/breadcrumbs': 3.5.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/button': 3.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/calendar': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/checkbox': 3.15.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/color': 3.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/combobox': 3.12.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/datepicker': 3.14.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/dialog': 3.5.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/dnd': 3.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/gridlist': 3.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/i18n': 3.12.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/label': 3.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/link': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/listbox': 3.14.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/menu': 3.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/meter': 3.4.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/numberfield': 3.11.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/overlays': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/progress': 3.4.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/radio': 3.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/searchfield': 3.8.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/select': 3.15.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/selection': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/separator': 3.4.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/slider': 3.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/ssr': 3.9.8(react@18.3.1)
-      '@react-aria/switch': 3.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/table': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/tabs': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/tag': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/textfield': 3.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/tooltip': 3.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-aria/switch': 3.7.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/table': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/tabs': 3.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/tag': 3.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/textfield': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/tooltip': 3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/utils': 3.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/visually-hidden': 3.8.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -14092,37 +14155,37 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      use-isomorphic-layout-effect: 1.2.0(@types/react@18.3.5)(react@18.3.1)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.5)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
   react-stately@3.33.0(react@18.3.1):
     dependencies:
-      '@react-stately/calendar': 3.8.0(react@18.3.1)
-      '@react-stately/checkbox': 3.6.13(react@18.3.1)
-      '@react-stately/collections': 3.12.3(react@18.3.1)
-      '@react-stately/color': 3.8.4(react@18.3.1)
-      '@react-stately/combobox': 3.10.4(react@18.3.1)
-      '@react-stately/data': 3.12.3(react@18.3.1)
-      '@react-stately/datepicker': 3.14.0(react@18.3.1)
-      '@react-stately/dnd': 3.5.3(react@18.3.1)
-      '@react-stately/form': 3.1.3(react@18.3.1)
-      '@react-stately/list': 3.12.1(react@18.3.1)
-      '@react-stately/menu': 3.9.3(react@18.3.1)
-      '@react-stately/numberfield': 3.9.11(react@18.3.1)
-      '@react-stately/overlays': 3.6.15(react@18.3.1)
-      '@react-stately/radio': 3.10.12(react@18.3.1)
-      '@react-stately/searchfield': 3.5.11(react@18.3.1)
-      '@react-stately/select': 3.6.12(react@18.3.1)
-      '@react-stately/selection': 3.20.1(react@18.3.1)
-      '@react-stately/slider': 3.6.3(react@18.3.1)
-      '@react-stately/table': 3.14.1(react@18.3.1)
-      '@react-stately/tabs': 3.8.1(react@18.3.1)
-      '@react-stately/toggle': 3.8.3(react@18.3.1)
-      '@react-stately/tooltip': 3.5.3(react@18.3.1)
-      '@react-stately/tree': 3.8.9(react@18.3.1)
-      '@react-types/shared': 3.29.0(react@18.3.1)
+      '@react-stately/calendar': 3.8.1(react@18.3.1)
+      '@react-stately/checkbox': 3.6.14(react@18.3.1)
+      '@react-stately/collections': 3.12.4(react@18.3.1)
+      '@react-stately/color': 3.8.5(react@18.3.1)
+      '@react-stately/combobox': 3.10.5(react@18.3.1)
+      '@react-stately/data': 3.13.0(react@18.3.1)
+      '@react-stately/datepicker': 3.14.1(react@18.3.1)
+      '@react-stately/dnd': 3.5.4(react@18.3.1)
+      '@react-stately/form': 3.1.4(react@18.3.1)
+      '@react-stately/list': 3.12.2(react@18.3.1)
+      '@react-stately/menu': 3.9.4(react@18.3.1)
+      '@react-stately/numberfield': 3.9.12(react@18.3.1)
+      '@react-stately/overlays': 3.6.16(react@18.3.1)
+      '@react-stately/radio': 3.10.13(react@18.3.1)
+      '@react-stately/searchfield': 3.5.12(react@18.3.1)
+      '@react-stately/select': 3.6.13(react@18.3.1)
+      '@react-stately/selection': 3.20.2(react@18.3.1)
+      '@react-stately/slider': 3.6.4(react@18.3.1)
+      '@react-stately/table': 3.14.2(react@18.3.1)
+      '@react-stately/tabs': 3.8.2(react@18.3.1)
+      '@react-stately/toggle': 3.8.4(react@18.3.1)
+      '@react-stately/tooltip': 3.5.4(react@18.3.1)
+      '@react-stately/tree': 3.8.10(react@18.3.1)
+      '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
   react-syntax-highlighter@15.5.0(react@18.3.1):
@@ -15210,7 +15273,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.5
 
-  use-isomorphic-layout-effect@1.2.0(@types/react@18.3.5)(react@18.3.1):
+  use-isomorphic-layout-effect@1.2.1(@types/react@18.3.5)(react@18.3.1):
     dependencies:
       react: 18.3.1
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
-  - 'packages/*'
-  - 'vendor/*'
-
+  - packages/*
+  - vendor/*
 catalog:
-  'neo4j-driver': '5.12.0'
+  neo4j-driver: 5.12.0
+registry: http://localhost:4873/


### PR DESCRIPTION
Switches so the vscode extension downloads the appropriate linter version when we connect to an older neo4j server. This way, when we use older syntax that is no longer valid on newer servers - ex. call subqueries without a variable scope clause - we won't get linting for it when connected to an older server.

Ex. connected to 5.23
![image](https://github.com/user-attachments/assets/ad13a90e-a62a-43d2-b607-ae8ea5bda477)
but connected to Aura
![image](https://github.com/user-attachments/assets/12608db5-a991-4bf4-af65-c43c6d9da200)

This is also what we would get on the main branch connecting to 5.23
![image](https://github.com/user-attachments/assets/1c597fed-1f8a-44c8-a741-e535f3000d4f)


To avoid the PR being too massive, we've decided to add this part behind a feature flag before adding the e2e tests
