### PR TITLE
Fixes extension folder being removed from breaking linter switching

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -45,11 +45,6 @@ export async function activate(context: ExtensionContext) {
     'neo4j:useVersionedLinters',
     useVersionedLinters,
   );
-  if (useVersionedLinters) {
-    //Create the globalStorage directory for the lint worker files if it doesnt exist
-    const storageUri = context.globalStorageUri;
-    await workspace.fs.createDirectory(storageUri);
-  }
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used


### PR DESCRIPTION
In my recent PR I moved so we create the extension folder on startup. This breaks the old linter handling if we remove the folder they are stored in after startup, as in the new e2e test.

This alters all accesses of the globalstorage uri to go through a method that recreates the folder if it is missing