### PR TITLE
Fix unignore list to include correct lintWorker script

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -8,7 +8,7 @@
 !LICENSE.md
 !resources/
 !dist/extension.js
-!dist/lintWorker.js
+!dist/lintWorker.cjs
 !dist/cypher-language-server.js
 !dist/webviews/
 !cypher-language-configuration.json


### PR DESCRIPTION
Before we were unignoring lintWorker.js, but creating the worker with lintWorker.cjs, so it was missing in the packaged vsix (and we got no linting)