### PR TITLE
Adds testing that broken rel chains give symbol table

### DIFF
--- a/packages/language-support/src/tests/syntaxValidation/symbolTable.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolTable.test.ts
@@ -257,4 +257,89 @@ describe('Symbol table spec', () => {
       ],
     ]);
   });
+
+  test('Symbol table contains labels and rels for unfinished rel chain', () => {
+    const query = 'MATCH (t:Trainer)-[r:';
+    expect(
+      getSymbolTablesForQuery({
+        query,
+        dbSchema: {
+          ...testData.mockSchema,
+        },
+      }),
+    ).toEqual([
+      [
+        {
+          definitionPosition: 7,
+          labels: {
+            andOr: 'and',
+            children: [
+              {
+                validFrom: 16,
+                value: 'Trainer',
+              },
+            ],
+          },
+          references: [7],
+          types: ['Node'],
+          variable: 't',
+        },
+        {
+          definitionPosition: 19,
+          labels: {
+            andOr: 'and',
+            children: [],
+          },
+          references: [19],
+          types: ['Relationship'],
+          variable: 'r',
+        },
+      ],
+    ]);
+  });
+
+  test('Symbol table contains labels and rels for unfinished long rel chain', () => {
+    const query = 'MATCH (n:Person)-[r:KNOWS]->()-[:MET]-';
+    expect(
+      getSymbolTablesForQuery({
+        query,
+        dbSchema: {
+          ...testData.mockSchema,
+        },
+      }),
+    ).toEqual([
+      [
+        {
+          definitionPosition: 18,
+          labels: {
+            andOr: 'and',
+            children: [
+              {
+                validFrom: 25,
+                value: 'KNOWS',
+              },
+            ],
+          },
+          references: [18],
+          types: ['Relationship'],
+          variable: 'r',
+        },
+        {
+          definitionPosition: 7,
+          labels: {
+            andOr: 'and',
+            children: [
+              {
+                validFrom: 15,
+                value: 'Person',
+              },
+            ],
+          },
+          references: [7],
+          types: ['Node'],
+          variable: 'n',
+        },
+      ],
+    ]);
+  });
 });


### PR DESCRIPTION
We added AST-repair of rel chains on the server end, with testing there that it works. Just to be sure things are properly transpiled (with certain constructs, ex. the scala syntax `:+` it can work on the server side but transpile incorrectly) we should have a few tests on our end too