### PR TITLE
Add build of type files to query-tools package

### DIFF
--- a/packages/query-tools/package.json
+++ b/packages/query-tools/package.json
@@ -6,8 +6,10 @@
   "version": "2.0.0-next.23",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "require": "./dist/cjs/src/index.js",
       "import": "./dist/esm/src/index.js",
       "default": "./dist/cjs/src/index.js"
@@ -33,9 +35,10 @@
     "@testcontainers/neo4j": "^11.5.1"
   },
   "scripts": {
-    "build": "concurrently 'npm:build-esm' 'npm:build-commonjs'",
+    "build": "concurrently 'npm:build-esm' 'npm:build-commonjs' 'npm:build-types'",
     "build-esm": "tsc --module esnext --outDir dist/esm",
     "build-commonjs": "tsc --module commonjs --outDir dist/cjs",
+    "build-types": "tsc --emitDeclarationOnly --outDir dist/types",
     "dev": "concurrently 'npm:build-esm -- --watch' 'npm:build-commonjs -- --watch'",
     "clean": "rm -rf {dist,tsconfig.tsbuildinfo}",
     "test": "vitest run extract-unique-nodes-and-relationships",


### PR DESCRIPTION
I don't see how this was not failing before (maybe the methods from a dependency that was using our types werent strict in their check, but got a patch?), but the query-tools package was not exporting types, which caused tests importing objects that needed these types to fail. 

Basically `sandbox.stub` (using Sinon) didn't recognize that our schema had fields that it did, because the schema used was inheriting the schema in query-tools, which didnt build/export its type files.

This PR introduces a step to the query-tools build script to also construct types, and exports these similar to how we do it in other packages