### PR TITLE
fix(language-server): wait for cancellation before re-acquiring lint worker

### DIFF
--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -19,7 +19,7 @@ const defaultWorkerPath = join(__dirname, 'lintWorker.cjs');
 
 let pool = workerpool.pool(defaultWorkerPath, {
   minWorkers: 2,
-  workerTerminateTimeout: 0,
+  workerTerminateTimeout: 1000,
 });
 let linterVersion: string | undefined = undefined;
 let lastSemanticJob: LinterTask | undefined;
@@ -33,7 +33,7 @@ export async function setLintWorker(
   linterVersion = linter;
   pool = workerpool.pool(lintWorkerPath, {
     minWorkers: 2,
-    workerTerminateTimeout: 0,
+    workerTerminateTimeout: 1000,
   });
 }
 
@@ -51,17 +51,42 @@ async function rawLintDocument(
 
   const dbSchema = neo4j.metadata?.dbSchema ?? {};
   try {
+    // Wait for any in-flight cancellation to settle before grabbing a new
+    // worker, otherwise pool.proxy() may return a worker that is being torn
+    // down and the next call rejects with "Worker is terminated".
     if (lastSemanticJob !== undefined && !lastSemanticJob.resolved) {
-      void lastSemanticJob.cancel();
+      lastSemanticJob.cancel();
+      try {
+        await lastSemanticJob;
+      } catch {
+        /* expected CancellationError */
+      }
     }
 
-    const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
-
     const fixedDbSchema = convertDbSchema(dbSchema, linterVersion);
-    lastSemanticJob = proxyWorker.lintCypherQuery(query, fixedDbSchema, {
-      consoleCommands: false,
-    });
-    const result = await lastSemanticJob;
+
+    // Retry once on transient "Worker is terminated" — covers the rare case
+    // where a worker exits between proxy() and the actual call.
+    const runLint = async () => {
+      const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
+      lastSemanticJob = proxyWorker.lintCypherQuery(query, fixedDbSchema, {
+        consoleCommands: false,
+      });
+      return await lastSemanticJob;
+    };
+
+    let result;
+    try {
+      result = await runLint();
+    } catch (err) {
+      if (err instanceof workerpool.Promise.CancellationError) throw err;
+      const msg = err && err.message ? String(err.message) : String(err);
+      if (/worker is terminated/i.test(msg)) {
+        result = await runLint();
+      } else {
+        throw err;
+      }
+    }
 
     //marks the entire text if any position is negative
     const positionSafeResult = clampUnsafePositions(


### PR DESCRIPTION
## Summary

Three stacked issues in `packages/language-server/src/linting.ts` cause `publishDiagnostics: []` after the first `textDocument/didChange`. After this fix the lint pipeline survives rapid document changes and delivers diagnostics on every turn.

## The bug

```ts
if (lastSemanticJob !== undefined && !lastSemanticJob.resolved) {
  void lastSemanticJob.cancel();              // (1) fire-and-forget
}
const proxyWorker = (await pool.proxy())      // (2) races a worker that's being torn down
  as unknown as LintWorker;
lastSemanticJob = proxyWorker.lintCypherQuery(...);
const result = await lastSemanticJob;          // (3) rejects "Worker is terminated"
```

1. `cancel()` is not awaited; the next `pool.proxy()` may return the same worker mid-termination.
2. `workerTerminateTimeout: 0` removes any drain period, so (1) hits on every cancellation cycle. Workerpool's own default is `1e3` ms.
3. The transient `Worker is terminated` rejection is treated as fatal noise — `console.error` and no retry — so the user-visible result is empty diagnostics.

## Reproduction

LSP harness against a freshly installed `@neo4j-cypher/language-server` (works on every release tested, `2.0.0-next.6` … `2.0.0-next.32`):

```js
const cp = require('child_process');
const p = cp.spawn('cypher-language-server', ['--stdio']);
const send = o => { const j = Buffer.from(JSON.stringify(o));
  p.stdin.write(Buffer.concat([Buffer.from(`Content-Length: ${j.length}\r\n\r\n`), j])); };
send({ jsonrpc:'2.0', id:1, method:'initialize',
       params:{ processId:null, rootUri:null, capabilities:{} } });
setTimeout(() => send({ jsonrpc:'2.0', method:'initialized', params:{} }), 500);
setTimeout(() => send({ jsonrpc:'2.0', method:'textDocument/didOpen',
  params:{ textDocument:{ uri:'file:///t.cypher', languageId:'cypher', version:1,
                          text:'MATCH (n) RETURN n;' } } }), 1500);
// the change that triggers the race
setTimeout(() => send({ jsonrpc:'2.0', method:'textDocument/didChange',
  params:{ textDocument:{ uri:'file:///t.cypher', version:2 },
           contentChanges:[{ text:'MATCH (n: RETURN n;' }] } }), 3000);
```

Stderr fires `Error: Worker is terminated` on the second turn; `publishDiagnostics` for the syntactically-broken text comes back as `[]` instead of containing the parser error.

## Fix

Three correlated changes — none of them by themselves is enough on every Node version / load profile we hit, but together they make the pipeline robust:

1. **Await the cancellation.** `lastSemanticJob.cancel(); try { await lastSemanticJob; } catch { /* CancellationError */ }`. Wait for the resource to actually be released before re-acquiring it (classical producer-consumer-with-graceful-cancellation idiom; mapped to Node's promise model it's just `await`ing the rejection).
2. **`workerTerminateTimeout: 0` → `1000`** in both `pool()` calls. Restores a non-zero grace period for worker drain. Matches workerpool's own default.
3. **Retry once on `/worker is terminated/i`** as belt-and-braces for any residual race the first two changes don't cover. `CancellationError` is re-thrown unchanged so cancellation semantics remain identical.

## Test plan

- [x] Reproducer above returns `[{ severity: 1, message: 'Expected...' }]` on the second turn (was `[]`).
- [x] First-turn behavior unchanged (still produces correct diagnostics on initial `didOpen`).
- [x] `CancellationError` still propagates out of the try block — no behavior change for legitimate cancellation paths.
- [ ] `pnpm test` in `packages/language-server` (local environment lacked the full ANTLR toolchain — please verify on CI).

## Notes

While digging through this I also noticed that in `2.0.0-next.32` `rawLintDocument` reads `result.diagnostics` and `result.symbolTables`, but the bundled `lintCypherQuery` returns a bare array. Same user-visible symptom (empty diagnostics) by a different path. That looks like a separate refactor left half-finished and is **not** addressed in this PR — flagging in case it's news.