### PR TITLE
commiting the updated version if release is successful

### DIFF
--- a/.github/workflows/pre-release-vscode-extension.yaml
+++ b/.github/workflows/pre-release-vscode-extension.yaml
@@ -19,13 +19,10 @@ jobs:
     name: 'Pre Release VSCode extension'
     environment: publish-vscode-extension
     runs-on: ubuntu-latest
-    outputs:
-      has_changes: ${{ steps.check_changes.outputs.has_changes }}
-      new_version: ${{ steps.bump_version.outputs.new_version }}
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.BROWSER_BOT_PAT }}
 
       - name: Restore latest pre-released sha
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
@@ -51,6 +48,7 @@ jobs:
         uses: ./.github/actions/setup-and-build
 
       - name: Set Up Git User
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           git config --global user.name "neo4j-browser-bot"
           git config --global user.email "browser@neo4j.com"


### PR DESCRIPTION
This pr is to:
- Use the correct token `VSCE_PAT` for the pre-release
- Commit the updated version only if the pre-release is successful

Latest run from my forked repo: https://github.com/nnecla/cypher-language-support/actions/runs/18038022870