### PR TITLE
limit html copy by selected text character length

### DIFF
--- a/packages/react-codemirror/src/richClipboardCopier.ts
+++ b/packages/react-codemirror/src/richClipboardCopier.ts
@@ -89,11 +89,11 @@ export const richClipboardCopier = EditorView.domEventHandlers({
 
     if (!selectedText) return;
 
-    const richHtml = getHTML(view, from, to);
-
     if (event.clipboardData) {
       event.clipboardData.setData('text/plain', selectedText);
-      event.clipboardData.setData('text/html', richHtml);
+      if (selectedText.length < 1000) {
+        event.clipboardData.setData('text/html', getHTML(view, from, to));
+      }
     }
   },
 });


### PR DESCRIPTION
This PR improves copy performance by adding a safeguard that limits when we attempt a rich HTML copy.

If the selected text is under 1000 characters, we copy it with full HTML styling; otherwise, we fall back to plain-text copy. This is a temporary solution until we find a more efficient approach for handling larger selections.

resolves DEV-603