### PR TITLE
Revert "Remove slice"

### DIFF
--- a/packages/language-server/src/autocompletion.ts
+++ b/packages/language-server/src/autocompletion.ts
@@ -31,7 +31,8 @@ export function doAutoCompletion(
       completionParams.context?.triggerCharacter !== ' ';
     if (yieldTriggered || manualOrCharacterOrInwordTriggered) {
       const completions: CompletionItem[] = autocomplete(
-        textDocument.getText(),
+        // TODO This is a temporary hack because completions are not working well
+        textDocument.getText().slice(0, offset),
         neo4j.metadata?.dbSchema ?? {},
         offset,
         completionParams.context.triggerKind === CompletionTriggerKind.Invoked,

--- a/packages/language-support/src/autocompletion/autocompletion.ts
+++ b/packages/language-support/src/autocompletion/autocompletion.ts
@@ -10,7 +10,7 @@ export function autocomplete(
   caretPosition: number = query.length,
   manual = false,
 ): CompletionItem[] {
-  const parsingResult = parserWrapper.parse(query, { caretPosition });
+  const parsingResult = parserWrapper.parse(query);
   const symbolsInfo = parserWrapper.symbolsInfo;
   /* We try to locate the statement where the caret is and the token of the caret
 

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -563,7 +563,7 @@ export function completionCoreCompletion(
 
       if (ruleNumber === CypherParser.RULE_procedureResultItem) {
         const callContext = findParent(
-          parsingResult.lastRule.parentCtx,
+          parsingResult.stopNode.parentCtx,
           (x) => x instanceof CallClauseContext,
         );
         if (callContext instanceof CallClauseContext) {
@@ -632,10 +632,7 @@ export function completionCoreCompletion(
           grandParentRule == CypherParser.RULE_postFix &&
           greatGrandParentRule === CypherParser.RULE_expression2
         ) {
-          const expr2 = findParent(
-            parsingResult.lastRule,
-            (x) => x instanceof Expression2Context,
-          );
+          const expr2 = parsingResult.stopNode?.parentCtx?.parentCtx?.parentCtx;
           if (expr2 instanceof Expression2Context) {
             const variable = expr2.expression1().variable();
             const variablePosition = variable?.start?.start;

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -127,21 +127,19 @@ export function completeRelationshipType(
 
   // limitation: not checking PathPatternNonEmptyContext
   // limitation: not handling parenthesized paths
-  const patternContext = findParent(
-    parsingResult.lastRule.parentCtx,
+  const callContext = findParent(
+    parsingResult.stopNode.parentCtx,
     (x) => x instanceof PatternElementContext,
   );
 
-  if (patternContext instanceof PatternElementContext) {
-    const lastValidElement = patternContext.children
-      .toReversed()
-      .find((child) => {
-        if (child instanceof ParserRuleContext) {
-          if (child.exception === null) {
-            return true;
-          }
+  if (callContext instanceof PatternElementContext) {
+    const lastValidElement = callContext.children.toReversed().find((child) => {
+      if (child instanceof ParserRuleContext) {
+        if (child.exception === null) {
+          return true;
         }
-      });
+      }
+    });
 
     // limitation: bailing out on quantifiers
     if (lastValidElement instanceof QuantifierContext) {

--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -185,7 +185,7 @@ export function signatureHelp(
   const prevCaretPosition = caretPosition - 1;
 
   if (prevCaretPosition > 0) {
-    const parserResult = parserWrapper.parse(query, { caretPosition });
+    const parserResult = parserWrapper.parse(query);
     const caret = findCaret(parserResult, prevCaretPosition);
 
     if (caret) {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -335,7 +335,7 @@ export function lintCypherQuery(
   consoleCommandsEnabled?: boolean,
 ): { diagnostics: SyntaxDiagnostic[]; symbolTables: SymbolTable[] } {
   if (query.length > 0) {
-    const cachedParse = parserWrapper.parse(query, { consoleCommandsEnabled });
+    const cachedParse = parserWrapper.parse(query, consoleCommandsEnabled);
     const statements = cachedParse.statementsParsing;
     const result = statements.map((current) => {
       const cmd = current.command;

--- a/packages/react-codemirror/src/lang-cypher/autocomplete.ts
+++ b/packages/react-codemirror/src/lang-cypher/autocomplete.ts
@@ -82,7 +82,8 @@ export const cypherAutocomplete: (config: CypherConfig) => CompletionSource =
     }
 
     const options = autocomplete(
-      documentText,
+      // TODO This is a temporary hack because completions are not working well
+      documentText.slice(0, offset),
       config.schema ?? {},
       offset,
       context.explicit,


### PR DESCRIPTION
Reverts neo4j/cypher-language-support#594

Broke queries with spaces in rels after the caret like:
`MATCH (n:Answer)-[:  ^ `