### PR TITLE
Fix missing label warnings

### DIFF
--- a/.changeset/slick-pandas-dance.md
+++ b/.changeset/slick-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes "missing label/rel type" warnings for some special cases

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -1,5 +1,11 @@
-import type { ParserRuleContext, Token } from 'antlr4';
-import { CharStreams, CommonTokenStream, ParseTreeListener } from 'antlr4';
+import {
+  ParserRuleContext,
+  ParseTreeWalker,
+  Token,
+  CharStreams,
+  CommonTokenStream,
+  ParseTreeListener,
+} from 'antlr4';
 
 import CypherLexer from './generated-parser/CypherCmdLexer';
 
@@ -248,6 +254,22 @@ const getClearParamName = (name: string): string => {
   return name;
 };
 
+function hasErrorNodesUnder(ctx: ParserRuleContext): boolean {
+  let found: boolean = false;
+  ParseTreeWalker.DEFAULT.walk(
+    {
+      visitTerminal() {},
+      visitErrorNode() {
+        found = true;
+      },
+      enterEveryRule() {},
+      exitEveryRule() {},
+    },
+    ctx,
+  );
+  return found;
+}
+
 export function parseParameters(
   query: string,
   consoleCommandsEnabled: boolean,
@@ -275,11 +297,11 @@ class LabelAndRelTypesCollector extends ParseTreeListener {
 
   exitEveryRule(ctx: unknown) {
     if (ctx instanceof LabelNameContext) {
-      // If the parent ctx start doesn't coincide with this ctx start,
-      // it means the parser recovered from an error reading the label
+      // If the parser recovered from an error reading the label
       // like in the case MATCH (n:) RETURN n
-      // RETURN would be idenfified as the label in that case
-      if (ctx.parentCtx && ctx.parentCtx.start === ctx.start) {
+      // RETURN would be incorrectly idenfified as the label
+      // If this is the case, the context containing the label would have an error node
+      if (ctx.parentCtx && !hasErrorNodesUnder(ctx.parentCtx)) {
         this.labelOrRelTypes.push({
           labelType: getLabelType(ctx),
           labelText: ctx.getText(),
@@ -298,17 +320,17 @@ class LabelAndRelTypesCollector extends ParseTreeListener {
       if (
         isDefined(symbolicName) &&
         ctx.parentCtx &&
-        ctx.parentCtx.start === ctx.start
+        !hasErrorNodesUnder(ctx.parentCtx)
       ) {
         this.labelOrRelTypes.push({
           labelType: getLabelType(ctx),
           labelText: symbolicName.start.text,
           couldCreateNewLabel: couldCreateNewLabel(ctx),
-          line: ctx.start.line,
-          column: ctx.start.column,
+          line: symbolicName.start.line,
+          column: symbolicName.start.column,
           offsets: {
-            start: ctx.start.start,
-            end: ctx.stop.stop + 1,
+            start: symbolicName.start.start,
+            end: symbolicName.stop.stop + 1,
           },
         });
       }

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -1,7 +1,6 @@
+import type { ParserRuleContext, Token } from 'antlr4';
 import {
-  ParserRuleContext,
   ParseTreeWalker,
-  Token,
   CharStreams,
   CommonTokenStream,
   ParseTreeListener,

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -225,7 +225,7 @@ describe('Syntactic validation spec', () => {
 
   //Needs adjusting of positions + should warn twice (both Person usages)
   test('Syntax validation warns on missing label in hint', () => {
-    const query = `MATCH (n: Person {Age:50}) USING INDEX n:Person(Age) RETURN n;`;
+    const query = `MATCH (n: Car {Age:20}) USING INDEX n:Car(Age) RETURN n;`;
 
     expect(
       getDiagnosticsForQuery({
@@ -234,19 +234,38 @@ describe('Syntactic validation spec', () => {
       }),
     ).toEqual([
       {
-        offsets: {
-          end: 17,
-          start: 11,
-        },
         message:
-          "Label Person is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+          "Label Car is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 13,
+          start: 10,
+        },
         range: {
           end: {
-            character: 17,
+            character: 13,
             line: 0,
           },
           start: {
-            character: 11,
+            character: 10,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Label or relationship type Car is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 41,
+          start: 38,
+        },
+        range: {
+          end: {
+            character: 41,
+            line: 0,
+          },
+          start: {
+            character: 38,
             line: 0,
           },
         },
@@ -385,7 +404,7 @@ describe('Syntactic validation spec', () => {
   });
 
   //Needs adjusting of positions + should warn twice (both Rel usages)
-  test('Syntax validation warns on missing rel type when using !-syntax', () => {
+  test('Syntax validation warns on missing rel type in hint', () => {
     const query = `MATCH (n)-[r:Rel {k:3}]->(m) USING INDEX r:Rel(k) RETURN n`;
 
     expect(
@@ -408,6 +427,25 @@ describe('Syntactic validation spec', () => {
           },
           start: {
             character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Label or relationship type Rel is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 46,
+          start: 43,
+        },
+        range: {
+          end: {
+            character: 46,
+            line: 0,
+          },
+          start: {
+            character: 43,
             line: 0,
           },
         },

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -223,6 +223,69 @@ describe('Syntactic validation spec', () => {
     ]);
   });
 
+  //Needs adjusting of positions + should warn twice (both Person usages)
+  test('Syntax validation warns on missing label in hint', () => {
+    const query = `MATCH (n: Person {Age:50}) USING INDEX n:Person(Age) RETURN n;`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: { labels: ['Dog', 'Cat'], relationshipTypes: ['Person'] },
+      }),
+    ).toEqual([
+      {
+        offsets: {
+          end: 17,
+          start: 11,
+        },
+        message:
+          "Label Person is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        range: {
+          end: {
+            character: 17,
+            line: 0,
+          },
+          start: {
+            character: 11,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Syntax validation warns on missing label using !-syntax', () => {
+    const query = `MATCH (n: !Person) RETURN n`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: { labels: ['Dog', 'Cat'], relationshipTypes: ['Person'] },
+      }),
+    ).toEqual([
+      {
+        offsets: {
+          end: 17,
+          start: 11,
+        },
+        message:
+          "Label Person is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        range: {
+          end: {
+            character: 17,
+            line: 0,
+          },
+          start: {
+            character: 11,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
   test('Syntax validation warns on missing label when database can be contacted', () => {
     const query = `MATCH (n: Person) RETURN n`;
 
@@ -313,6 +376,69 @@ describe('Syntactic validation spec', () => {
           },
           start: {
             character: 24,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  //Needs adjusting of positions + should warn twice (both Rel usages)
+  test('Syntax validation warns on missing rel type when using !-syntax', () => {
+    const query = `MATCH (n)-[r:Rel {k:3}]->(m) USING INDEX r:Rel(k) RETURN n`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: { labels: ['Dog', 'Cat'], relationshipTypes: ['Person'] },
+      }),
+    ).toEqual([
+      {
+        message:
+          "Relationship type Rel is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 16,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 16,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Syntax validation warns on missing rel type when using !-syntax', () => {
+    const query = `MATCH (n)-[:!Rel]->(m) RETURN n`;
+
+    expect(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: { labels: ['Dog', 'Cat'], relationshipTypes: ['Person'] },
+      }),
+    ).toEqual([
+      {
+        message:
+          "Relationship type Rel is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 16,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 16,
+            line: 0,
+          },
+          start: {
+            character: 13,
             line: 0,
           },
         },

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -223,7 +223,6 @@ describe('Syntactic validation spec', () => {
     ]);
   });
 
-  //Needs adjusting of positions + should warn twice (both Person usages)
   test('Syntax validation warns on missing label in hint', () => {
     const query = `MATCH (n: Car {Age:20}) USING INDEX n:Car(Age) RETURN n;`;
 

--- a/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/syntacticValidation.test.ts
@@ -402,7 +402,6 @@ describe('Syntactic validation spec', () => {
     ]);
   });
 
-  //Needs adjusting of positions + should warn twice (both Rel usages)
   test('Syntax validation warns on missing rel type in hint', () => {
     const query = `MATCH (n)-[r:Rel {k:3}]->(m) USING INDEX r:Rel(k) RETURN n`;
 


### PR DESCRIPTION
We have logic that looks through the parse-tree for labels/rels used in the query, and then warns if these are not available on the db. Certain queries would not get these warnings though - see image below
<img width="735" height="65" alt="Screenshot 2025-08-28 110612" src="https://github.com/user-attachments/assets/a18a8f4b-b00c-4157-b3a1-28544e86da8c" />

The issue arose because of a check to prevent another bug. We were getting these "missing label"-warnings when the parser recovered by deleting tokens. This would give warnings like ~"RETURN is not a label in the db" on `MATCH (n:) RETURN`. 

The new logic handles the parser recovery too (see test syntacticValidation.test.ts -> `Syntax validation errors on missing label expression` which is still passing), but without covering the above mentioned legitimate warnings, resulting in the expected:
<img width="725" height="64" alt="image" src="https://github.com/user-attachments/assets/ffcfdb6b-7046-4835-b8d2-388bd01e88d5" />
