### PR TITLE
Bugfix webview tests 

### DIFF
--- a/packages/vscode-extension/tests/runWebviewTests.ts
+++ b/packages/vscode-extension/tests/runWebviewTests.ts
@@ -61,7 +61,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: '1.93.1', // also possible: "insiders" or a specific version e.g. "1.80.0"
+      browserVersion: '1.103.0', // also possible: "insiders" or a specific version e.g. "1.80.0"
       'wdio:vscodeOptions': {
         // points to directory where extension package.json is located
         extensionPath: `${__dirname}/../..`,

--- a/packages/vscode-extension/tests/runWebviewTests.ts
+++ b/packages/vscode-extension/tests/runWebviewTests.ts
@@ -61,7 +61,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: '1.103.0', // also possible: "insiders" or a specific version e.g. "1.80.0"
+      browserVersion: '1.96.1', // also possible: "insiders" or a specific version e.g. "1.80.0"
       'wdio:vscodeOptions': {
         // points to directory where extension package.json is located
         extensionPath: `${__dirname}/../..`,


### PR DESCRIPTION
Some overnight update (think the update to vscode yesterday https://code.visualstudio.com/updates/v1_103) caused the webview tests to start failing. It looks like the chromedriver fetched by wdio-vscode-service started requiring a newer chrome version than the one we had
error:
```
[0-0] session not created: This version of ChromeDriver only supports Chrome version 138
[0-0] Current browser version is 124.0.6367.243 ...
```

Updating the vscode version used in the tests brought in the newer browser and fixed this bug, but updating to latest brought in some new issues for the tests themselves. Visually I saw that the latest version had copilot introduced by default, so maybe this is causing some issues with the available views... 

Either way, I think we should merge in this working config for now so that the CI is working for any other PR. At some point we will probably have to fix this for the newer vscode version though, unless we switch to some other test framework.
