### PR TITLE
adding auto-completion for :auto

### DIFF
--- a/.changeset/fancy-bushes-travel.md
+++ b/.changeset/fancy-bushes-travel.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/language-support': patch
+---
+
+adding auto-completion for :auto

--- a/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdLexer.g4
@@ -25,3 +25,5 @@ PLAY: P L A Y;
 ACCESSMODE: A C C E S S '-' M O D E;
 
 HELP: H E L P;
+
+AUTO: A U T O;

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -22,6 +22,7 @@ consoleCommand: COLON (
     | playCmd
     | accessModeCmd
     | helpCmd
+    | autoCmd
 );
 
 paramsCmd: PARAM paramsArgs?;
@@ -57,6 +58,8 @@ accessModeArgs: (readCompletionRule | writeCompletionRule);
 accessModeCmd: ACCESSMODE accessModeArgs?;
 
 helpCmd: HELP;
+
+autoCmd: AUTO statement SEMICOLON? EOF | AUTO EOF;
 
 // These rules are needed to distinguish cypher <-> commands, for exapmle `USE` and `:use` in autocompletion
 listCompletionRule: LIST; 

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -59,9 +59,9 @@ accessModeCmd: ACCESSMODE accessModeArgs?;
 
 helpCmd: HELP;
 
-autoCmd: AUTO statement SEMICOLON? EOF | AUTO EOF;
+autoCmd: AUTO statement?;
 
-// These rules are needed to distinguish cypher <-> commands, for exapmle `USE` and `:use` in autocompletion
+// These rules are needed to distinguish cypher <-> commands, for example `USE` and `:use` in autocompletion
 listCompletionRule: LIST; 
 
 useCompletionRule: USE;

--- a/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
+++ b/packages/language-support/src/antlr-grammar/CypherCmdParser.g4
@@ -59,7 +59,7 @@ accessModeCmd: ACCESSMODE accessModeArgs?;
 
 helpCmd: HELP;
 
-autoCmd: AUTO statement?;
+autoCmd: AUTO statement;
 
 // These rules are needed to distinguish cypher <-> commands, for example `USE` and `:use` in autocompletion
 listCompletionRule: LIST; 

--- a/packages/language-support/src/cypherLanguageService.ts
+++ b/packages/language-support/src/cypherLanguageService.ts
@@ -574,7 +574,8 @@ export type ParsedCommandNoPosition =
   | { type: 'style'; operation?: 'reset' }
   | { type: 'play'; guide?: string }
   | { type: 'access-mode'; operation?: string }
-  | { type: 'help' };
+  | { type: 'help' }
+  | { type: 'auto'; statement?: string };
 
 export type ParsedCommand = ParsedCommandNoPosition & RuleTokens;
 
@@ -775,6 +776,19 @@ function parseToCommand(
       const helpCmd = consoleCmd.helpCmd();
       if (helpCmd) {
         return { type: 'help', start, stop };
+      }
+
+      const autoCmd = consoleCmd.autoCmd();
+      if (autoCmd) {
+        const autoStmt = autoCmd.statement();
+        if (autoStmt && autoStmt.start && autoStmt.stop) {
+          const statement = inputstream.getText(
+            autoStmt.start.start,
+            autoStmt.stop.stop,
+          );
+          return { type: 'auto', statement, start, stop };
+        }
+        return { type: 'auto', start, stop };
       }
 
       return { type: 'parse-error', start, stop };

--- a/packages/language-support/src/cypherLanguageService.ts
+++ b/packages/language-support/src/cypherLanguageService.ts
@@ -782,11 +782,13 @@ function parseToCommand(
       if (autoCmd) {
         const autoStmt = autoCmd.statement();
         if (autoStmt && autoStmt.start && autoStmt.stop) {
+          //we want autoStmt.start so we skip :auto when calling semantic analysis
+          //but regular stop, so we include trailing error nodes not parsed as statement
           const statement = inputstream.getText(
             autoStmt.start.start,
-            autoStmt.stop.stop,
+            stop.stop,
           );
-          return { type: 'auto', statement, start, stop };
+          return { type: 'auto', statement, start: autoStmt.start, stop };
         }
         return { type: 'auto', start, stop };
       }

--- a/packages/language-support/src/lexerSymbols.ts
+++ b/packages/language-support/src/lexerSymbols.ts
@@ -425,6 +425,7 @@ export const lexerConsoleCmds = [
   CypherLexer.PLAY,
   CypherLexer.ACCESSMODE,
   CypherLexer.HELP,
+  CypherLexer.AUTO,
 ];
 
 function toTokentypeObject(arr: number[], tokenType: CypherTokenType) {

--- a/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
+++ b/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
@@ -28,6 +28,7 @@ export function completionCoreErrormessage(
   parser: CypherParser,
   currentToken: Token,
   consoleCommandsEnabled: boolean,
+  insideConsoleCommand: boolean = false,
 ): string | undefined {
   const codeCompletion = new CodeCompletionCore(parser);
   const caretIndex = currentToken.tokenIndex;
@@ -69,7 +70,10 @@ export function completionCoreErrormessage(
 
   // If we can complete only a statement, we don't want to suggest that
   // We want to be using the database errors stack instead
+  // Exception: inside console commands (e.g. :auto) we do want to report
+  // statement-level errors since there's no database error stack for those
   if (
+    !insideConsoleCommand &&
     ruleCandidates.length === 1 &&
     ruleCandidates[0] === CypherParser.RULE_statement
   ) {

--- a/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
+++ b/packages/language-support/src/syntaxValidation/completionCoreErrors.ts
@@ -28,7 +28,6 @@ export function completionCoreErrormessage(
   parser: CypherParser,
   currentToken: Token,
   consoleCommandsEnabled: boolean,
-  insideConsoleCommand: boolean = false,
 ): string | undefined {
   const codeCompletion = new CodeCompletionCore(parser);
   const caretIndex = currentToken.tokenIndex;
@@ -73,7 +72,6 @@ export function completionCoreErrormessage(
   // Exception: inside console commands (e.g. :auto) we do want to report
   // statement-level errors since there's no database error stack for those
   if (
-    !insideConsoleCommand &&
     ruleCandidates.length === 1 &&
     ruleCandidates[0] === CypherParser.RULE_statement
   ) {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -347,7 +347,10 @@ export function lintCypherQuery(
     const statements = resolvedParsingResult.statementsParsing;
     const result = statements.map((current) => {
       const cmd = current.command;
-      if (cmd.type === 'cypher' && cmd.statement.length > 0) {
+      if (
+        (cmd.type === 'cypher' || cmd.type === 'auto') &&
+        cmd.statement.length > 0
+      ) {
         if (current.cypherVersionError)
           return { diagnostics: [current.cypherVersionError], symbolTable: [] };
 

--- a/packages/language-support/src/syntaxValidation/syntaxValidationHelpers.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidationHelpers.ts
@@ -97,15 +97,10 @@ export class SyntaxErrorsListener implements ANTLRErrorListener<CommonToken> {
         offendingSymbol.type !== CypherLexer.ErrorChar &&
         !unfinishedComment
       ) {
-        const insideConsoleCommand = !!findParent(
-          ctx,
-          (n) => n instanceof ConsoleCommandContext,
-        );
         const errorMessage = completionCoreErrormessage(
           parser,
           offendingSymbol,
           this.consoleCommandsEnabled,
-          insideConsoleCommand,
         );
 
         if (errorMessage) {

--- a/packages/language-support/src/syntaxValidation/syntaxValidationHelpers.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidationHelpers.ts
@@ -97,10 +97,15 @@ export class SyntaxErrorsListener implements ANTLRErrorListener<CommonToken> {
         offendingSymbol.type !== CypherLexer.ErrorChar &&
         !unfinishedComment
       ) {
+        const insideConsoleCommand = !!findParent(
+          ctx,
+          (n) => n instanceof ConsoleCommandContext,
+        );
         const errorMessage = completionCoreErrormessage(
           parser,
           offendingSymbol,
           this.consoleCommandsEnabled,
+          insideConsoleCommand,
         );
 
         if (errorMessage) {

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -224,12 +224,28 @@ describe('sanity checks', () => {
         tokenType: 'consoleCommand',
       },
     ]);
+
+    expect(highlightSyntax(':auto')).toEqual([
+      {
+        length: 1,
+        position: { line: 0, startCharacter: 0, startOffset: 0 },
+        token: ':',
+        tokenType: 'consoleCommand',
+      },
+      {
+        length: 4,
+        position: { line: 0, startCharacter: 1, startOffset: 1 },
+        token: 'auto',
+        tokenType: 'consoleCommand',
+      },
+    ]);
   });
 
   test('completes basic console cmds on :', () => {
     expect(autocomplete(':', {})).toEqual([
       { kind: 23, label: 'server' },
       { kind: 23, label: 'use' },
+      { kind: 23, label: 'auto' },
       { kind: 23, label: 'help' },
       { kind: 23, label: 'access-mode' },
       { kind: 23, label: 'play' },
@@ -277,7 +293,7 @@ describe('sanity checks', () => {
   test('handles misspelled or non-existing command', () => {
     expectErrorMessage(
       ':foo',
-      'Expected any of help, access-mode, play, style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
+      'Expected any of auto, help, access-mode, play, style, sysinfo, welcome, disconnect, connect, param, history, clear, server or use',
     );
 
     expectErrorMessage(':clea', 'Unexpected token. Did you mean clear?');
@@ -782,6 +798,26 @@ describe('server', () => {
         tokenType: 'consoleCommand',
       },
     ]);
+  });
+});
+
+describe('auto', () => {
+  test('parses without arg', () => {
+    expectParsedCommands(':auto', [{ type: 'auto' }]);
+  });
+
+  test('parses with valid statement', () => {
+    expectParsedCommands(':auto RETURN 1', [
+      { type: 'auto', statement: 'RETURN 1' },
+    ]);
+  });
+
+  test('gives errors on invalid statement', () => {
+    expectErrorMessage(':auto asdf', 'Expected a statement');
+  });
+
+  test('gives errors on trailing garbage after valid statement', () => {
+    expectErrorMessage(':auto RETURN 1 asdf', "Expected ';' or a statement");
   });
 });
 

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -5,6 +5,7 @@ import {
 import { testData } from './testData.js';
 import { highlightSyntax } from '../syntaxHighlighting/syntaxHighlighting.js';
 import { autocomplete } from '../autocompletion/autocompletion.js';
+import { getDiagnosticsForQuery } from './syntaxValidation/helpers.js';
 
 function expectParsedCommands(
   query: string,
@@ -803,7 +804,7 @@ describe('server', () => {
 
 describe('auto', () => {
   test('parses without arg', () => {
-    expectParsedCommands(':auto', [{ type: 'auto' }]);
+    expectParsedCommands(':auto', [{ type: 'auto', statement: '' }]);
   });
 
   test('parses with valid statement', () => {
@@ -813,11 +814,113 @@ describe('auto', () => {
   });
 
   test('gives errors on invalid statement', () => {
-    expectErrorMessage(':auto asdf', 'Expected a statement');
+    const linting = getDiagnosticsForQuery({
+      query: ':auto asdf',
+      consoleCommandsEnabled: true,
+    });
+    expect(linting).toEqual([
+      {
+        offsets: {
+          end: 10,
+          start: 6,
+        },
+        message:
+          "Invalid input 'asdf': expected 'ALTER', 'ORDER BY', 'CALL', 'USING PERIODIC COMMIT', 'CREATE', 'LOAD CSV', 'START DATABASE', 'STOP DATABASE', 'DEALLOCATE', 'DELETE', 'DENY', 'DETACH', 'DROP', 'DRYRUN', 'FINISH', 'FOREACH', 'GRANT', 'INSERT', 'LIMIT', 'MATCH', 'MERGE', 'NODETACH', 'OFFSET', 'OPTIONAL', 'REALLOCATE', 'REMOVE', 'RENAME', 'RETURN', 'REVOKE', 'ENABLE SERVER', 'SET', 'SHOW', 'SKIP', 'TERMINATE', 'UNWIND', 'USE' or 'WITH'",
+        range: {
+          end: {
+            character: 10,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
   });
 
   test('gives errors on trailing garbage after valid statement', () => {
-    expectErrorMessage(':auto RETURN 1 asdf', "Expected ';' or a statement");
+    const linting = getDiagnosticsForQuery({
+      query: ':auto RETURN 1 asdf',
+      consoleCommandsEnabled: true,
+    });
+    expect(linting).toEqual([
+      {
+        offsets: {
+          end: 19,
+          start: 15,
+        },
+        message:
+          "Invalid input 'asdf': expected an expression, ',', 'AS', 'ORDER BY', 'CALL', 'CREATE', 'LOAD CSV', 'DELETE', 'DETACH', 'FINISH', 'FOREACH', 'INSERT', 'LIMIT', 'MATCH', 'MERGE', 'NODETACH', 'OFFSET', 'OPTIONAL', 'REMOVE', 'RETURN', 'SET', 'SKIP', 'UNION', 'UNWIND', 'USE', 'WITH' or <EOF>",
+        range: {
+          end: {
+            character: 19,
+            line: 0,
+          },
+          start: {
+            character: 15,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('provides semantic errors', () => {
+    const linting = getDiagnosticsForQuery({
+      query: ':auto RETURN n',
+      consoleCommandsEnabled: true,
+    });
+    expect(linting).toEqual([
+      {
+        offsets: {
+          end: 14,
+          start: 13,
+        },
+        message: 'Variable `n` not defined',
+        range: {
+          end: {
+            character: 14,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('handles multiple statements', () => {
+    const linting = getDiagnosticsForQuery({
+      query: ':auto RETURN n; MATCH (n) RETURN n',
+      consoleCommandsEnabled: true,
+    });
+    expect(linting).toEqual([
+      {
+        offsets: {
+          end: 14,
+          start: 13,
+        },
+        message: 'Variable `n` not defined',
+        range: {
+          end: {
+            character: 14,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
   });
 });
 

--- a/packages/language-support/src/tests/consoleCommands.test.ts
+++ b/packages/language-support/src/tests/consoleCommands.test.ts
@@ -5,7 +5,10 @@ import {
 import { testData } from './testData.js';
 import { highlightSyntax } from '../syntaxHighlighting/syntaxHighlighting.js';
 import { autocomplete } from '../autocompletion/autocompletion.js';
-import { getDiagnosticsForQuery } from './syntaxValidation/helpers.js';
+import {
+  getDiagnosticsForQuery,
+  getSymbolTablesForQuery,
+} from './syntaxValidation/helpers.js';
 
 function expectParsedCommands(
   query: string,
@@ -866,6 +869,27 @@ describe('auto', () => {
         },
         severity: 1,
       },
+    ]);
+  });
+
+  test('provides symbol tables with correct positions', () => {
+    const symbolTables = getSymbolTablesForQuery({
+      query: ':auto MATCH (n) RETURN n',
+      consoleCommandsEnabled: true,
+    });
+    expect(symbolTables).toEqual([
+      [
+        {
+          variable: 'n',
+          definitionPosition: 13,
+          types: ['Node'],
+          references: [13, 23],
+          labels: {
+            condition: 'and',
+            children: [],
+          },
+        },
+      ],
     ]);
   });
 


### PR DESCRIPTION
This pr is to add auto-completion support for the `:auto` command which is used by the Query app:
- `:auto` to preview a small explanation on auto-committing transactions
- `:auto [STATEMENT]` to run the statement with forced auto-committing transactions