### PR TITLE
Remove injection vulnerability in codemirror e2e via inputs.browser

### DIFF
--- a/.github/actions/codemirror-e2e-tests/action.yaml
+++ b/.github/actions/codemirror-e2e-tests/action.yaml
@@ -13,25 +13,33 @@ runs:
   steps:
     - name: Validate browser input
       shell: bash
+      env: 
+        BROWSER: ${{ inputs.browser }}
       run: |
-        if [[ "${{ inputs.browser }}" != "chromium" && "${{ inputs.browser }}" != "firefox" ]]; then
-          echo "Invalid browser (should be one of firefox or chromium): ${{ inputs.browser }}"
+        if [[ "$BROWSER" != "chromium" && "$BROWSER" != "firefox" ]]; then
+          echo "Invalid browser (should be one of firefox or chromium): $BROWSER"
           exit 1
         fi
 
     - name: Install Playwright Browsers
       shell: bash
-      run: pnpm exec playwright install --only-shell --with-deps ${{ inputs.browser }}
+      env: 
+        BROWSER: ${{ inputs.browser }}
+      run: pnpm exec playwright install --only-shell --with-deps "$BROWSER"
       working-directory: packages/react-codemirror
 
     - name: Run e2e test
       shell: bash
-      run: pnpm --filter react-codemirror test:e2e --project=${{ inputs.browser }}
+      env: 
+        BROWSER: ${{ inputs.browser }}
+      run: pnpm --filter react-codemirror test:e2e --project="$BROWSER"
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
       if: always()
+      env: 
+        BROWSER: ${{ inputs.browser }}
       with:
-        name: playwright-report-${{ inputs.browser }}
+        name: playwright-report-"$BROWSER"
         path: packages/react-codemirror/playwright-report/
         retention-days: 30

--- a/.github/actions/codemirror-e2e-tests/action.yaml
+++ b/.github/actions/codemirror-e2e-tests/action.yaml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Validate browser input
       shell: bash
-      env: 
+      env:
         BROWSER: ${{ inputs.browser }}
       run: |
         if [[ "$BROWSER" != "chromium" && "$BROWSER" != "firefox" ]]; then
@@ -23,23 +23,21 @@ runs:
 
     - name: Install Playwright Browsers
       shell: bash
-      env: 
+      env:
         BROWSER: ${{ inputs.browser }}
       run: pnpm exec playwright install --only-shell --with-deps "$BROWSER"
       working-directory: packages/react-codemirror
 
     - name: Run e2e test
       shell: bash
-      env: 
+      env:
         BROWSER: ${{ inputs.browser }}
       run: pnpm --filter react-codemirror test:e2e --project="$BROWSER"
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
       if: always()
-      env: 
-        BROWSER: ${{ inputs.browser }}
       with:
-        name: playwright-report-"$BROWSER"
+        name: playwright-report-${{ inputs.browser }}
         path: packages/react-codemirror/playwright-report/
         retention-days: 30

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -7,5 +7,7 @@
   ],
   "vendor/antlr4-c3/index.ts": ["bash check-imports.sh"],
   "*.js": ["oxlint --fix --type-aware --max-warnings 0"],
-  "*.json": ["oxfmt"]
+  "*.json": ["oxfmt"],
+  "*.yaml": ["oxfmt"],
+  "*.yml": ["oxfmt"]
 }


### PR DESCRIPTION
Closes LS-128

See description [here](https://linear.app/neo4j/issue/LS-128/command-injection-vulnerability-in-neo4jcypher-language-support)