### PR TITLE
Tries to switch to antlr4ng and antlr-ng parser WIP

### DIFF
--- a/packages/language-support/package.json
+++ b/packages/language-support/package.json
@@ -51,14 +51,15 @@
     "node": ">=22.15.0"
   },
   "dependencies": {
-    "antlr4": "4.13.2",
+    "antlr4ng": "3.0.16",
+    "antlr4-c3": "3.4.4",
     "fastest-levenshtein": "^1.0.16",
     "vscode-languageserver-types": "^3.17.3"
   },
   "scripts": {
-    "gen-parser": "cross-env ANTLR4_TOOLS_ANTLR_VERSION=4.13.2 antlr4 -Dlanguage=TypeScript -visitor src/antlr-grammar/CypherCmdLexer.g4 src/antlr-grammar/CypherCmdParser.g4 -o src/generated-parser/ -Xexact-output-dir",
-    "build": "cd ../../vendor/antlr4-c3/ && pnpm build && cd - && pnpm gen-parser && concurrently 'npm:build-esm-and-types' 'npm:build-commonjs' 'npm:build-cypherfmt-cli'",
-    "build-esm-and-types": "tsc --module esnext --outDir dist/esm/project/language-support && cp src/syntaxValidation/semanticAnalysis.js dist/esm/project/language-support/src/syntaxValidation/semanticAnalysis.js && mkdir -p dist/esm/vendor/antlr4-c3/dist/ && cp -r ../../vendor/antlr4-c3/dist/esm  dist/esm/vendor/antlr4-c3/dist/",
+    "gen-parser": "cross-env antlr-ng -Dlanguage=TypeScript --generate-visitor true src/antlr-grammar/CypherCmdLexer.g4 src/antlr-grammar/CypherCmdParser.g4 -o src/generated-parser/ --exact-output-dir",
+    "build": "pnpm gen-parser && concurrently 'npm:build-esm-and-types' 'npm:build-commonjs' 'npm:build-cypherfmt-cli'",
+    "build-esm-and-types": "tsc --module esnext --outDir dist/esm/project/language-support && cp src/syntaxValidation/semanticAnalysis.js dist/esm/project/language-support/src/syntaxValidation/semanticAnalysis.js",
     "build-commonjs": "esbuild ./src/index.ts --bundle --format=cjs --sourcemap --outfile=dist/cjs/index.cjs",
     "build-cypherfmt-cli": "esbuild ./src/formatting/cli.ts --bundle --format=esm --sourcemap --outfile=dist/esm/formatting/cli.mjs --external:fs --external:path",
     "dev": "pnpm build && concurrently 'tsc --module esnext --outDir dist/esm/project/language-support --watch' 'npm:build-commonjs -- --watch'",

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -11,7 +11,7 @@ import {
   PatternElementContext,
   QuantifierContext,
 } from '../generated-parser/CypherCmdParser';
-import { ParserRuleContext } from 'antlr4';
+import { ParserRuleContext } from 'antlr4ng';
 import { backtickIfNeeded } from './autocompletionHelpers';
 import { _internalFeatureFlags } from '../featureFlags';
 
@@ -128,7 +128,7 @@ export function completeRelationshipType(
   // limitation: not checking PathPatternNonEmptyContext
   // limitation: not handling parenthesized paths
   const patternContext = findParent(
-    parsingResult.lastRule.parentCtx,
+    parsingResult.lastRule.parent,
     (x) => x instanceof PatternElementContext,
   );
 
@@ -137,9 +137,7 @@ export function completeRelationshipType(
       .toReversed()
       .find((child) => {
         if (child instanceof ParserRuleContext) {
-          if (child.exception === null) {
-            return true;
-          }
+          return true; 
         }
       });
 

--- a/packages/language-support/src/formatting/formatting.ts
+++ b/packages/language-support/src/formatting/formatting.ts
@@ -4,8 +4,8 @@ import {
   ParserRuleContext,
   TerminalNode,
   Token,
-} from 'antlr4';
-import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
+} from 'antlr4ng';
+import { CypherCmdLexer as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
 import {
   AddPropContext,
   ArrowLineContext,
@@ -112,7 +112,7 @@ import {
   WhereClauseContext,
   WithClauseContext,
 } from '../generated-parser/CypherCmdParser';
-import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
+import { CypherCmdParserVisitor } from '../generated-parser/CypherCmdParserVisitor';
 import {
   Chunk,
   CommentChunk,
@@ -577,7 +577,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
     let gapText = '';
     if (this.previousTokenIndex < errorTokenIndex - 1) {
-      const skippedTokens = this.tokenStream.tokens.slice(
+      const skippedTokens = this.tokenStream.getTokens().slice(
         this.previousTokenIndex + 1,
         errorTokenIndex,
       );
@@ -607,7 +607,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitStatementsOrCommands = (ctx: StatementsOrCommandsContext) => {
-    const n = ctx.statementOrCommand_list().length;
+    const n = ctx.statementOrCommand().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.statementOrCommand(i));
       if (i < n - 1 || ctx.SEMICOLON(i)) {
@@ -746,7 +746,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.avoidSpaceBetween();
     this.visit(ctx.COLON());
     this.avoidSpaceBetween();
-    const n = ctx.symbolicNameString_list().length;
+    const n = ctx.symbolicNameString().length;
     for (let i = 0; i < n; i++) {
       this.visit(ctx.symbolicNameString(i));
       if (i < n - 1) {
@@ -802,7 +802,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitWhen = (ctx: WhenContext) => {
-    const n = ctx.whenBranch_list().length;
+    const n = ctx.whenBranch().length;
     for (let i = 0; i < n; i++) {
       this.breakLine();
       this._visit(ctx.whenBranch(i));
@@ -868,7 +868,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.patternList());
     this.endGroup(patternListGrp);
     this.endGroup(matchClauseGrp);
-    const n = ctx.hint_list().length;
+    const n = ctx.hint().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.hint(i));
     }
@@ -901,7 +901,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this._visit(ctx.DELETE());
     const deleteIndent = this.addIndentation();
-    const n = ctx.expression_list().length;
+    const n = ctx.expression().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.expression(i));
       if (i < n - 1) {
@@ -1002,7 +1002,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const letGrp = this.startGroup();
     this._visit(ctx.LET());
     const letIndent = this.addIndentation();
-    const n = ctx.letItem_list().length;
+    const n = ctx.letItem().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.letItem(i));
       if (i < n - 1) {
@@ -1049,7 +1049,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (ctx.TIMES()) {
       this._visit(ctx.TIMES());
     }
-    const n = ctx.returnItem_list().length;
+    const n = ctx.returnItem().length;
     if (n === 1) {
       this.setOneItemProperty();
     }
@@ -1166,7 +1166,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitLabelExpression2 = (ctx: LabelExpression2Context) => {
-    const n = ctx.EXCLAMATION_MARK_list().length;
+    const n = ctx.EXCLAMATION_MARK().length;
     for (let i = 0; i < n; i++) {
       this._visitTerminalRaw(ctx.EXCLAMATION_MARK(i));
       this.concatenate();
@@ -1184,7 +1184,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (this.chunkList.length === 0) {
       this.addCommentsBefore(node);
     }
-    if (node.symbol.type === CypherCmdLexer.EOF) {
+    if (node.symbol.type === CypherCmdLexer.cEOF) {
       return;
     }
     let text = node.getText();
@@ -1375,7 +1375,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
       this.avoidSpaceBetween();
       this._visit(ctx.leftArrow());
     }
-    const arrowLineList = ctx.arrowLine_list();
+    const arrowLineList = ctx.arrowLine();
     // Concatenations are to ensure the (left) arrow remains
     // on the previous line (styleguide rule) if we need to break within the pattern
     this._visit(arrowLineList[0]);
@@ -1532,7 +1532,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitPatternList = (ctx: PatternListContext) => {
-    const n = ctx.pattern_list().length;
+    const n = ctx.pattern().length;
     const wholePatternListGrp = this.startGroup();
     for (let i = 0; i < n; i++) {
       const patternListItemGrp = this.startGroup();
@@ -1621,7 +1621,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   // Handled separately because the dots aren't operators
   visitNamespace = (ctx: NamespaceContext) => {
-    const n = ctx.DOT_list().length;
+    const n = ctx.DOT().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.symbolicNameString(i));
       this.avoidSpaceBetween();
@@ -1632,7 +1632,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Handled separately because the dot is not an operator
   visitProperty = (ctx: PropertyContext) => {
     this._visitTerminalRaw(ctx.DOT());
-    if (!(ctx.parentCtx instanceof MapProjectionElementContext)) {
+    if (!(ctx.parent instanceof MapProjectionElementContext)) {
       this.concatenate();
     }
     this._visit(ctx.propertyKeyName());
@@ -1696,7 +1696,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   };
 
   visitExpression9 = (ctx: Expression9Context) => {
-    const n = ctx.NOT_list().length;
+    const n = ctx.NOT().length;
     if (n === 0) {
       this.visitChildren(ctx);
       return;
@@ -1736,7 +1736,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
 
   visitExpression2 = (ctx: Expression2Context) => {
     this._visit(ctx.expression1());
-    const n = ctx.postFix_list().length;
+    const n = ctx.postFix().length;
     for (let i = 0; i < n; i++) {
       this.avoidSpaceBetween();
       this._visit(ctx.postFix(i));
@@ -1862,7 +1862,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const wholeCaseGrp = this.startGroup();
     this.mustBreakBetween();
     this.visit(ctx.CASE());
-    const n = ctx.caseAlternative_list().length;
+    const n = ctx.caseAlternative().length;
     for (let i = 0; i < n; i++) {
       this.mustBreakBetween();
       this.visit(ctx.caseAlternative(i));
@@ -1888,7 +1888,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const wholeAlternativeGrp = this.startGroup();
     this._visit(ctx.WHEN());
     const whenIndent = this.addIndentation();
-    const n = ctx.extendedWhen_list().length;
+    const n = ctx.extendedWhen().length;
     for (let i = 0; i < n; i++) {
       this.visit(ctx.extendedWhen(i));
       if (i < n - 1) {
@@ -1913,7 +1913,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.avoidBreakBetween();
     this._visit(ctx.expression(0));
     this.mustBreakBetween();
-    const n = ctx.extendedCaseAlternative_list().length;
+    const n = ctx.extendedCaseAlternative().length;
     for (let i = 0; i < n; i++) {
       this.mustBreakBetween();
       this.visit(ctx.extendedCaseAlternative(i));
@@ -1958,7 +1958,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     if (ctx.TIMES()) {
       this._visit(ctx.TIMES());
     } else {
-      const n = ctx.variable_list().length;
+      const n = ctx.variable().length;
       for (let i = 0; i < n; i++) {
         const functionArgGrp = this.startGroup();
         this._visit(ctx.variable(i));
@@ -1980,7 +1980,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
   // Handled separately because UNION wants to look a certain way
   visitUnion = (ctx: UnionContext) => {
     this._visit(ctx.singleQuery(0));
-    const n = ctx.singleQuery_list().length - 1;
+    const n = ctx.singleQuery().length - 1;
     for (let i = 0; i < n; i++) {
       const unionIndent = this.addIndentation();
       this.breakLine();
@@ -2065,7 +2065,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     this._visit(ctx.ALL());
     this._visit(ctx.DISTINCT());
-    const n = ctx.functionArgument_list().length;
+    const n = ctx.functionArgument().length;
     if (n === 1) {
       this.setOneItemProperty();
     }
@@ -2103,7 +2103,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.pattern());
     this.removeIndentation(mergeClauseIndent);
     this.endGroup(mergeGrp);
-    const n = ctx.mergeAction_list().length;
+    const n = ctx.mergeAction().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.mergeAction(i));
     }
@@ -2180,7 +2180,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const setClauseGrp = this.startGroup();
     this._visit(ctx.SET());
     const setIndent = this.addIndentation();
-    const n = ctx.setItem_list().length;
+    const n = ctx.setItem().length;
     for (let i = 0; i < n; i++) {
       const setItemGrp = this.startGroup();
       this._visit(ctx.setItem(i));
@@ -2201,7 +2201,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this.setSpecialSplitProperty();
     const mapIndent = this.addIndentation();
     this.avoidSpaceBetween();
-    const n = ctx.expression_list().length;
+    const n = ctx.expression().length;
     for (let i = 0; i < n; i++) {
       const keyValueGrp = this.startGroup();
       this._visit(ctx.propertyKeyName(i));
@@ -2250,7 +2250,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.LCURLY());
     const mapProjectionIndent = this.addIndentation();
     this.avoidSpaceBetween();
-    const n = ctx.mapProjectionElement_list().length;
+    const n = ctx.mapProjectionElement().length;
     for (let i = 0; i < n; i++) {
       this._visit(ctx.mapProjectionElement(i));
       if (i < n - 1) {
@@ -2306,7 +2306,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.LBRACKET());
     this.setSpecialSplitProperty();
     const listIndent = this.addIndentation();
-    const n = ctx.expression_list().length;
+    const n = ctx.expression().length;
     for (let i = 0; i < n; i++) {
       const listElemGrp = this.startGroup();
       this._visit(ctx.expression(i));
@@ -2367,7 +2367,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     this._visit(ctx.expression());
     this._visit(ctx.BAR());
 
-    const n = ctx.clause_list().length;
+    const n = ctx.clause().length;
     const clauseIndent = this.addIndentation();
     for (let i = 0; i < n; i++) {
       this._visit(ctx.clause(i));
@@ -2395,7 +2395,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     const procedureNameGrp = this.startGroup();
     this._visit(ctx.procedureName());
     this.endGroup(procedureNameGrp);
-    const n = ctx.procedureArgument_list().length;
+    const n = ctx.procedureArgument().length;
     if (ctx.LPAREN()) {
       this.avoidSpaceBetween();
       this.avoidBreakBetween();
@@ -2426,7 +2426,7 @@ export class TreePrintVisitor extends CypherCmdParserVisitor<void> {
     }
     if (ctx.YIELD()) {
       const yieldGrp = this.startGroup();
-      const m = ctx.procedureResultItem_list().length;
+      const m = ctx.procedureResultItem().length;
       this._visit(ctx.YIELD());
       if (ctx.TIMES()) {
         this._visit(ctx.TIMES());
@@ -2525,7 +2525,7 @@ export function formatQuery(
     };
   }
 
-  const targetToken = findTargetToken(tokens.tokens, cursorPosition);
+  const targetToken = findTargetToken(tokens.getTokens(), cursorPosition);
   if (!targetToken) {
     return {
       formattedQuery: visitor.format(),

--- a/packages/language-support/src/formatting/formattingHelpers.ts
+++ b/packages/language-support/src/formatting/formattingHelpers.ts
@@ -1,6 +1,6 @@
-import { CharStreams, CommonTokenStream, TerminalNode, Token } from 'antlr4';
-import { default as CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
-import CypherCmdParser, {
+import { CharStream, CommonTokenStream, TerminalNode, Token } from 'antlr4ng';
+import { CypherCmdLexer } from '../generated-parser/CypherCmdLexer';
+import { CypherCmdParser,
   EscapedSymbolicNameStringContext,
   UnescapedSymbolicNameStringContext,
 } from '../generated-parser/CypherCmdParser';
@@ -122,7 +122,7 @@ function isSymbolicName(node: TerminalNode): boolean {
 }
 
 export function getParseTreeAndTokens(query: string) {
-  const inputStream = CharStreams.fromString(query);
+  const inputStream = CharStream.fromString(query);
   const lexer = new CypherCmdLexer(inputStream);
   const tokens = new CommonTokenStream(lexer);
   const parser = new CypherCmdParser(tokens);
@@ -131,20 +131,21 @@ export function getParseTreeAndTokens(query: string) {
   const tree = parser.statementsOrCommands();
   let unParseable: string | undefined;
   let firstUnParseableToken: Token | undefined;
-  if (tree.exception) {
-    const idx = tree.exception.offendingToken.tokenIndex;
-    const errorTokens = tokens.tokens.slice(idx);
-    const hiddenBefore = (tokens.getHiddenTokensToLeft(idx) || [])
-      .map((t) => t.text)
-      .join('');
-    unParseable =
-      hiddenBefore +
-      errorTokens
-        .slice(0, -1)
-        .map((t) => t.text)
-        .join('');
-    firstUnParseableToken = tree.exception.offendingToken;
-  }
+  //TODO Undo
+  // if (tree.exception) {
+  //   const idx = tree.exception.offendingToken.tokenIndex;
+  //   const errorTokens = tokens.getTokens().slice(idx);
+  //   const hiddenBefore = (tokens.getHiddenTokensToLeft(idx) || [])
+  //     .map((t) => t.text)
+  //     .join('');
+  //   unParseable =
+  //     hiddenBefore +
+  //     errorTokens
+  //       .slice(0, -1)
+  //       .map((t) => t.text)
+  //       .join('');
+  //   firstUnParseableToken = tree.exception.offendingToken;
+  // }
   return { tree, tokens, unParseable, firstUnParseableToken };
 }
 

--- a/packages/language-support/src/formatting/standardizer.ts
+++ b/packages/language-support/src/formatting/standardizer.ts
@@ -1,6 +1,6 @@
-import { TerminalNode } from 'antlr4';
+import { TerminalNode } from 'antlr4ng';
 import { StatementsOrCommandsContext } from '../generated-parser/CypherCmdParser';
-import CypherCmdParserVisitor from '../generated-parser/CypherCmdParserVisitor';
+import {CypherCmdParserVisitor} from '../generated-parser/CypherCmdParserVisitor';
 import { getParseTreeAndTokens } from './formattingHelpers';
 
 class StandardizingVisitor extends CypherCmdParserVisitor<void> {

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -1,11 +1,11 @@
-export type { ParserRuleContext } from 'antlr4';
+export type { ParserRuleContext } from 'antlr4ng';
 export { autocomplete } from './autocompletion/autocompletion';
 export { shouldAutoCompleteYield } from './autocompletion/autocompletionHelpers';
 export { backtickIfNeeded } from './autocompletion/autocompletionHelpers';
 export type { DbSchema } from './dbSchema';
 export { _internalFeatureFlags } from './featureFlags';
 export { formatQuery } from './formatting/formatting';
-export { antlrUtils } from './helpers';
+// export { antlrUtils } from './helpers';
 export { CypherTokenType, lexerSymbols } from './lexerSymbols';
 export {
   parse,
@@ -35,12 +35,12 @@ export type {
   Neo4jProcedure,
   SymbolTable,
 } from './types';
-export { CypherLexer, CypherParser, CypherParserListener, CypherParserVisitor };
+export { CypherLexer, CypherParser, CypherParserListener, CypherCmdParserVisitor };
 
-import CypherLexer from './generated-parser/CypherCmdLexer';
-import CypherParser from './generated-parser/CypherCmdParser';
-import CypherParserListener from './generated-parser/CypherCmdParserListener';
-import CypherParserVisitor from './generated-parser/CypherCmdParserVisitor';
+import { CypherCmdLexer as CypherLexer } from './generated-parser/CypherCmdLexer';
+import { CypherCmdParser as CypherParser } from './generated-parser/CypherCmdParser';
+import { CypherCmdParserListener as CypherParserListener } from './generated-parser/CypherCmdParserListener';
+import { CypherCmdParserVisitor } from './generated-parser/CypherCmdParserVisitor';
 
 export * from './generated-parser/CypherCmdLexer';
 export * from './generated-parser/CypherCmdParser';

--- a/packages/language-support/src/lexerSymbols.ts
+++ b/packages/language-support/src/lexerSymbols.ts
@@ -1,4 +1,4 @@
-import CypherLexer from './generated-parser/CypherCmdLexer';
+import {CypherCmdLexer as CypherLexer} from './generated-parser/CypherCmdLexer';
 
 export enum CypherTokenType {
   comment = 'comment',
@@ -84,7 +84,7 @@ export const lexerStringLiteral = [
 
 export const lexerGarbage = [
   CypherLexer.ErrorChar,
-  CypherLexer.EOF,
+  CypherLexer.cEOF,
   CypherLexer.SPACE,
 ];
 

--- a/packages/language-support/src/signatureHelp.ts
+++ b/packages/language-support/src/signatureHelp.ts
@@ -3,16 +3,16 @@ import {
   SignatureInformation,
 } from 'vscode-languageserver-types';
 
-import { ParseTreeWalker } from 'antlr4';
-import CypherParser, {
+import { ParseTreeWalker } from 'antlr4ng';
+import {CypherCmdParser as CypherParser,
   CallClauseContext,
   ExpressionContext,
   FunctionInvocationContext,
 } from './generated-parser/CypherCmdParser';
 
-import { Token } from '../../../vendor/antlr4-c3/dist/esm/index.js';
+import { Token } from 'antlr4ng';
 import { DbSchema } from './dbSchema';
-import CypherCmdParserListener from './generated-parser/CypherCmdParserListener';
+import {CypherCmdParserListener} from './generated-parser/CypherCmdParserListener';
 import { findCaret, isDefined, resolveCypherVersion } from './helpers';
 import { parserWrapper } from './parserWrapper';
 import { Neo4jFunction, Neo4jProcedure } from './types';
@@ -135,7 +135,7 @@ class SignatureHelper extends CypherCmdParserListener {
       isDefined(ctx.LPAREN())
     ) {
       const methodName = ctx.functionName().getText();
-      const previousArguments = ctx.COMMA_list().filter((arg) => {
+      const previousArguments = ctx.COMMA().filter((arg) => {
         return arg.symbol.stop <= this.caretToken.start;
       });
 
@@ -156,7 +156,7 @@ class SignatureHelper extends CypherCmdParserListener {
       isDefined(ctx.LPAREN())
     ) {
       const methodName = ctx.procedureName().getText();
-      const previousArguments = ctx.COMMA_list().filter((arg) => {
+      const previousArguments = ctx.COMMA().filter((arg) => {
         return arg.symbol.stop <= this.caretToken.start;
       });
 

--- a/packages/language-support/src/syntaxColouring/syntaxColouring.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouring.ts
@@ -1,4 +1,4 @@
-import { ParseTreeWalker, TerminalNode, Token } from 'antlr4';
+import { ParseTreeWalker, TerminalNode, Token } from 'antlr4ng';
 
 import {
   AccessModeArgsContext,
@@ -35,8 +35,8 @@ import {
   SemanticTokensLegend,
   SemanticTokenTypes,
 } from 'vscode-languageserver-types';
-import CypherLexer from '../generated-parser/CypherCmdLexer';
-import CypherParserListener from '../generated-parser/CypherCmdParserListener';
+import {CypherCmdLexer as CypherLexer} from '../generated-parser/CypherCmdLexer';
+import {CypherCmdParserListener as CypherParserListener} from '../generated-parser/CypherCmdParserListener';
 import { CypherTokenType } from '../lexerSymbols';
 import { parserWrapper } from '../parserWrapper';
 import {
@@ -169,7 +169,7 @@ class SyntaxHighlighter extends CypherParserListener {
   ) {
     const namespace = ctx.namespace();
 
-    namespace.symbolicNameString_list().forEach((namespaceName) => {
+    namespace.symbolicNameString().forEach((namespaceName) => {
       this.addToken(namespaceName.start, tokenType, namespaceName.getText());
     });
 
@@ -338,7 +338,7 @@ function colourLexerTokens(tokens: Token[]) {
 
       if (!tokenFinished) {
         tokens.slice(i + 1, tokens.length).forEach((nextToken) => {
-          if (nextToken.type !== CypherLexer.EOF) {
+          if (nextToken.type !== CypherLexer.cEOF) {
             tokenStr += nextToken.text;
           }
         });

--- a/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
+++ b/packages/language-support/src/syntaxColouring/syntaxColouringHelpers.ts
@@ -1,8 +1,8 @@
 import { SemanticTokenTypes } from 'vscode-languageserver-types';
 
-import { Token } from 'antlr4';
+import { Token } from 'antlr4ng';
 
-import CypherLexer from '../generated-parser/CypherCmdLexer';
+import {CypherCmdLexer as CypherLexer} from '../generated-parser/CypherCmdLexer';
 
 import { isCommentOpener } from '../helpers';
 import { CypherTokenType, lexerSymbols } from '../lexerSymbols';

--- a/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
+++ b/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
@@ -1,8 +1,8 @@
-import { Token } from 'antlr4';
+import { Token } from 'antlr4ng';
 import { distance } from 'fastest-levenshtein';
-import { CodeCompletionCore } from '../../../../vendor/antlr4-c3/dist/esm/index.js';
-import CypherLexer from '../generated-parser/CypherCmdLexer';
-import CypherParser from '../generated-parser/CypherCmdParser';
+import { CodeCompletionCore } from 'antlr4-c3';
+import {CypherCmdLexer as CypherLexer} from '../generated-parser/CypherCmdLexer';
+import {CypherCmdParser as CypherParser} from '../generated-parser/CypherCmdParser';
 import {
   CypherTokenType,
   keywordNames,

--- a/packages/language-support/src/tests/lexer.test.ts
+++ b/packages/language-support/src/tests/lexer.test.ts
@@ -1,6 +1,6 @@
-import { CharStreams, CommonTokenStream } from 'antlr4';
-import CypherLexer from '../generated-parser/CypherCmdLexer';
-import CypherParser from '../generated-parser/CypherCmdParser';
+import { CharStream, CommonTokenStream } from 'antlr4ng';
+import { CypherCmdLexer as CypherLexer} from '../generated-parser/CypherCmdLexer';
+import { CypherCmdParser as CypherParser} from '../generated-parser/CypherCmdParser';
 import { CypherTokenType, lexerSymbols, tokenNames } from '../lexerSymbols';
 
 describe('Lexer tokens', () => {
@@ -14,7 +14,7 @@ describe('Lexer tokens', () => {
       const symbolNumber = parseInt(k, 10);
 
       // There is no "-1" position in the symbolic name list so we handle EOF separately
-      if (symbolNumber === CypherParser.EOF) {
+      if (symbolNumber === CypherParser.cEOF) {
         return 'EOF';
       }
       return symbolicNames[symbolNumber];
@@ -41,13 +41,13 @@ describe('Lexer tokens', () => {
 
     keywordTokens.forEach((token) => {
       const tokenName = tokenNames[token];
-      const inputStream = CharStreams.fromString(tokenName);
+      const inputStream = CharStream.fromString(tokenName);
       const lexer = new CypherLexer(inputStream);
 
       const tokenStream = new CommonTokenStream(lexer);
       tokenStream.fill();
 
-      const tokens = tokenStream.tokens;
+      const tokens = tokenStream.getTokens();
 
       expect(tokens.length).toBe(2);
       // If the test fails, it is useful to see the token that was parsed
@@ -68,7 +68,7 @@ describe('Lexer tokens', () => {
         );
       }
       expect(tokens[0].type).toBe(token);
-      expect(tokens[1].type).toBe(CypherLexer.EOF);
+      expect(tokens[1].type).toBe(CypherLexer.cEOF);
     });
   });
 });

--- a/packages/react-codemirror-playground/src/treeUtil.ts
+++ b/packages/react-codemirror-playground/src/treeUtil.ts
@@ -4,32 +4,32 @@ interface SimpleTree {
 }
 
 import {
-  antlrUtils,
+  // antlrUtils,
   CypherParser,
   parse,
   ParserRuleContext,
 } from '@neo4j-cypher/language-support';
 
-export function getDebugTree(cypher: string): SimpleTree {
-  const statements = parse(cypher);
+// export function getDebugTree(cypher: string): SimpleTree {
+//   const statements = parse(cypher);
 
-  function walk(node: ParserRuleContext): SimpleTree {
-    const name = antlrUtils.tree.Trees.getNodeText(
-      node,
-      CypherParser.ruleNames,
-      CypherParser,
-    );
+//   function walk(node: ParserRuleContext): SimpleTree {
+//     const name = antlrUtils.tree.Trees.getNodeText(
+//       node,
+//       CypherParser.ruleNames,
+//       CypherParser,
+//     );
 
-    return {
-      name: name,
-      children: antlrUtils.tree.Trees.getChildren(node).map(walk),
-    };
-  }
+//     return {
+//       name: name,
+//       children: antlrUtils.tree.Trees.getChildren(node).map(walk),
+//     };
+//   }
 
-  const children = statements.map((statement) => walk(statement));
+//   const children = statements.map((statement) => walk(statement));
 
-  return {
-    name: 'topNode',
-    children: children,
-  };
-}
+//   return {
+//     name: 'topNode',
+//     children: children,
+//   };
+// }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,12 @@ importers:
 
   packages/language-support:
     dependencies:
-      antlr4:
-        specifier: 4.13.2
-        version: 4.13.2
+      antlr4-c3:
+        specifier: 3.4.4
+        version: 3.4.4
+      antlr4ng:
+        specifier: 3.0.16
+        version: 3.0.16
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16


### PR DESCRIPTION
Would be nice to not have an old built-in ANTLR4-c3 package in the repo. Looks like antlr4-c3 is TS now, so think we should be good to swap. 

Saw that antlr-ng is developed by the same guy who makes antlr4-c3 (and the readme says "antlr4-c3 The antlr-ng and ANTLR4 Code Completion Core", so I thought it could be nice to swap to this as well. 

My quick try of it needed a bunch of minor changes for small changes to how things work/are named.

Biggest issue seems to be that antlr-ng produces parser with "EOF" tokens, while it seems the library uses "cEOF" for the same purpose? 