### PR TITLE
Fixes missing errors in semantic analysis, makes positions safer

### DIFF
--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -1,4 +1,7 @@
-import { _internalFeatureFlags } from '@neo4j-cypher/language-support';
+import {
+  _internalFeatureFlags,
+  SyntaxDiagnostic,
+} from '@neo4j-cypher/language-support';
 import { Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
 import debounce from 'lodash.debounce';
 import { join } from 'path';
@@ -37,12 +40,43 @@ async function rawLintDocument(
       dbSchema,
       _internalFeatureFlags,
     );
+
     const result = await lastSemanticJob;
+
+    cleanPositions(
+      result,
+      document.lineCount,
+      document.getText().length -
+        document.offsetAt({ line: document.lineCount - 1, character: 0 }),
+    );
 
     sendDiagnostics(result);
   } catch (err) {
     if (!(err instanceof workerpool.Promise.CancellationError)) {
       console.error(err);
+    }
+  }
+}
+
+//marks the entire text if any position is negative
+function cleanPositions(
+  diagnostics: SyntaxDiagnostic[],
+  endLine: number,
+  endOffset: number,
+): void {
+  for (const diagnostic of diagnostics) {
+    if (
+      [
+        diagnostic.range.end.character,
+        diagnostic.range.start.character,
+        diagnostic.range.end.line,
+        diagnostic.range.start.line,
+      ].find((pos) => pos < 0)
+    ) {
+      diagnostic.range.start.line = 0;
+      diagnostic.range.end.line = endLine;
+      diagnostic.range.start.character = 0;
+      diagnostic.range.end.character = endOffset;
     }
   }
 }

--- a/packages/language-support/src/antlr-grammar/Cypher25Parser.g4
+++ b/packages/language-support/src/antlr-grammar/Cypher25Parser.g4
@@ -1726,11 +1726,11 @@ graphScope
 // Database commands
 
 createCompositeDatabase
-   : COMPOSITE DATABASE databaseName (IF NOT EXISTS)? (SET? defaultLanguageSpecification)? commandOptions? waitClause?
+   : COMPOSITE DATABASE symbolicAliasNameOrParameter (IF NOT EXISTS)? (SET? defaultLanguageSpecification)? commandOptions? waitClause?
    ;
 
 createDatabase
-   : DATABASE databaseName (IF NOT EXISTS)? (SET? defaultLanguageSpecification)? (topology | shards)? commandOptions? waitClause?
+   : DATABASE symbolicAliasNameOrParameter (IF NOT EXISTS)? (SET? defaultLanguageSpecification)? (topology | shards)? commandOptions? waitClause?
    ;
 
 shards
@@ -1765,6 +1765,10 @@ secondaryToken
    : SECONDARY | SECONDARIES
    ;
 
+replicaToken
+   : REPLICA | REPLICAS
+   ;
+
 defaultLanguageSpecification
     : DEFAULT LANGUAGE CYPHER UNSIGNED_DECIMAL_INTEGER
     ;
@@ -1780,7 +1784,7 @@ aliasAction
 
 alterDatabase
    : DATABASE symbolicAliasNameOrParameter (IF EXISTS)? (
-      (SET (alterDatabaseAccess | alterDatabaseTopology | alterDatabaseOption | defaultLanguageSpecification))+
+      (SET (alterDatabaseAccess | alterDatabaseTopology | alterReplicaTopology | alterGraphShard | alterPropertyShards | alterDatabaseOption | defaultLanguageSpecification))+
       | (REMOVE OPTION symbolicNameString)+
    ) waitClause?
    ;
@@ -1795,6 +1799,18 @@ alterDatabaseTopology
 
 alterDatabaseOption
    : OPTION symbolicNameString expression
+   ;
+
+alterGraphShard
+   : GRAPH SHARD LCURLY SET alterDatabaseTopology RCURLY
+   ;
+
+alterPropertyShards
+   : PROPERTY (SHARD | SHARDS) LCURLY SET alterReplicaTopology RCURLY
+   ;
+
+alterReplicaTopology
+   : TOPOLOGY uIntOrIntParameter replicaToken
    ;
 
 startDatabase
@@ -1824,10 +1840,6 @@ aliasName
 
 aliasTargetName
    : symbolicAliasNameOrParameter
-   ;
-
-databaseName
-   : symbolicNameOrStringParameter
    ;
 
 // Alias commands

--- a/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/semanticValidation.test.ts
@@ -14,6 +14,32 @@ describe('Semantic validation spec', () => {
     _internalFeatureFlags.cypher25 = isCypher25;
   });
 
+  test('SyntaxChecker-exceptions work', () => {
+    const query1 = 'ALTER DATABASE neo4j SET DEFAULT LANGUAGE CYPHER 25000';
+    const diagnostics1 = getDiagnosticsForQuery({ query: query1 });
+    expect(diagnostics1).toEqual([
+      {
+        message:
+          "Invalid Cypher version '25000'. Valid Cypher versions are: 5, 25",
+        offsets: {
+          end: 54,
+          start: 49,
+        },
+        range: {
+          end: {
+            character: 54,
+            line: 0,
+          },
+          start: {
+            character: 49,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
   test('Semantic analysis is dependant on cypher version', () => {
     const query1 = 'CYPHER  5 MATCH (n)-[r]->(m) SET r += m';
     const diagnostics1 = getDiagnosticsForQuery({ query: query1 });


### PR DESCRIPTION
The parsers on the main db had a SyntaxChecker-listener to the parsers that didnt get called in the semantic analysis, causing these errors to be missing for us. Also, sometimes the errors are missing positions, which causes negative positions for us, breaking linting. For the cases I found, I fixed this too on the main db, and I added a check in linting.ts to set the start/end positions to cover the entire query if any position is negative.

