### PR TITLE
Fixes formatter capitalizing preparser keywords in procedure/function namespaces

### DIFF
--- a/.changeset/thick-signs-prove.md
+++ b/.changeset/thick-signs-prove.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+Fixes a bug in formatting when using preparser keywords in function/procedure namespaces

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -2,9 +2,10 @@ import { CharStreams, CommonTokenStream, TerminalNode, Token } from 'antlr4';
 import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import CypherCmdParser, {
   EscapedSymbolicNameStringContext,
-  UnescapedSymbolicNameString_Context,
+  UnescapedSymbolicNameStringContext,
 } from '../generated-parser/CypherCmdParser';
 import { lexerKeywords } from '../lexerSymbols';
+import { findParent } from '../helpers';
 
 export const INTERNAL_FORMAT_ERROR_MESSAGE = `
 Internal formatting error: An unexpected issue occurred while formatting.
@@ -103,12 +104,20 @@ export function isComment(token: Token) {
 export const isInlineComment = (chunk: Chunk) =>
   chunk.comment && chunk.comment.startsWith('/*');
 
-// Variables or property names that have the same name as a keyword should not be
+// Variables, functions/procedures namespaces or property names that have the same name as a keyword should not be
 // treated as keywords
 function isSymbolicName(node: TerminalNode): boolean {
-  return (
-    node.parentCtx instanceof UnescapedSymbolicNameString_Context ||
-    node.parentCtx instanceof EscapedSymbolicNameStringContext
+  const unescapedSymbolicNameStringParent = findParent(
+    node,
+    (x) => x instanceof UnescapedSymbolicNameStringContext,
+  );
+  const escapedSymbolicNameStringParent = findParent(
+    node,
+    (x) => x instanceof EscapedSymbolicNameStringContext,
+  );
+  return !(
+    unescapedSymbolicNameStringParent == null &&
+    escapedSymbolicNameStringParent == null
   );
 }
 

--- a/packages/language-support/src/tests/formatting/edgecases.test.ts
+++ b/packages/language-support/src/tests/formatting/edgecases.test.ts
@@ -1158,4 +1158,11 @@ RETURN
   }[1..10]`;
     verifyFormatting(query, expected);
   });
+
+  test('Preparser keywords do not break in procedures', () => {
+    const query = `cypher CALL apoc.cypher.run("RETURN 5", {})`;
+    const expected = `CYPHER
+CALL apoc.cypher.run("RETURN 5", {})`;
+    verifyFormatting(query, expected);
+  });
 });


### PR DESCRIPTION
Fixes the issue mentioned in: https://github.com/neo4j/cypher-language-support/issues/551

Basically, when keywords that would be capitalized in the preparser are used in functions/procedures, these were also capitalized in functions/procedures that used them, which actually breaks case-sensitive cases.

When checking whether we should capitalize a keyword we already had the check for isSymbolicName, but it didn't cover the full rule containing preparserKeywords. It also didnt cover the case when the rule was higher up in the parent chain, which was the case here, see image below, so all that was needed was to adjust the check a little bit.
<img width="836" height="118" alt="image" src="https://github.com/user-attachments/assets/1097c863-9134-4946-a437-f328fabf8e50" />

The image is from looking at the parser node that we check for capitlizing (or not) the namespace `cypher` in the procedure call of the query used here:
<img width="566" height="139" alt="image" src="https://github.com/user-attachments/assets/c39ebacc-79e6-451d-8765-b09954d25a27" />
Before the fix, this was formatted to:
<img width="487" height="110" alt="image" src="https://github.com/user-attachments/assets/2affaa05-8295-43f6-96c5-7a96c0320010" />

After the fix, this gets formatted to:
<img width="498" height="110" alt="image" src="https://github.com/user-attachments/assets/1caedb75-087b-44d3-b071-1c7e46cda00a" />

