### PR TITLE
removing all references to showBottomPanel

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -268,8 +268,7 @@
         {
           "id": "neo4jQueryResults",
           "title": "Query Results",
-          "icon": "resources/images/neo4j.png",
-          "when": "neo4j:showBottomPanel"
+          "icon": "resources/images/neo4j.png"
         }
       ],
       "activitybar": [
@@ -287,7 +286,6 @@
           "id": "neo4jQueryDetails",
           "name": "Query Details",
           "initialSize": 1,
-          "when": "neo4j:showBottomPanel",
           "icon": "$(list-tree)"
         },
         {
@@ -295,7 +293,6 @@
           "id": "neo4jQueryVisualization",
           "name": "Visualization",
           "initialSize": 7,
-          "when": "neo4j:showBottomPanel",
           "icon": "resources/images/visualization.svg"
         }
       ],

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -32,15 +32,6 @@ export async function activate(context: ExtensionContext) {
     path.join('..', 'language-server', 'dist', 'server.js'),
   );
 
-  // show query result bottom panel only if showBottomPanel is set to true
-  const config = workspace.getConfiguration('neo4j.features');
-  const showBottomPanel = config.get('showBottomPanel', false);
-  await commands.executeCommand(
-    'setContext',
-    'neo4j:showBottomPanel',
-    showBottomPanel,
-  );
-
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
   const serverOptions: ServerOptions = {


### PR DESCRIPTION
Ups sorry! Second pr of the [clean-up](https://github.com/neo4j/cypher-language-support/pull/528/files). Removing all references to `showBottomPanel`(hopefully) so that bottom panel shows up without the feature flag.