### PR TITLE
fix: properly store parsing result in CypherLanguageService cache

### DIFF
--- a/packages/language-support/src/cypherLanguageService.ts
+++ b/packages/language-support/src/cypherLanguageService.ts
@@ -851,6 +851,7 @@ export class CypherLanguageService {
       const parsingResult = createParsingResult(query, {
         consoleCommandsEnabled: this.consoleCommandsEnabled,
       });
+      this.parsingResult = parsingResult;
       return parsingResult;
     }
   }


### PR DESCRIPTION
One-liner change to actually activate the cache, which was previously dead code.

We encountered issues with performance and found that the cache for previously parsed result is never activated.

`CypherLanguageService.parse()` checks `this.parsingResult` to see if the query string matches the latest parsed result, but the `else` branch forgets to ever assign the newly created result to `this.parsingResult`. The intention behind this was presumably so that running highlight, and then suggestions, and then lint etc. on the same query would re-use the previously parsed result. Consumers calling multiple methods on the same query currently pay for a full ANTLR parse each time.

Unit testing: failed :( however running `pnpm test` on the main branch seems to yield the same failures, so probably pre-existing?