### PR TITLE
use repo-wide PAT for fetch-dev-artifacts

### DIFF
--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -122,7 +122,7 @@ jobs:
         if: steps.git-check.outputs.modified == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.BROWSER_BOT_PAT }}
           branch: ${{ env.BRANCH_NAME }}
           base: main
           title: "Automated update of artifacts to neo4j version ${{ env.neo4j_version_base }}"


### PR DESCRIPTION
We recently moved the browser-bot PAT from being an env secret to instead be a repo-wide secret, since we use it in two different environments right now (this, and the prerelease workflow - and could very well want it in another later). To be sure it worked, we checked that the pre-release workflow worked, and since it does, we should safely be able to use the PAT here too