### PR TITLE
Start vscode changelog 1.14.0

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,7 +1,7 @@
 # neo4j-for-vscode
 
 ## 1.14.0
-- Minor bugfixes (handling new linter naming scheme, formatter capitalizing preparser keywords in namespaces, linter terminating on slow queries, missing label warnings, handle queries needing implicit transactions,)
+- Minor bugfixes (handling new linter naming scheme, formatter capitalizing preparser keywords in namespaces, linter terminating on slow queries, missing label warnings, handle queries needing implicit transactions)
 - Speed up symbol table reliant completions
 - Adds first iteration of schema aware completions for paths, behind feature flag
 


### PR DESCRIPTION
We used to add changes relevant for the next vscode release to the next changelog as we went, preventing the need to dig back into old commits and check what happened since the last release. I think we should do so again. I added the entry for 1.14.0 and did some digging of what we had done since 1.13.0 to come up with this. 