### PR TITLE
Fixes flaky param test

### DIFF
--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -4,8 +4,10 @@ import { Workbench } from 'wdio-vscode-service';
 import { Key } from 'webdriverio';
 import {
   checkResultsContent,
+  clickOnContextMenuItem,
   ensureNotificationsAreDismissed,
   executeFile,
+  getConnectionSection,
   waitUntilNotification,
 } from '../../webviewUtils';
 
@@ -87,14 +89,6 @@ suite('Params panel testing', () => {
     await waitUntilNotification(browser, `Switched to database '${database}'.`);
   }
 
-  async function forceConnect(i: number) {
-    void browser.executeWorkbench((vscode, i) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      void vscode.commands.executeCommand('neo4j.internal.forceConnect', i);
-    }, i);
-    await waitUntilNotification(browser, 'Connected to Neo4j.');
-  }
-
   test.skip('Should correctly set and clear cypher parameters', async function () {
     await forceAddParam('a', '"charmander"');
     await forceAddParam('b', '"caterpie"');
@@ -136,7 +130,9 @@ suite('Params panel testing', () => {
     );
 
     await ensureNotificationsAreDismissed(browser);
-    await forceConnect(1);
+    const connectionSection = await getConnectionSection(workbench);
+    await clickOnContextMenuItem(connectionSection, 'Connect', 1);
+    await waitUntilNotification(browser, 'Connected to Neo4j.');
   });
 
   test('Parameters cannot be set when connected to system', async function () {


### PR DESCRIPTION
Sometimes the test failed with:
<img width="942" height="50" alt="image" src="https://github.com/user-attachments/assets/3359aa1f-9ca4-4c7c-8aa9-2dd1424065f8" />

After calling a vscode command to switch connection.

The method used in the connection spec does not run into this issue, and switching for this test removed the flakiness