### PR TITLE
Re-run queries that need implicit transaction

### DIFF
--- a/.changeset/wild-rooms-shop.md
+++ b/.changeset/wild-rooms-shop.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/query-tools': patch
+---
+
+Fixes execution of queries that need to be ran in implicit transactions

--- a/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
+++ b/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
@@ -275,9 +275,10 @@ export class Neo4jQueryDetailsProvider implements WebviewViewProvider {
         });
       } catch (e) {
         if (e instanceof Neo4jError && isImplicitTransactionError(e)) {
-          return await connection.runImplicitCypherTransaction({
+          return await connection.runCypherQuery({
             query,
             parameters: parameters,
+            implicitTransaction: true,
           });
         }
         const error = e as Error;


### PR DESCRIPTION
Certain queries, like those with "call in transactions" need to be run in implicit transactions, which we previously didnt support. In upx, this was solved by re-running queries with specific errors in an implicit transaction, so to keep the code understandable I do the same in this PR.

Before: 
<img width="926" height="429" alt="image" src="https://github.com/user-attachments/assets/88360713-0f6e-4f32-8ab1-bea57ce5f9f2" />

Now:
<img width="924" height="381" alt="Screenshot 2025-08-04 131819" src="https://github.com/user-attachments/assets/7e4480f4-5748-4c39-ad9b-1e657f4ed8f1" />
