### PR TITLE
Fixes linter terminating on slow query

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -41,7 +41,7 @@
     "neo4j-driver": "catalog:",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",
-    "workerpool": "^9.0.4",
+    "workerpool": "^9.3.3",
     "axios": "^1.9.0"
   },
   "scripts": {

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -19,7 +19,7 @@ const defaultWorkerPath = join(__dirname, 'lintWorker.cjs');
 
 let pool = workerpool.pool(defaultWorkerPath, {
   minWorkers: 2,
-  workerTerminateTimeout: 2000,
+  workerTerminateTimeout: 20000,
 });
 export let workerPath = defaultWorkerPath;
 let linterVersion: string | undefined = undefined;

--- a/packages/lint-worker/package.json
+++ b/packages/lint-worker/package.json
@@ -36,7 +36,7 @@
     "languageSupport-next.13": "npm:@neo4j-cypher/language-support@2.0.0-next.13",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-types": "^3.17.3",
-    "workerpool": "^9.0.4",
+    "workerpool": "^9.3.3",
     "axios": "^1.9.0"
   },
   "scripts": {

--- a/packages/lint-worker/src/lintWorker.ts
+++ b/packages/lint-worker/src/lintWorker.ts
@@ -9,12 +9,23 @@ import {
 } from '@neo4j-cypher/language-support';
 import workerpool from 'workerpool';
 
+type simplifiedWorkerThread = {
+  worker: { addAbortListener: (listener: () => object) => void };
+};
+
 function lintCypherQuery(
   query: string,
   dbSchema,
   featureFlags: { consoleCommands?: boolean } = {},
 ): { diagnostics: SyntaxDiagnostic[]; symbolTables?: SymbolTable[] } {
   // We allow to override the consoleCommands feature flag
+
+  // on runtime "me" will have a "worker" property when run from the workerpool
+  // Having an abortListener, even one that does nothing,
+  // allows the worker to be re-used instead of terminating on cancellation
+  const me = this as simplifiedWorkerThread;
+  me.worker.addAbortListener(async () => {});
+
   if (featureFlags.consoleCommands !== undefined) {
     _internalFeatureFlags.consoleCommands = featureFlags.consoleCommands;
   }

--- a/packages/react-codemirror/package.json
+++ b/packages/react-codemirror/package.json
@@ -62,7 +62,7 @@
     "prismjs": "^1.29.0",
     "style-mod": "^4.1.2",
     "vscode-languageserver-types": "^3.17.3",
-    "workerpool": "^9.0.4"
+    "workerpool": "^9.3.3"
   },
   "devDependencies": {
     "@neo4j-ndl/base": "^3.2.10",

--- a/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
+++ b/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
@@ -11,7 +11,7 @@ const WorkerURL = new URL('./lintWorker.mjs', import.meta.url).pathname;
 const pool = workerpool.pool(WorkerURL, {
   minWorkers: 2,
   workerOpts: { type: 'module' },
-  workerTerminateTimeout: 2000,
+  workerTerminateTimeout: 20000,
 });
 
 let lastSemanticJob: LinterTask | undefined;
@@ -64,7 +64,7 @@ export const cypherLinter: (config: CypherConfig) => Extension = (config) =>
       return a;
     } catch (err) {
       if (!(err instanceof workerpool.Promise.CancellationError)) {
-        console.error(String(err) + ' ' + query);
+        console.error(String(err));
       }
     }
     return [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.12
       workerpool:
-        specifier: ^9.0.4
-        version: 9.0.4
+        specifier: ^9.3.3
+        version: 9.3.3
     devDependencies:
       '@types/lodash.debounce':
         specifier: ^4.0.9
@@ -149,8 +149,8 @@ importers:
         specifier: ^3.17.3
         version: 3.17.5
       workerpool:
-        specifier: ^9.0.4
-        version: 9.0.4
+        specifier: ^9.3.3
+        version: 9.3.3
     devDependencies:
       '@types/lodash.debounce':
         specifier: ^4.0.9
@@ -232,8 +232,8 @@ importers:
         specifier: ^3.17.3
         version: 3.17.5
       workerpool:
-        specifier: ^9.0.4
-        version: 9.0.4
+        specifier: ^9.3.3
+        version: 9.3.3
     devDependencies:
       '@neo4j-ndl/base':
         specifier: ^3.2.10
@@ -7579,8 +7579,8 @@ packages:
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
-  workerpool@9.0.4:
-    resolution: {integrity: sha512-EDeF5re9hGJ88HH2vYDuvG0rV3+I0hlP+9lLQYYzXykW0kjDGyuw21vR1rRWUqNy9x+o5yPlqmyzpHvELzhyeQ==}
+  workerpool@9.3.3:
+    resolution: {integrity: sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -16359,7 +16359,7 @@ snapshots:
 
   workerpool@6.5.1: {}
 
-  workerpool@9.0.4: {}
+  workerpool@9.3.3: {}
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
Fixes an issue where in large and slow queries would crash the codemirror, since the worker returned by the pool for the current task got terminated by cancelling the previous task. In quick queries this would not show since the previous task would never be cancelled.

Looking at the docs for the workerpool, it seems that the worker performing the cancelled task is always terminated when no abortListener is added. I could not find a way to get the workerpool to give us a different worker, so we always got an error when the termination happened. Having an abortListener - even one that does nothing - allows the worker to be reused, and fixes our issue.

For even larger queries the workerTerminateTimeout would kick in during cancellation, terminating the active worker, so I increased this number as well.