### PR TITLE
Fix archive-vscode-artifacts workflow

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -491,7 +491,7 @@
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "@types/sinon": "17.0.3",
-    "@types/vscode": "1.93.0",
+    "@types/vscode": "1.75.0",
     "@vscode/test-electron": "2.4.1",
     "@vscode/vsce": "3.3.2",
     "@wdio/cli": "8.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,8 +394,8 @@ importers:
         specifier: 17.0.3
         version: 17.0.3
       '@types/vscode':
-        specifier: 1.93.0
-        version: 1.93.0
+        specifier: 1.75.0
+        version: 1.75.0
       '@vscode/test-electron':
         specifier: 2.4.1
         version: 2.4.1
@@ -2353,8 +2353,8 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/vscode@1.93.0':
-    resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
+  '@types/vscode@1.75.0':
+    resolution: {integrity: sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==}
 
   '@types/which@2.0.2':
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
@@ -10087,7 +10087,7 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@types/vscode@1.93.0': {}
+  '@types/vscode@1.75.0': {}
 
   '@types/which@2.0.2': {}
 


### PR DESCRIPTION
It looks like there is a check in `vsce package` that ensures the `@types/vscode` version and the `engine.vscode` versions are compatible, and that this is based off the package.json.
<img width="1532" height="503" alt="image" src="https://github.com/user-attachments/assets/46a80274-3c3a-4814-8c1b-f86044e4aec8" />
Even though we already had 1.93.0 installed in the pnpm-lock file previous to my caret-fixing PR, this didnt trigger the check to fail. However, I think the idea is for the types to not be too new anyway, since this would mean the type system thinks we have newer apis than we do (so we dont error on incorrect calls), so installing 1.75.0 types would be the way to go.