### PR TITLE
changing to use browser bot instead of the action bot

### DIFF
--- a/.github/workflows/pre-release-vscode-extension.yaml
+++ b/.github/workflows/pre-release-vscode-extension.yaml
@@ -15,12 +15,16 @@ env:
   NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
-  pre-release-vscode-extension:
-    name: 'Pre Release VSCode extension'
-    environment: publish-vscode-extension
+  update-vscode-extension:
+    name: 'Update VSCode extension'
+    environment: aws-artifacts
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Restore latest pre-released sha
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
@@ -48,8 +52,8 @@ jobs:
       - name: Set Up Git User
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
-          git config --global user.name "Pre-release Bot"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "neo4j-browser-bot"
+          git config --global user.email "browser@neo4j.com"
 
       - name: Bump version (odd minor rule)
         if: steps.check_changes.outputs.has_changes == 'true'
@@ -87,8 +91,14 @@ jobs:
           path: last-published-sha
           key: vs-code-extension-pre-release-sha-${{ github.run_number }}
 
+  pre-release-vscode-extension:
+    name: 'Pre Release VSCode extension'
+    environment: publish-vscode-extension
+    needs: [update-vscode-extension]
+    if: ${{ needs.update-vscode-extension.outputs.has_changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Publish pre-release
-        if: steps.check_changes.outputs.has_changes == 'true'
         env:
           VSX_PAT: ${{ secrets.VSX_PAT }}
         run: |


### PR DESCRIPTION
This pr is to use the browser bot instead of the github action's bot to allow it to push to the main branch.