### PR TITLE
Remove re-calc of symbol table on switching to non-cypher file

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -124,14 +124,16 @@ export async function activate(context: ExtensionContext) {
 
   window.onDidChangeActiveTextEditor((editor) => {
     const doc = editor.document;
-    const query = doc.getText();
-    const uri = doc.uri.fsPath;
-    const schema = getSchemaPoller().metadata?.dbSchema;
-    void sendNotificationToLanguageClient('fetchSymbolTable', {
-      query,
-      uri,
-      schema,
-    });
+    if (doc.languageId === 'cypher') {
+      const query = doc.getText();
+      const uri = doc.uri.fsPath;
+      const schema = getSchemaPoller().metadata?.dbSchema;
+      void sendNotificationToLanguageClient('fetchSymbolTable', {
+        query,
+        uri,
+        schema,
+      });
+    }
   });
 }
 


### PR DESCRIPTION
My check for "if focused on new file -> re-calculate symbol table" didn't check that the file was a cypher file, so we do it on any file you open in the editor. This adds a `if (doc.languageId === 'cypher')` check first