### PR TITLE
adding support for the help command

### DIFF
--- a/.changeset/fuzzy-mangos-throw.md
+++ b/.changeset/fuzzy-mangos-throw.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+adding support for the help command

--- a/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
@@ -23,3 +23,5 @@ RESET: R E S E T;
 PLAY: P L A Y;
 
 ACCESSMODE: A C C E S S '-' M O D E;
+
+HELP: H E L P;

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -21,6 +21,7 @@ consoleCommand: COLON (
     | styleCmd
     | playCmd
     | accessModeCmd
+    | helpCmd
 );
 
 paramsCmd: PARAM paramsArgs?;
@@ -54,6 +55,8 @@ playCmd: PLAY;
 accessModeArgs: (readCompletionRule | writeCompletionRule);
 
 accessModeCmd: ACCESSMODE accessModeArgs?;
+
+helpCmd: HELP;
 
 // These rules are needed to distinguish cypher <-> commands, for exapmle `USE` and `:use` in autocompletion
 listCompletionRule: LIST; 

--- a/packages/language-support/src/lexerSymbols.ts
+++ b/packages/language-support/src/lexerSymbols.ts
@@ -407,6 +407,7 @@ export const lexerConsoleCmds = [
   CypherLexer.RESET,
   CypherLexer.PLAY,
   CypherLexer.ACCESSMODE,
+  CypherLexer.HELP,
 ];
 
 function toTokentypeObject(arr: number[], tokenType: CypherTokenType) {

--- a/packages/language-support/src/parserWrapper.ts
+++ b/packages/language-support/src/parserWrapper.ts
@@ -566,7 +566,8 @@ export type ParsedCommandNoPosition =
   | { type: 'sysinfo' }
   | { type: 'style'; operation?: 'reset' }
   | { type: 'play' }
-  | { type: 'access-mode'; operation?: string };
+  | { type: 'access-mode'; operation?: string }
+  | { type: 'help' };
 
 export type ParsedCommand = ParsedCommandNoPosition & RuleTokens;
 
@@ -757,6 +758,11 @@ function parseToCommand(
             stop,
           };
         }
+      }
+
+      const helpCmd = consoleCmd.helpCmd();
+      if (helpCmd) {
+        return { type: 'help', start, stop };
       }
 
       return { type: 'parse-error', start, stop };

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -55,6 +55,7 @@ describe('sanity checks', () => {
     expectParsedCommands(':sysinfo', [{ type: 'sysinfo' }]);
     expectParsedCommands(':style', [{ type: 'style' }]);
     expectParsedCommands(':play', [{ type: 'play' }]);
+    expectParsedCommands(':help', [{ type: 'help' }]);
   });
 
   test('properly highlights simple commands', () => {
@@ -218,12 +219,28 @@ describe('sanity checks', () => {
         tokenType: 'consoleCommand',
       },
     ]);
+
+    expect(applySyntaxColouring(':help')).toEqual([
+      {
+        length: 1,
+        position: { line: 0, startCharacter: 0, startOffset: 0 },
+        token: ':',
+        tokenType: 'consoleCommand',
+      },
+      {
+        length: 4,
+        position: { line: 0, startCharacter: 1, startOffset: 1 },
+        token: 'help',
+        tokenType: 'consoleCommand',
+      },
+    ]);
   });
 
   test('completes basic console cmds on :', () => {
     expect(autocomplete(':', {})).toEqual([
       { kind: 23, label: 'server' },
       { kind: 23, label: 'use' },
+      { kind: 23, label: 'help' },
       { kind: 23, label: 'access-mode' },
       { kind: 23, label: 'play' },
       { kind: 23, label: 'style' },
@@ -270,7 +287,7 @@ describe('sanity checks', () => {
   test('handles misspelled or non-existing command', () => {
     expectErrorMessage(
       ':foo',
-      'Expected any of access-mode, play, style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
+      'Expected any of help, access-mode, play, style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
     );
 
     expectErrorMessage(':clea', 'Unexpected token. Did you mean clear?');


### PR DESCRIPTION
This pr is to add :help command to the grammar. This command displays the available commands in query.