### PR TITLE
Schema based linting

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -246,12 +246,12 @@ connection.onNotification(
   }) => {
     neo4jSchemaPoller.events.once(
       'schemaFetched',
-      // oxlint-disable-next-line typescript-eslint/no-meaningless-void-operator
-      void symbolFetcher.queueSymbolJob(
-        params.query,
-        params.uri,
-        params.schema,
-      ),
+      () =>
+         symbolFetcher.queueSymbolJob(
+          params.query,
+          params.uri,
+          params.schema,
+        ),
     );
   },
 );

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -244,14 +244,8 @@ connection.onNotification(
     version: number;
     schema: DbSchema;
   }) => {
-    neo4jSchemaPoller.events.once(
-      'schemaFetched',
-      () =>
-         symbolFetcher.queueSymbolJob(
-          params.query,
-          params.uri,
-          params.schema,
-        ),
+    neo4jSchemaPoller.events.once('schemaFetched', () =>
+      symbolFetcher.queueSymbolJob(params.query, params.uri, params.schema),
     );
   },
 );

--- a/packages/language-support/src/autocompletion/completionCoreCompletions.ts
+++ b/packages/language-support/src/autocompletion/completionCoreCompletions.ts
@@ -307,11 +307,11 @@ const parameterCompletions = (
         ? { insertText: `$${backtickedName}` }
         : {};
       // If there is a preceding token and it's not empty, compute the suffix
-      if (previousToken.type !== CypherLexer.SPACE) {
+      if (previousToken && tokens && previousToken.type !== CypherLexer.SPACE) {
         const param = maybeInsertText.insertText ?? `$${paramName}`;
         const hasDollar =
           previousToken.type === CypherLexer.DOLLAR ||
-          tokens.at(previousToken.tokenIndex - 1).type === CypherLexer.DOLLAR;
+          tokens.at(previousToken.tokenIndex - 1)?.type === CypherLexer.DOLLAR;
         // If the $ symbol is already there, we need to have the insert
         // text without the starting $ in VSCode, otherwise when we have
         // 'RETURN $' and we get offered $param we would complete

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -202,7 +202,7 @@ const reltypesToCompletions = (reltypes: string[] = []) =>
 export const allReltypeCompletions = (dbSchema: DbSchema) =>
   reltypesToCompletions(dbSchema.relationshipTypes);
 
-function walkCNFTree(
+export function walkCNFTree(
   incomingLabels: Map<string, Set<string>>,
   outGoingLabels: Map<string, Set<string>>,
   labelTree: LabelOrCondition,
@@ -271,7 +271,7 @@ function walkCNFTree(
   return { inLabels, outLabels };
 }
 
-function getRelsFromNodesSets(dbSchema: DbSchema): {
+export function getRelsFromNodesSets(dbSchema: DbSchema): {
   toNodes: Map<string, Set<string>>;
   fromNodes: Map<string, Set<string>>;
 } {

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -5,13 +5,7 @@ import {
 } from 'vscode-languageserver-types';
 import { DbSchema } from '../dbSchema.js';
 import { ParsedStatement } from '../cypherLanguageService.js';
-import {
-  ConditionNode,
-  isLabelLeaf,
-  LabelLeaf,
-  LabelOrCondition,
-  SymbolsInfo,
-} from '../types.js';
+import { isLabelLeaf, LabelOrCondition, SymbolsInfo } from '../types.js';
 import { findParent } from '../helpers.js';
 import {
   NodePatternContext,
@@ -26,6 +20,11 @@ import {
   isNotAnyNode,
   removeInnerAnys,
 } from '../labelTreeRewriting.js';
+import {
+  getNodesFromRelsSet,
+  getRelsFromNodesSets,
+  walkCNFTree,
+} from '../labelTreeWalking.js';
 
 export function getShortPathCompletions(
   lastNode: RelationshipPatternContext,
@@ -202,120 +201,6 @@ const reltypesToCompletions = (reltypes: string[] = []) =>
 export const allReltypeCompletions = (dbSchema: DbSchema) =>
   reltypesToCompletions(dbSchema.relationshipTypes);
 
-export function walkCNFTree(
-  incomingLabels: Map<string, Set<string>>,
-  outGoingLabels: Map<string, Set<string>>,
-  labelTree: LabelOrCondition,
-): { inLabels: Set<string>; outLabels: Set<string> } {
-  //Bail if tree is not CNF
-  if (isLabelLeaf(labelTree) || labelTree.condition !== 'and') {
-    let inLabels = new Set<string>();
-    let outLabels = new Set<string>();
-    incomingLabels.values().forEach((x) => (inLabels = inLabels.union(x)));
-    outGoingLabels.values().forEach((x) => (outLabels = outLabels.union(x)));
-
-    return { inLabels, outLabels };
-  }
-  const notLabels: LabelLeaf[] = [];
-  const literalLabels: LabelLeaf[] = [];
-  const orNodes: ConditionNode[] = [];
-
-  labelTree.children.forEach((c) => {
-    if (isLabelLeaf(c)) {
-      literalLabels.push(c);
-    } else if (
-      c.condition === 'not' &&
-      c.children.length === 1 &&
-      isLabelLeaf(c.children[0])
-    ) {
-      notLabels.push(c.children[0]);
-    } else if (c.condition === 'or') {
-      orNodes.push(c);
-    }
-  });
-
-  let inLabels = new Set<string>();
-  incomingLabels.forEach((part, key) => {
-    if (!notLabels.some((c) => c.value === key)) {
-      inLabels = inLabels.union(part);
-    }
-  });
-  let outLabels = new Set<string>();
-  outGoingLabels.forEach((part, key) => {
-    if (!notLabels.some((c) => c.value === key)) {
-      outLabels = outLabels.union(part);
-    }
-  });
-
-  for (const label of literalLabels) {
-    const incoming = incomingLabels.get(label.value) ?? new Set();
-    const outgoing = outGoingLabels.get(label.value) ?? new Set();
-    inLabels = inLabels.intersection(incoming);
-    outLabels = outLabels.intersection(outgoing);
-  }
-
-  for (const node of orNodes) {
-    let incoming = new Set();
-    let outGoing = new Set();
-    for (const c of node.children) {
-      if (isLabelLeaf(c)) {
-        const newIncoming = incomingLabels.get(c.value) ?? new Set();
-        const newOutgoing = outGoingLabels.get(c.value) ?? new Set();
-        incoming = incoming.union(newIncoming);
-        outGoing = outGoing.union(newOutgoing);
-      }
-    }
-    inLabels = inLabels.intersection(incoming);
-    outLabels = outLabels.intersection(outGoing);
-  }
-  return { inLabels, outLabels };
-}
-
-export function getRelsFromNodesSets(dbSchema: DbSchema): {
-  toNodes: Map<string, Set<string>>;
-  fromNodes: Map<string, Set<string>>;
-} {
-  if (dbSchema.graphSchema) {
-    const toNodes: Map<string, Set<string>> = new Map();
-    const fromNodes: Map<string, Set<string>> = new Map();
-    dbSchema.graphSchema.forEach((rel) => {
-      //rels in schema defined like (from)-(relType)->(to)
-      //Means 'from' is "node going to rel", hence why we
-      //pass rel.from into toNodes
-      if (!toNodes.has(rel.from)) {
-        toNodes.set(rel.from, new Set());
-      }
-      if (!fromNodes.has(rel.to)) {
-        fromNodes.set(rel.to, new Set());
-      }
-      toNodes.get(rel.from).add(rel.relType);
-      fromNodes.get(rel.to).add(rel.relType);
-    });
-    return { toNodes, fromNodes };
-  }
-  return undefined;
-}
-
-export function getNodesFromRelsSet(dbSchema: DbSchema): {
-  toRels: Map<string, Set<string>>;
-  fromRels: Map<string, Set<string>>;
-} {
-  if (dbSchema.graphSchema) {
-    const toRels: Map<string, Set<string>> = new Map();
-    const fromRels: Map<string, Set<string>> = new Map();
-    dbSchema.graphSchema.forEach((rel) => {
-      if (!toRels.has(rel.relType)) {
-        toRels.set(rel.relType, new Set());
-        fromRels.set(rel.relType, new Set());
-      }
-      toRels.get(rel.relType).add(rel.to);
-      fromRels.get(rel.relType).add(rel.from);
-    });
-    return { toRels, fromRels };
-  }
-  return undefined;
-}
-
 function findLastVariable(
   lastValidElement: NodePatternContext | RelationshipPatternContext,
   symbolsInfo: SymbolsInfo,
@@ -328,7 +213,7 @@ function findLastVariable(
           // Because the anonymous variable created in the AST is "made up", it doesnt have a position of its own in the query.
           // It therefor inherits the parent-nodes (The NodePattern/RelationshipPattern = lastValidElement) position
           entry.definitionPosition >= lastValidElement.start.start &&
-          entry.definitionPosition <= lastValidElement.stop.stop,
+          entry.definitionPosition <= (lastValidElement.stop?.stop ?? -1),
       )
     : symbolsInfo?.symbolTables
         ?.flat()
@@ -350,7 +235,7 @@ export function completeNodeLabel(
     (x) => x instanceof PatternElementContext,
   );
 
-  if (callContext instanceof PatternElementContext) {
+  if (callContext instanceof PatternElementContext && callContext.children) {
     const lastValidElement = callContext.children.toReversed().find((child) => {
       if (child instanceof RelationshipPatternContext) {
         if (child.exception === null) {
@@ -431,7 +316,10 @@ export function completeRelationshipType(
     (x) => x instanceof PatternElementContext,
   );
 
-  if (patternContext instanceof PatternElementContext) {
+  if (
+    patternContext instanceof PatternElementContext &&
+    patternContext.children
+  ) {
     const lastValidElement = patternContext.children
       .toReversed()
       .find((child) => {

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -296,7 +296,7 @@ export function getRelsFromNodesSets(dbSchema: DbSchema): {
   return undefined;
 }
 
-function getNodesFromRelsSet(dbSchema: DbSchema): {
+export function getNodesFromRelsSet(dbSchema: DbSchema): {
   toRels: Map<string, Set<string>>;
   fromRels: Map<string, Set<string>>;
 } {
@@ -375,11 +375,12 @@ export function completeNodeLabel(
         return allLabelCompletions(dbSchema);
       }
 
-      const direction = lastValidElement.leftArrow()
-        ? 'outgoing'
-        : lastValidElement.rightArrow()
-          ? 'incoming'
-          : 'bidirectional';
+      const direction =
+        lastValidElement.leftArrow() && !lastValidElement.rightArrow()
+          ? 'outgoing'
+          : !lastValidElement.leftArrow() && lastValidElement.rightArrow()
+            ? 'incoming'
+            : 'bidirectional';
 
       // limitation: not checking node label repetition
       const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
@@ -455,11 +456,12 @@ export function completeRelationshipType(
     );
     let direction = 'bidirectional';
     if (thisCtx instanceof RelationshipPatternContext) {
-      direction = thisCtx.leftArrow()
-        ? 'outgoing'
-        : thisCtx.rightArrow()
-          ? 'incoming'
-          : 'bidirectional';
+      direction =
+        thisCtx.leftArrow() && !thisCtx.rightArrow()
+          ? 'outgoing'
+          : !thisCtx.leftArrow() && thisCtx.rightArrow()
+            ? 'incoming'
+            : 'bidirectional';
     }
 
     // limitation: bailing out on quantifiers

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -397,14 +397,6 @@ export function completeNodeLabel(
       } catch {
         return allLabelCompletions(dbSchema);
       }
-      let allIncomingLabels = new Set<string>();
-      nodesToRelsSet.forEach((part) => {
-        allIncomingLabels = allIncomingLabels.union(part);
-      });
-      let allOutGoingLabels = new Set<string>();
-      nodesFromRelsSet.forEach((part) => {
-        allOutGoingLabels = allOutGoingLabels.union(part);
-      });
       const { inLabels, outLabels } = walkCNFTree(
         nodesToRelsSet,
         nodesFromRelsSet,
@@ -495,14 +487,6 @@ export function completeRelationshipType(
       } catch {
         return [];
       }
-      let allIncomingLabels = new Set<string>();
-      relsToNodesSet.forEach((part) => {
-        allIncomingLabels = allIncomingLabels.union(part);
-      });
-      let allOutGoingLabels = new Set<string>();
-      relsFromNodesSet.forEach((part) => {
-        allOutGoingLabels = allOutGoingLabels.union(part);
-      });
       const { inLabels, outLabels } = walkCNFTree(
         relsToNodesSet,
         relsFromNodesSet,

--- a/packages/language-support/src/cypherLanguageService.ts
+++ b/packages/language-support/src/cypherLanguageService.ts
@@ -802,7 +802,7 @@ function parseToCommand(
   return { type: 'parse-error', start: stmts.start, stop: stmts.stop };
 }
 
-function translateTokensToRange(
+export function translateTokensToRange(
   start: Token,
   stop: Token,
 ): Pick<SyntaxDiagnostic, 'range' | 'offsets'> {

--- a/packages/language-support/src/featureFlags.ts
+++ b/packages/language-support/src/featureFlags.ts
@@ -8,5 +8,5 @@ export const _internalFeatureFlags: FeatureFlags = {
     typeof process === 'undefined'
       ? false
       : process.env.debugSymbolTable == 'true',
-  lintPatternDirectionalityIssues: true,
+  lintPatternDirectionalityIssues: false,
 };

--- a/packages/language-support/src/featureFlags.ts
+++ b/packages/language-support/src/featureFlags.ts
@@ -1,5 +1,6 @@
 interface FeatureFlags {
   debugSymbolTable: boolean;
+  lintPatternDirectionalityIssues: boolean;
 }
 
 export const _internalFeatureFlags: FeatureFlags = {
@@ -7,4 +8,5 @@ export const _internalFeatureFlags: FeatureFlags = {
     typeof process === 'undefined'
       ? false
       : process.env.debugSymbolTable == 'true',
+  lintPatternDirectionalityIssues: true,
 };

--- a/packages/language-support/src/featureFlags.ts
+++ b/packages/language-support/src/featureFlags.ts
@@ -1,6 +1,5 @@
 interface FeatureFlags {
   debugSymbolTable: boolean;
-  lintPatternDirectionalityIssues: boolean;
 }
 
 export const _internalFeatureFlags: FeatureFlags = {
@@ -8,5 +7,4 @@ export const _internalFeatureFlags: FeatureFlags = {
     typeof process === 'undefined'
       ? false
       : process.env.debugSymbolTable == 'true',
-  lintPatternDirectionalityIssues: false,
 };

--- a/packages/language-support/src/labelTreeRewriting.ts
+++ b/packages/language-support/src/labelTreeRewriting.ts
@@ -134,7 +134,7 @@ export function childAlreadyExists(
   }
 }
 
-function equalConditions(c1: LabelOrCondition, c2: LabelOrCondition) {
+function equalConditions(c1: LabelOrCondition, c2: LabelOrCondition): boolean {
   if (isLabelLeaf(c1)) {
     return isLabelLeaf(c2) && c1.value === c2.value;
   } else if (isLabelLeaf(c2)) {

--- a/packages/language-support/src/labelTreeWalking.ts
+++ b/packages/language-support/src/labelTreeWalking.ts
@@ -1,0 +1,119 @@
+import { DbSchema } from './dbSchema.js';
+import {
+  ConditionNode,
+  isLabelLeaf,
+  LabelLeaf,
+  LabelOrCondition,
+} from './types.js';
+
+export function walkCNFTree(
+  incomingLabels: Map<string, Set<string>>,
+  outGoingLabels: Map<string, Set<string>>,
+  labelTree: LabelOrCondition,
+): { inLabels: Set<string>; outLabels: Set<string> } {
+  //Bail if tree is not CNF
+  if (isLabelLeaf(labelTree) || labelTree.condition !== 'and') {
+    let inLabels = new Set<string>();
+    let outLabels = new Set<string>();
+    incomingLabels.values().forEach((x) => (inLabels = inLabels.union(x)));
+    outGoingLabels.values().forEach((x) => (outLabels = outLabels.union(x)));
+
+    return { inLabels, outLabels };
+  }
+  const notLabels: LabelLeaf[] = [];
+  const literalLabels: LabelLeaf[] = [];
+  const orNodes: ConditionNode[] = [];
+
+  labelTree.children.forEach((c) => {
+    if (isLabelLeaf(c)) {
+      literalLabels.push(c);
+    } else if (
+      c.condition === 'not' &&
+      c.children.length === 1 &&
+      isLabelLeaf(c.children[0])
+    ) {
+      notLabels.push(c.children[0]);
+    } else if (c.condition === 'or') {
+      orNodes.push(c);
+    }
+  });
+
+  let inLabels = new Set<string>();
+  incomingLabels.forEach((part, key) => {
+    if (!notLabels.some((c) => c.value === key)) {
+      inLabels = inLabels.union(part);
+    }
+  });
+  let outLabels = new Set<string>();
+  outGoingLabels.forEach((part, key) => {
+    if (!notLabels.some((c) => c.value === key)) {
+      outLabels = outLabels.union(part);
+    }
+  });
+
+  for (const label of literalLabels) {
+    const incoming = incomingLabels.get(label.value) ?? new Set();
+    const outgoing = outGoingLabels.get(label.value) ?? new Set();
+    inLabels = inLabels.intersection(incoming);
+    outLabels = outLabels.intersection(outgoing);
+  }
+
+  for (const node of orNodes) {
+    let incoming = new Set();
+    let outGoing = new Set();
+    for (const c of node.children) {
+      if (isLabelLeaf(c)) {
+        const newIncoming = incomingLabels.get(c.value) ?? new Set();
+        const newOutgoing = outGoingLabels.get(c.value) ?? new Set();
+        incoming = incoming.union(newIncoming);
+        outGoing = outGoing.union(newOutgoing);
+      }
+    }
+    inLabels = inLabels.intersection(incoming);
+    outLabels = outLabels.intersection(outGoing);
+  }
+  return { inLabels, outLabels };
+}
+
+export function getRelsFromNodesSets(dbSchema: DbSchema): {
+  toNodes: Map<string, Set<string>>;
+  fromNodes: Map<string, Set<string>>;
+} {
+  const toNodes: Map<string, Set<string>> = new Map();
+  const fromNodes: Map<string, Set<string>> = new Map();
+  if (dbSchema.graphSchema) {
+    dbSchema.graphSchema.forEach((rel) => {
+      //rels in schema defined like (from)-(relType)->(to)
+      //Means 'from' is "node going to rel", hence why we
+      //pass rel.from into toNodes
+      if (!toNodes.has(rel.from)) {
+        toNodes.set(rel.from, new Set());
+      }
+      if (!fromNodes.has(rel.to)) {
+        fromNodes.set(rel.to, new Set());
+      }
+      toNodes.get(rel.from)?.add(rel.relType);
+      fromNodes.get(rel.to)?.add(rel.relType);
+    });
+  }
+  return { toNodes, fromNodes };
+}
+
+export function getNodesFromRelsSet(dbSchema: DbSchema): {
+  toRels: Map<string, Set<string>>;
+  fromRels: Map<string, Set<string>>;
+} {
+  const toRels: Map<string, Set<string>> = new Map();
+  const fromRels: Map<string, Set<string>> = new Map();
+  if (dbSchema.graphSchema) {
+    dbSchema.graphSchema.forEach((rel) => {
+      if (!toRels.has(rel.relType)) {
+        toRels.set(rel.relType, new Set());
+        fromRels.set(rel.relType, new Set());
+      }
+      toRels.get(rel.relType)?.add(rel.to);
+      fromRels.get(rel.relType)?.add(rel.from);
+    });
+  }
+  return { toRels, fromRels };
+}

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -37,6 +37,7 @@ import {
 } from '../generated-parser/CypherCmdParser.js';
 import { ParserRuleContext } from 'antlr4';
 import {
+  getNodesFromRelsSet,
   getRelsFromNodesSets,
   walkCNFTree,
 } from '../autocompletion/schemaBasedCompletions.js';
@@ -294,19 +295,13 @@ function warnOnPathDirectionalityIssues(
     if (!stmt) {
       return acc;
     }
-    const pathIssues = findPathIssues(
-      stmt,
-      parsingResult,
-      dbSchema,
-      symbolTable,
-    );
+    const pathIssues = findPathIssues(stmt, dbSchema, symbolTable);
     return acc.concat(pathIssues);
   }, []);
 }
 
 function findPathIssues(
   stmt: StatementContext,
-  parsingResult: ParsedStatement,
   dbSchema: DbSchema,
   symbolTable: SymbolTable,
 ): SyntaxDiagnostic[] {
@@ -317,63 +312,119 @@ function findPathIssues(
   const diagnostics: SyntaxDiagnostic[] = [];
   for (const pattern of patternElements) {
     const children = pattern.children ?? [];
-    if (
-      children.length >= 2 &&
-      children[0] instanceof NodePatternContext &&
-      children[1] instanceof RelationshipPatternContext
-    ) {
-      const child = children[0];
-      const nextChild = children[1];
-      if (!nextChild.stop?.stop || !child.stop?.stop) {
-        return [];
-      }
-      const symbol = symbolTable.find((x) =>
-        x.references.some(
-          (ref) => ref >= child.start.start && ref <= (child.stop?.stop ?? -1),
-        ),
-      );
-      const nextSymbolLabels = symbolTable.find((x) =>
-        x.references.some(
-          (ref) =>
-            ref >= nextChild.start.start && ref <= (nextChild.stop?.stop ?? -1),
-        ),
-      )?.labels;
+    let n = 0;
+    while (n < children.length - 1) {
+      const child = children[n];
+      const nextChild = children[n + 1];
       if (
-        symbol &&
-        nextSymbolLabels &&
-        parsingResult.command.type === 'cypher'
+        child instanceof NodePatternContext &&
+        nextChild instanceof RelationshipPatternContext
       ) {
-        const direction = nextChild.leftArrow()
-          ? 'outgoing'
-          : nextChild.rightArrow()
-            ? 'incoming'
-            : 'bidirectional';
-        const possibleRels = possibleFollowingRelType(
-          direction,
-          dbSchema,
-          symbol.labels,
+        if (!nextChild.stop?.stop || !child.stop?.stop) {
+          continue;
+        }
+        const symbol = symbolTable.find((x) =>
+          x.references.some(
+            (ref) =>
+              ref >= child.start.start && ref <= (child.stop?.stop ?? -1),
+          ),
         );
-        if (
-          possibleRels &&
-          nextSymbolLabels &&
-          'children' in nextSymbolLabels &&
-          nextSymbolLabels.children.length == 1 &&
-          isLabelLeaf(nextSymbolLabels.children[0])
-        ) {
+        const nextSymbolLabels = symbolTable.find((x) =>
+          x.references.some(
+            (ref) =>
+              ref >= nextChild.start.start &&
+              ref <= (nextChild.stop?.stop ?? -1),
+          ),
+        )?.labels;
+        if (symbol && nextSymbolLabels) {
+          const direction =
+            nextChild.leftArrow() && !nextChild.rightArrow()
+              ? 'outgoing'
+              : !nextChild.leftArrow() && nextChild.rightArrow()
+                ? 'incoming'
+                : 'bidirectional';
+          const possibleRels = possibleFollowingRelType(
+            direction,
+            dbSchema,
+            symbol.labels,
+          );
           if (
-            !possibleRels
-              .values()
-              .toArray()
-              .includes(nextSymbolLabels.children[0].value)
+            possibleRels &&
+            nextSymbolLabels &&
+            'children' in nextSymbolLabels &&
+            nextSymbolLabels.children.length === 1 &&
+            isLabelLeaf(nextSymbolLabels.children[0])
           ) {
-            diagnostics.push({
-              message: 'Path segment does not exist on graph.',
-              severity: DiagnosticSeverity.Warning,
-              ...translateTokensToRange(child.start, nextChild.stop),
-            });
+            if (
+              !possibleRels
+                .values()
+                .toArray()
+                .includes(nextSymbolLabels.children[0].value)
+            ) {
+              diagnostics.push({
+                message: 'Path segment does not exist on graph.',
+                severity: DiagnosticSeverity.Warning,
+                ...translateTokensToRange(child.start, nextChild.stop),
+              });
+            }
           }
         }
       }
+      if (
+        child instanceof RelationshipPatternContext &&
+        nextChild instanceof NodePatternContext
+      ) {
+        if (!nextChild.stop?.stop || !child.stop?.stop) {
+          continue;
+        }
+        const symbol = symbolTable.find((x) =>
+          x.references.some(
+            (ref) =>
+              ref >= child.start.start && ref <= (child.stop?.stop ?? -1),
+          ),
+        );
+        const nextSymbolLabels = symbolTable.find((x) =>
+          x.references.some(
+            (ref) =>
+              ref >= nextChild.start.start &&
+              ref <= (nextChild.stop?.stop ?? -1),
+          ),
+        )?.labels;
+        if (symbol && nextSymbolLabels) {
+          const direction =
+            child.leftArrow() && !child.rightArrow()
+              ? 'outgoing'
+              : !child.leftArrow() && child.rightArrow()
+                ? 'incoming'
+                : 'bidirectional';
+          const possibleRels = possibleFollowingLabels(
+            direction,
+            dbSchema,
+            symbol.labels,
+          );
+          if (
+            possibleRels &&
+            nextSymbolLabels &&
+            'children' in nextSymbolLabels &&
+            nextSymbolLabels.children.length === 1 &&
+            isLabelLeaf(nextSymbolLabels.children[0])
+          ) {
+            if (
+              !possibleRels
+                .values()
+                .toArray()
+                .includes(nextSymbolLabels.children[0].value)
+            ) {
+              diagnostics.push({
+                message: 'Path segment does not exist on graph.',
+                severity: DiagnosticSeverity.Warning,
+                ...translateTokensToRange(child.start, nextChild.stop),
+              });
+            }
+          }
+        }
+      }
+      n++;
     }
   }
   return diagnostics;
@@ -523,7 +574,10 @@ export function lintCypherQuery(
         });
 
         let missingPathWarnings: SyntaxDiagnostic[] = [];
-        if (_internalFeatureFlags.lintPatternDirectionalityIssues) {
+        if (
+          _internalFeatureFlags.lintPatternDirectionalityIssues &&
+          dbSchema.graphSchema
+        ) {
           missingPathWarnings = warnOnPathDirectionalityIssues(
             current,
             dbSchema,
@@ -599,6 +653,48 @@ function possibleFollowingRelType(
         ? inLabels
         : inLabels.union(outLabels);
   return allRels.values().toArray();
+}
+
+//Returns possible following labels, or undefined in cases where we should quit
+function possibleFollowingLabels(
+  direction: 'incoming' | 'outgoing' | 'bidirectional',
+  dbSchema: DbSchema,
+  labels: LabelOrCondition,
+): string[] | undefined {
+  const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
+    getNodesFromRelsSet(dbSchema);
+  let cnfTree: LabelOrCondition;
+  try {
+    const treeWithRewrittenAnys = removeInnerAnys(labels);
+    if (isAnyNode(treeWithRewrittenAnys)) {
+      return undefined;
+    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
+      return undefined;
+    }
+    cnfTree = convertToCNF(treeWithRewrittenAnys);
+  } catch {
+    return undefined;
+  }
+  let allIncomingLabels = new Set<string>();
+  nodesToRelsSet.forEach((part) => {
+    allIncomingLabels = allIncomingLabels.union(part);
+  });
+  let allOutGoingLabels = new Set<string>();
+  nodesFromRelsSet.forEach((part) => {
+    allOutGoingLabels = allOutGoingLabels.union(part);
+  });
+  const { inLabels, outLabels } = walkCNFTree(
+    nodesToRelsSet,
+    nodesFromRelsSet,
+    cnfTree,
+  );
+  const allNodes =
+    direction === 'outgoing'
+      ? outLabels
+      : direction === 'incoming'
+        ? inLabels
+        : inLabels.union(outLabels);
+  return allNodes.values().toArray();
 }
 
 function warningOnDeprecatedProcedure(

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -571,10 +571,7 @@ export function lintCypherQuery(
         });
 
         let missingPathWarnings: SyntaxDiagnostic[] = [];
-        if (
-          _internalFeatureFlags.lintPatternDirectionalityIssues &&
-          dbSchema.graphSchema
-        ) {
+        if (dbSchema.graphSchema) {
           missingPathWarnings = warnOnPathDirectionalityIssues(
             current,
             dbSchema,

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -308,10 +308,8 @@ function findPathIssues(
   dbSchema: DbSchema,
   symbolTable: SymbolTable,
 ): SyntaxDiagnostic[] {
-  const patternElements: PatternElementContext[] = findPatternElements(
-    stmt,
-    [],
-  );
+  const patternElements: PatternElementContext[] =
+    findNonCreatingPatternElements(stmt, []);
   const diagnostics: SyntaxDiagnostic[] = [];
   for (const pattern of patternElements) {
     const children = pattern.children ?? [];
@@ -427,7 +425,7 @@ function findPathIssues(
   return diagnostics;
 }
 
-function findPatternElements(
+function findNonCreatingPatternElements(
   ctx: ParserRuleContext,
   acc: PatternElementContext[],
 ): PatternElementContext[] {
@@ -443,7 +441,7 @@ function findPatternElements(
       acc.push(c);
     }
     if (c instanceof ParserRuleContext) {
-      findPatternElements(c, acc);
+      findNonCreatingPatternElements(c, acc);
     }
   }
   return acc;

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -654,14 +654,9 @@ export function lintCypherQuery(
           parseResult: current,
         });
 
-        let missingPathWarnings: SyntaxDiagnostic[] = [];
-        if (dbSchema.graphSchema) {
-          missingPathWarnings = warnOnPathDirectionalityIssues(
-            current,
-            dbSchema,
-            symbolTable,
-          );
-        }
+        const missingPathWarnings = dbSchema.graphSchema
+          ? warnOnPathDirectionalityIssues(current, dbSchema, symbolTable)
+          : [];
 
         const diagnostics = semanticDiagnostics
           .concat(

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -316,6 +316,7 @@ function findPathIssues(
     while (n < children.length - 1) {
       const child = children[n];
       const nextChild = children[n + 1];
+      n++;
       if (
         child instanceof NodePatternContext &&
         nextChild instanceof RelationshipPatternContext
@@ -424,7 +425,6 @@ function findPathIssues(
           }
         }
       }
-      n++;
     }
   }
   return diagnostics;
@@ -620,39 +620,10 @@ function possibleFollowingRelType(
 ): string[] | undefined {
   const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
     getRelsFromNodesSets(dbSchema);
-
-  let cnfTree: LabelOrCondition;
-  try {
-    const treeWithRewrittenAnys = removeInnerAnys(labels);
-    if (isAnyNode(treeWithRewrittenAnys)) {
-      return undefined;
-    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-      return undefined;
-    }
-    cnfTree = convertToCNF(treeWithRewrittenAnys);
-  } catch {
-    return undefined;
-  }
-  let allIncomingLabels = new Set<string>();
-  relsToNodesSet.forEach((part) => {
-    allIncomingLabels = allIncomingLabels.union(part);
+  return getFollowingLabels(direction, labels, {
+    incomingLabels: relsToNodesSet,
+    outGoingLabels: relsFromNodesSet,
   });
-  let allOutGoingLabels = new Set<string>();
-  relsFromNodesSet.forEach((part) => {
-    allOutGoingLabels = allOutGoingLabels.union(part);
-  });
-  const { inLabels, outLabels } = walkCNFTree(
-    relsToNodesSet,
-    relsFromNodesSet,
-    cnfTree,
-  );
-  const allRels =
-    direction === 'outgoing'
-      ? outLabels
-      : direction === 'incoming'
-        ? inLabels
-        : inLabels.union(outLabels);
-  return allRels.values().toArray();
 }
 
 //Returns possible following labels, or undefined in cases where we should quit
@@ -663,6 +634,23 @@ function possibleFollowingLabels(
 ): string[] | undefined {
   const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
     getNodesFromRelsSet(dbSchema);
+  return getFollowingLabels(direction, labels, {
+    incomingLabels: nodesToRelsSet,
+    outGoingLabels: nodesFromRelsSet,
+  });
+}
+
+function getFollowingLabels(
+  direction: 'incoming' | 'outgoing' | 'bidirectional',
+  labels: LabelOrCondition,
+  {
+    incomingLabels,
+    outGoingLabels,
+  }: {
+    incomingLabels: Map<string, Set<string>>;
+    outGoingLabels: Map<string, Set<string>>;
+  },
+): string[] | undefined {
   let cnfTree: LabelOrCondition;
   try {
     const treeWithRewrittenAnys = removeInnerAnys(labels);
@@ -676,16 +664,16 @@ function possibleFollowingLabels(
     return undefined;
   }
   let allIncomingLabels = new Set<string>();
-  nodesToRelsSet.forEach((part) => {
+  incomingLabels.forEach((part) => {
     allIncomingLabels = allIncomingLabels.union(part);
   });
   let allOutGoingLabels = new Set<string>();
-  nodesFromRelsSet.forEach((part) => {
+  outGoingLabels.forEach((part) => {
     allOutGoingLabels = allOutGoingLabels.union(part);
   });
   const { inLabels, outLabels } = walkCNFTree(
-    nodesToRelsSet,
-    nodesFromRelsSet,
+    incomingLabels,
+    outGoingLabels,
     cnfTree,
   );
   const allNodes =

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -356,12 +356,7 @@ function findPathIssues(
             nextSymbolLabels.children.length === 1 &&
             isLabelLeaf(nextSymbolLabels.children[0])
           ) {
-            if (
-              !possibleRels
-                .values()
-                .toArray()
-                .includes(nextSymbolLabels.children[0].value)
-            ) {
+            if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
               diagnostics.push({
                 message: 'Path segment does not exist on graph.',
                 severity: DiagnosticSeverity.Warning,

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -37,16 +37,16 @@ import {
 } from '../generated-parser/CypherCmdParser.js';
 import { ParserRuleContext } from 'antlr4';
 import {
-  getNodesFromRelsSet,
-  getRelsFromNodesSets,
-  walkCNFTree,
-} from '../autocompletion/schemaBasedCompletions.js';
-import {
   convertToCNF,
   isAnyNode,
   isNotAnyNode,
   removeInnerAnys,
 } from '../labelTreeRewriting.js';
+import {
+  getNodesFromRelsSet,
+  getRelsFromNodesSets,
+  walkCNFTree,
+} from '../labelTreeWalking.js';
 
 export type SyntaxDiagnostic = Diagnostic & {
   offsets: { start: number; end: number };

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -351,7 +351,6 @@ function findPathIssues(
           );
           if (
             possibleRels &&
-            nextSymbolLabels &&
             'children' in nextSymbolLabels &&
             nextSymbolLabels.children.length === 1 &&
             isLabelLeaf(nextSymbolLabels.children[0])
@@ -410,12 +409,7 @@ function findPathIssues(
             nextSymbolLabels.children.length === 1 &&
             isLabelLeaf(nextSymbolLabels.children[0])
           ) {
-            if (
-              !possibleRels
-                .values()
-                .toArray()
-                .includes(nextSymbolLabels.children[0].value)
-            ) {
+            if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
               diagnostics.push({
                 message: 'Path segment does not exist on graph.',
                 severity: DiagnosticSeverity.Warning,
@@ -617,7 +611,7 @@ function possibleFollowingRelType(
   direction: 'incoming' | 'outgoing' | 'bidirectional',
   dbSchema: DbSchema,
   labels: LabelOrCondition,
-): string[] | undefined {
+): Set<string> | undefined {
   const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
     getRelsFromNodesSets(dbSchema);
   return getFollowingLabels(direction, labels, {
@@ -631,7 +625,7 @@ function possibleFollowingLabels(
   direction: 'incoming' | 'outgoing' | 'bidirectional',
   dbSchema: DbSchema,
   labels: LabelOrCondition,
-): string[] | undefined {
+): Set<string> | undefined {
   const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
     getNodesFromRelsSet(dbSchema);
   return getFollowingLabels(direction, labels, {
@@ -650,7 +644,7 @@ function getFollowingLabels(
     incomingLabels: Map<string, Set<string>>;
     outGoingLabels: Map<string, Set<string>>;
   },
-): string[] | undefined {
+): Set<string> | undefined {
   let cnfTree: LabelOrCondition;
   try {
     const treeWithRewrittenAnys = removeInnerAnys(labels);
@@ -663,14 +657,6 @@ function getFollowingLabels(
   } catch {
     return undefined;
   }
-  let allIncomingLabels = new Set<string>();
-  incomingLabels.forEach((part) => {
-    allIncomingLabels = allIncomingLabels.union(part);
-  });
-  let allOutGoingLabels = new Set<string>();
-  outGoingLabels.forEach((part) => {
-    allOutGoingLabels = allOutGoingLabels.union(part);
-  });
   const { inLabels, outLabels } = walkCNFTree(
     incomingLabels,
     outGoingLabels,
@@ -682,7 +668,7 @@ function getFollowingLabels(
       : direction === 'incoming'
         ? inLabels
         : inLabels.union(outLabels);
-  return allNodes.values().toArray();
+  return allNodes;
 }
 
 function warningOnDeprecatedProcedure(

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -18,9 +18,34 @@ import {
   ParsedStatement,
   ParsingResult,
   createParsingResult,
+  translateTokensToRange,
 } from '../cypherLanguageService.js';
-import { Neo4jFunction, Neo4jProcedure, SymbolTable } from '../types.js';
+import {
+  isLabelLeaf,
+  LabelOrCondition,
+  Neo4jFunction,
+  Neo4jProcedure,
+  SymbolTable,
+} from '../types.js';
 import { wrappedSemanticAnalysis } from './semanticAnalysisWrapper.js';
+import { _internalFeatureFlags } from '../featureFlags.js';
+import {
+  NodePatternContext,
+  PatternElementContext,
+  RelationshipPatternContext,
+  StatementContext,
+} from '../generated-parser/CypherCmdParser.js';
+import { ParserRuleContext } from 'antlr4';
+import {
+  getRelsFromNodesSets,
+  walkCNFTree,
+} from '../autocompletion/schemaBasedCompletions.js';
+import {
+  convertToCNF,
+  isAnyNode,
+  isNotAnyNode,
+  removeInnerAnys,
+} from '../labelTreeRewriting.js';
 
 export type SyntaxDiagnostic = Diagnostic & {
   offsets: { start: number; end: number };
@@ -258,6 +283,117 @@ function warnOnUndeclaredLabels(
   return warnings;
 }
 
+function warnOnPathDirectionalityIssues(
+  parsingResult: ParsedStatement,
+  dbSchema: DbSchema,
+  symbolTable: SymbolTable,
+): SyntaxDiagnostic[] {
+  const statements = parsingResult.ctx.statementOrCommand_list();
+  return statements.reduce<SyntaxDiagnostic[]>((acc, stmtOrCommand) => {
+    const stmt = stmtOrCommand.preparsedStatement()?.statement();
+    if (!stmt) {
+      return acc;
+    }
+    const pathIssues = findPathIssues(
+      stmt,
+      parsingResult,
+      dbSchema,
+      symbolTable,
+    );
+    return acc.concat(pathIssues);
+  }, []);
+}
+
+function findPathIssues(
+  stmt: StatementContext,
+  parsingResult: ParsedStatement,
+  dbSchema: DbSchema,
+  symbolTable: SymbolTable,
+): SyntaxDiagnostic[] {
+  const patternElements: PatternElementContext[] = findPatternElements(
+    stmt,
+    [],
+  );
+  const diagnostics: SyntaxDiagnostic[] = [];
+  for (const pattern of patternElements) {
+    const children = pattern.children ?? [];
+    if (
+      children.length >= 2 &&
+      children[0] instanceof NodePatternContext &&
+      children[1] instanceof RelationshipPatternContext
+    ) {
+      const child = children[0];
+      const nextChild = children[1];
+      if (!nextChild.stop?.stop || !child.stop?.stop) {
+        return [];
+      }
+      const symbol = symbolTable.find((x) =>
+        x.references.some(
+          (ref) => ref >= child.start.start && ref <= (child.stop?.stop ?? -1),
+        ),
+      );
+      const nextSymbolLabels = symbolTable.find((x) =>
+        x.references.some(
+          (ref) =>
+            ref >= nextChild.start.start && ref <= (nextChild.stop?.stop ?? -1),
+        ),
+      )?.labels;
+      if (
+        symbol &&
+        nextSymbolLabels &&
+        parsingResult.command.type === 'cypher'
+      ) {
+        const direction = nextChild.leftArrow()
+          ? 'outgoing'
+          : nextChild.rightArrow()
+            ? 'incoming'
+            : 'bidirectional';
+        const possibleRels = possibleFollowingRelType(
+          direction,
+          dbSchema,
+          symbol.labels,
+        );
+        if (
+          possibleRels &&
+          nextSymbolLabels &&
+          'children' in nextSymbolLabels &&
+          nextSymbolLabels.children.length == 1 &&
+          isLabelLeaf(nextSymbolLabels.children[0])
+        ) {
+          if (
+            !possibleRels
+              .values()
+              .toArray()
+              .includes(nextSymbolLabels.children[0].value)
+          ) {
+            diagnostics.push({
+              message: 'Path segment does not exist on graph.',
+              severity: DiagnosticSeverity.Warning,
+              ...translateTokensToRange(child.start, nextChild.stop),
+            });
+          }
+        }
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function findPatternElements(
+  ctx: ParserRuleContext,
+  acc: PatternElementContext[],
+): PatternElementContext[] {
+  for (const c of ctx.children ?? []) {
+    if (c instanceof PatternElementContext) {
+      acc.push(c);
+    }
+    if (c instanceof ParserRuleContext) {
+      findPatternElements(c, acc);
+    }
+  }
+  return acc;
+}
+
 export function sortByPositionAndMessage(
   a: SyntaxDiagnostic,
   b: SyntaxDiagnostic,
@@ -381,6 +517,20 @@ export function lintCypherQuery(
           parseResult: current,
         });
 
+        const symbolTable = fixSymbolTableOffsets({
+          symbolTable: rawSymbolTable,
+          parseResult: current,
+        });
+
+        let missingPathWarnings: SyntaxDiagnostic[] = [];
+        if (_internalFeatureFlags.lintPatternDirectionalityIssues) {
+          missingPathWarnings = warnOnPathDirectionalityIssues(
+            current,
+            dbSchema,
+            symbolTable,
+          );
+        }
+
         const diagnostics = semanticDiagnostics
           .concat(
             labelWarnings,
@@ -389,14 +539,10 @@ export function lintCypherQuery(
             procedureErrors,
             functionWarnings,
             procedureWarnings,
+            missingPathWarnings,
             current.syntaxErrors,
           )
           .sort(sortByPositionAndMessage);
-
-        const symbolTable = fixSymbolTableOffsets({
-          symbolTable: rawSymbolTable,
-          parseResult: current,
-        });
 
         return { diagnostics, symbolTable };
       }
@@ -410,6 +556,49 @@ export function lintCypherQuery(
   }
 
   return { diagnostics: [], symbolTables: [] };
+}
+
+//Returns possible following rel types, or undefined in cases where we should quit
+function possibleFollowingRelType(
+  direction: 'incoming' | 'outgoing' | 'bidirectional',
+  dbSchema: DbSchema,
+  labels: LabelOrCondition,
+): string[] | undefined {
+  const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
+    getRelsFromNodesSets(dbSchema);
+
+  let cnfTree: LabelOrCondition;
+  try {
+    const treeWithRewrittenAnys = removeInnerAnys(labels);
+    if (isAnyNode(treeWithRewrittenAnys)) {
+      return undefined;
+    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
+      return undefined;
+    }
+    cnfTree = convertToCNF(treeWithRewrittenAnys);
+  } catch {
+    return undefined;
+  }
+  let allIncomingLabels = new Set<string>();
+  relsToNodesSet.forEach((part) => {
+    allIncomingLabels = allIncomingLabels.union(part);
+  });
+  let allOutGoingLabels = new Set<string>();
+  relsFromNodesSet.forEach((part) => {
+    allOutGoingLabels = allOutGoingLabels.union(part);
+  });
+  const { inLabels, outLabels } = walkCNFTree(
+    relsToNodesSet,
+    relsFromNodesSet,
+    cnfTree,
+  );
+  const allRels =
+    direction === 'outgoing'
+      ? outLabels
+      : direction === 'incoming'
+        ? inLabels
+        : inLabels.union(outLabels);
+  return allRels.values().toArray();
 }
 
 function warningOnDeprecatedProcedure(

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -303,6 +303,52 @@ function warnOnPathDirectionalityIssues(
   }, []);
 }
 
+function labelTreeToString(node: LabelOrCondition): string {
+  if (isLabelLeaf(node)) {
+    return node.value;
+  } else if (node.condition === 'any') {
+    return 'ANY';
+  } else if (node.children.length === 1) {
+    return labelTreeToString(node.children[0]);
+  } else {
+    let separator = ' ';
+    switch (node.condition) {
+      case 'and':
+        separator = ' & ';
+        break;
+      case 'or':
+        separator = ' | ';
+        break;
+      case 'not':
+        separator = '!';
+        break;
+    }
+    const childStrings: string[] = node.children.map((c) =>
+      labelTreeToString(c),
+    );
+    return '(' + childStrings.join(separator) + ')';
+  }
+}
+
+function labelsToMessage(
+  firstLabelTree: LabelOrCondition,
+  connectedLabel: string,
+  direction: 'outgoing' | 'incoming' | 'bidirectional',
+  firstVarType: 'node' | 'relationship' | 'variable',
+) {
+  const directionSubString =
+    direction === 'bidirectional' ? '' : direction + ' ';
+  const secondVarType =
+    firstVarType === 'node'
+      ? 'relationship'
+      : firstVarType === 'relationship'
+        ? 'node'
+        : 'variable';
+  const capitalizedSecondVar =
+    secondVarType.at(0)?.toUpperCase() + secondVarType.slice(1);
+  return `${capitalizedSecondVar} with label ${connectedLabel} has no ${directionSubString}connection to a ${firstVarType} with label(s) ${labelTreeToString(firstLabelTree)}.`;
+}
+
 function findPathIssues(
   stmt: StatementContext,
   dbSchema: DbSchema,
@@ -340,7 +386,9 @@ function findPathIssues(
         )?.labels;
         if (symbol && nextSymbolLabels) {
           const direction =
-            nextChild.leftArrow() && !nextChild.rightArrow()
+            nextChild.leftArrow() &&
+            !nextChild.rightArrow() &&
+            nextChild.arrowLine_list()?.length == 2 //check for 2 lines to handle unfinished rel better
               ? 'outgoing'
               : !nextChild.leftArrow() && nextChild.rightArrow()
                 ? 'incoming'
@@ -357,8 +405,25 @@ function findPathIssues(
             isLabelLeaf(nextSymbolLabels.children[0])
           ) {
             if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
+              let firstVarType: 'variable' | 'node' | 'relationship' =
+                'variable';
+              if (symbol.types.length === 1) {
+                switch (symbol.types[0]) {
+                  case 'Node':
+                    firstVarType = 'node';
+                    break;
+                  case 'Relationship':
+                    firstVarType = 'relationship';
+                    break;
+                }
+              }
               diagnostics.push({
-                message: 'Path segment does not exist on graph.',
+                message: labelsToMessage(
+                  symbol.labels,
+                  nextSymbolLabels.children[0].value,
+                  direction,
+                  firstVarType,
+                ),
                 severity: DiagnosticSeverity.Warning,
                 ...translateTokensToRange(child.start, nextChild.stop),
               });
@@ -388,7 +453,9 @@ function findPathIssues(
         )?.labels;
         if (symbol && nextSymbolLabels) {
           const direction =
-            child.leftArrow() && !child.rightArrow()
+            child.leftArrow() &&
+            !child.rightArrow() &&
+            child.arrowLine_list()?.length == 2 //check for 2 lines to handle unfinished rel better
               ? 'outgoing'
               : !child.leftArrow() && child.rightArrow()
                 ? 'incoming'
@@ -406,8 +473,25 @@ function findPathIssues(
             isLabelLeaf(nextSymbolLabels.children[0])
           ) {
             if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
+              let firstVarType: 'variable' | 'node' | 'relationship' =
+                'variable';
+              if (symbol.types.length === 1) {
+                switch (symbol.types[0]) {
+                  case 'Node':
+                    firstVarType = 'node';
+                    break;
+                  case 'Relationship':
+                    firstVarType = 'relationship';
+                    break;
+                }
+              }
               diagnostics.push({
-                message: 'Path segment does not exist on graph.',
+                message: labelsToMessage(
+                  symbol.labels,
+                  nextSymbolLabels.children[0].value,
+                  direction,
+                  firstVarType,
+                ),
                 severity: DiagnosticSeverity.Warning,
                 ...translateTokensToRange(child.start, nextChild.stop),
               });

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -30,6 +30,9 @@ import {
 import { wrappedSemanticAnalysis } from './semanticAnalysisWrapper.js';
 import { _internalFeatureFlags } from '../featureFlags.js';
 import {
+  CreateClauseContext,
+  InsertClauseContext,
+  MergeClauseContext,
   NodePatternContext,
   PatternElementContext,
   RelationshipPatternContext,
@@ -429,6 +432,13 @@ function findPatternElements(
   acc: PatternElementContext[],
 ): PatternElementContext[] {
   for (const c of ctx.children ?? []) {
+    if (
+      c instanceof MergeClauseContext ||
+      c instanceof CreateClauseContext ||
+      c instanceof InsertClauseContext
+    ) {
+      continue;
+    }
     if (c instanceof PatternElementContext) {
       acc.push(c);
     }

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -112,12 +112,12 @@ describe('Semantic validation spec', () => {
       {
         message: 'Path segment does not exist on graph.',
         offsets: {
-          end: 28,
+          end: 27,
           start: 8,
         },
         range: {
           end: {
-            character: 28,
+            character: 27,
             line: 0,
           },
           start: {
@@ -128,5 +128,153 @@ describe('Semantic validation spec', () => {
         severity: 2,
       },
     ]);
+  });
+
+  test('Does not warn on valid path segments. Rel->Node', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on invalid path segments. <-Rel-Node', () => {
+    const query = 'MATCH ()<-[:WEAK_TO]-(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 27,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 27,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on valid path segments. <-Rel-Node', () => {
+    const query = 'MATCH ()<-[:WEAK_TO]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on multiple invalid path segments at once', () => {
+    const query = 'MATCH (:Trainer)<-[:WEAK_TO]->(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 30,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 30,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 36,
+          start: 16,
+        },
+        range: {
+          end: {
+            character: 36,
+            line: 0,
+          },
+          start: {
+            character: 16,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on valid path segments. Node<-Rel->Node', () => {
+    const query = 'MATCH (:Type)<-[:WEAK_TO]->(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Handles multiple labels on first variable in path segment (node)', () => {
+    const query = 'MATCH (:Trainer|Gym)<-[:WEAK_TO]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 33,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 33,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles multiple labels on first variable in path segment (rel)', () => {
+    const query = 'MATCH (:Trainer)<-[:WEAK_TO|IS_IN]-(:Move) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 42,
+          start: 16,
+        },
+        range: {
+          end: {
+            character: 42,
+            line: 0,
+          },
+          start: {
+            character: 16,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Limitation: Bails on multiple labels on second variable in path segment (node)', () => {
+    const query = 'MATCH (:Type)<-[:WEAK_TO]-(:Trainer|Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Limitation: Bails on multiple labels on second variable in path segment (rel)', () => {
+    const query = 'MATCH (:Gym)<-[:WEAK_TO|IS_IN]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
   });
 });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1,3 +1,4 @@
+import { _internalFeatureFlags } from '../../featureFlags.js';
 import { getDiagnosticsForQuery } from './helpers.js';
 
 const dbSchema = {
@@ -43,6 +44,15 @@ const dbSchema = {
 };
 
 describe('Schema based linting spec', () => {
+  let flag: boolean;
+  beforeAll(() => {
+    flag = _internalFeatureFlags.lintPatternDirectionalityIssues;
+    _internalFeatureFlags.lintPatternDirectionalityIssues = true;
+  });
+  afterAll(() => {
+    _internalFeatureFlags.lintPatternDirectionalityIssues = flag;
+  });
+
   test('Warns on invalid path segments. Node->Rel', () => {
     const query = 'MATCH (n:Trainer)-[:WEAK_TO]->() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -49,7 +49,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Relationship with label WEAK_TO has no incoming connection to a node with label(s) Trainer.',
         offsets: {
           end: 30,
           start: 6,
@@ -80,7 +81,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) Pokemon.',
         offsets: {
           end: 30,
           start: 6,
@@ -111,7 +113,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Gym has no incoming connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 27,
           start: 8,
@@ -142,7 +145,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Gym has no outgoing connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 27,
           start: 8,
@@ -173,7 +177,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Relationship with label WEAK_TO has no connection to a node with label(s) Trainer.',
         offsets: {
           end: 30,
           start: 6,
@@ -191,7 +196,8 @@ describe('Schema based linting spec', () => {
         severity: 2,
       },
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Gym has no connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 36,
           start: 16,
@@ -222,7 +228,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) (Trainer | Gym).',
         offsets: {
           end: 33,
           start: 6,
@@ -247,7 +254,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Move has no outgoing connection to a relationship with label(s) (WEAK_TO | IS_IN).',
         offsets: {
           end: 42,
           start: 16,
@@ -259,6 +267,33 @@ describe('Schema based linting spec', () => {
           },
           start: {
             character: 16,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles multiple labels on first variable in path segment. Extreme case', () => {
+    const query =
+      'MATCH (:(Trainer|Gym) & (Gym | (Trainer & Pokemon)))<-[:WEAK_TO]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) ((Trainer | Gym) & (Gym | (Trainer & Pokemon))).',
+        offsets: {
+          end: 65,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 65,
+            line: 0,
+          },
+          start: {
+            character: 6,
             line: 0,
           },
         },
@@ -303,7 +338,8 @@ describe('Schema based linting spec', () => {
         severity: 1,
       },
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Relationship with label WEAK_TO has no connection to a node with label(s) Gym.',
         offsets: {
           end: 22,
           start: 6,
@@ -342,6 +378,96 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
+  test('Assumes bidirectional direction if rel direction is unfinished (expect no path issues when one way of bidirectional could be true) v1', () => {
+    const query = 'MATCH (:Region)-[:IS_IN RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 33,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 33,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input 'RETURN': expected a parameter, '&', '*', ':', 'WHERE', ']', '{' or '|'",
+        offsets: {
+          end: 30,
+          start: 24,
+        },
+        range: {
+          end: {
+            character: 30,
+            line: 0,
+          },
+          start: {
+            character: 24,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Assumes bidirectional direction if rel direction is unfinished (expect no path issues when one way of bidirectional could be true) v2', () => {
+    const query = 'MATCH (:Pokemon)<-[:WEAK_TO RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 37,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 37,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input 'RETURN': expected a parameter, '&', '*', ':', 'WHERE', ']', '{' or '|'",
+        offsets: {
+          end: 34,
+          start: 28,
+        },
+        range: {
+          end: {
+            character: 34,
+            line: 0,
+          },
+          start: {
+            character: 28,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
   test('Handles unfinished node when label is defined', () => {
     const query = 'MATCH (:Gym)-[:IS_IN]->(:Pokemon RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
@@ -366,7 +492,8 @@ describe('Schema based linting spec', () => {
         severity: 1,
       },
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Pokemon has no incoming connection to a relationship with label(s) IS_IN.',
         offsets: {
           end: 32,
           start: 12,
@@ -590,7 +717,8 @@ describe('Schema based linting spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
-        message: 'Path segment does not exist on graph.',
+        message:
+          'Node with label Archer has no outgoing connection to a relationship with label(s) MISSED.',
         offsets: {
           end: 30,
           start: 9,

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -277,4 +277,310 @@ describe('Semantic validation spec', () => {
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([]);
   });
+
+  test('Handles unfinished rel when reltype is defined', () => {
+    const query = 'MATCH (:Gym)-[:WEAK_TO RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 32,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 32,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 22,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 22,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Invalid input 'RETURN': expected a parameter, '&', '*', ':', 'WHERE', ']', '{' or '|'",
+        offsets: {
+          end: 29,
+          start: 23,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 23,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Handles unfinished node when label is defined', () => {
+    const query = 'MATCH (:Gym)-[:IS_IN]->(:Pokemon RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 42,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 42,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 32,
+          start: 12,
+        },
+        range: {
+          end: {
+            character: 32,
+            line: 0,
+          },
+          start: {
+            character: 12,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Invalid input 'RETURN': expected a parameter, '&', ')', ':', 'WHERE', '{' or '|'",
+        offsets: {
+          end: 39,
+          start: 33,
+        },
+        range: {
+          end: {
+            character: 39,
+            line: 0,
+          },
+          start: {
+            character: 33,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Should not fail on broken rel', () => {
+    const query = 'MATCH (n:Gym)<-[ :';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 18,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 18,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input '': expected a node label/relationship type name, '$', '%' or '('",
+        offsets: {
+          end: 18,
+          start: 18,
+        },
+        range: {
+          end: {
+            character: 18,
+            line: 0,
+          },
+          start: {
+            character: 18,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Should not fail on broken rel v2', () => {
+    const query = 'MATCH (n:Gym)<-[';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 16,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 16,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input '': expected a parameter, a variable name, '*', ':', 'IS', 'WHERE', ']' or '{'",
+        offsets: {
+          end: 16,
+          start: 16,
+        },
+        range: {
+          end: {
+            character: 16,
+            line: 0,
+          },
+          start: {
+            character: 16,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Should not fail on broken node', () => {
+    const query = 'MATCH (n)<-[:WEAK_TO]-( ';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 23,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 23,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input '': expected a parameter, a variable name, ')', ':', 'IS', 'WHERE' or '{'",
+        offsets: {
+          end: 23,
+          start: 23,
+        },
+        range: {
+          end: {
+            character: 23,
+            line: 0,
+          },
+          start: {
+            character: 23,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
+
+  test('Should not fail on broken node v2', () => {
+    const query = 'MATCH (n)<-[:WEAK_TO]-(m ';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Query cannot conclude with MATCH (must be a RETURN clause, a FINISH clause, an update clause, a unit subquery call, or a procedure call with no YIELD).',
+        offsets: {
+          end: 24,
+          start: 0,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+      {
+        message:
+          "Invalid input '': expected a parameter, ')', ':', 'IS', 'WHERE' or '{'",
+        offsets: {
+          end: 24,
+          start: 24,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 24,
+            line: 0,
+          },
+        },
+        severity: 1,
+      },
+    ]);
+  });
 });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -42,7 +42,7 @@ const dbSchema = {
   ],
 };
 
-describe('Semantic validation spec', () => {
+describe('Schema based linting spec', () => {
   test('Warns on invalid path segments. Node->Rel', () => {
     const query = 'MATCH (n:Trainer)-[:WEAK_TO]->() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -583,4 +583,22 @@ describe('Schema based linting spec', () => {
       },
     ]);
   });
+
+  test('Should not warn on CREATE', () => {
+    const query = 'CREATE (n:Person)<-[:WEAK_TO]-()';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Should not warn on INSERT', () => {
+    const query = 'INSERT (n:Person)<-[:WEAK_TO]-()';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Should not warn on MERGE', () => {
+    const query = 'MERGE (n:Type)-[:IS_IN]->()';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -585,6 +585,69 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
+  test('Warns both on missing label and path segment at once', () => {
+    const query = 'MATCH (n)<-[:MISSED]-(:Archer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 30,
+          start: 9,
+        },
+        range: {
+          end: {
+            character: 30,
+            line: 0,
+          },
+          start: {
+            character: 9,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Relationship type MISSED is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 19,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 19,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          "Label Archer is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+        offsets: {
+          end: 29,
+          start: 23,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 23,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
   test('Should not warn on CREATE', () => {
     const query = 'CREATE (n:Person)<-[:WEAK_TO]-()';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1,0 +1,132 @@
+import { getDiagnosticsForQuery } from './helpers.js';
+
+const dbSchema = {
+  labels: [
+    'Pokemon',
+    'Trainer',
+    'Gym',
+    'Region',
+    'Type',
+    'Move',
+    'UnrelatedLabel',
+    'Unconnected',
+  ],
+  relationshipTypes: [
+    'CATCHES',
+    'TRAINS',
+    'BATTLES',
+    'CHALLENGES',
+    'KNOWS',
+    'WEAK_TO',
+    'STRONG_AGAINST',
+    'IS_IN',
+    'UNRELATED_RELTYPE',
+  ],
+  graphSchema: [
+    { from: 'Trainer', relType: 'CATCHES', to: 'Pokemon' },
+    { from: 'Trainer', relType: 'TRAINS', to: 'Pokemon' },
+    { from: 'Trainer', relType: 'BATTLES', to: 'Trainer' },
+    { from: 'Trainer', relType: 'IS_IN', to: 'Region' },
+    { from: 'Gym', relType: 'IS_IN', to: 'Region' },
+    { from: 'Trainer', relType: 'CHALLENGES', to: 'Gym' },
+    { from: 'Pokemon', relType: 'CHALLENGES', to: 'Gym' },
+    { from: 'Pokemon', relType: 'CHALLENGES', to: 'Pokemon' },
+    { from: 'Pokemon', relType: 'KNOWS', to: 'Move' },
+    { from: 'Pokemon', relType: 'WEAK_TO', to: 'Type' },
+    { from: 'Type', relType: 'STRONG_AGAINST', to: 'Type' },
+    {
+      from: 'UnrelatedLabel',
+      relType: 'UNRELATED_RELTYPE',
+      to: 'UnrelatedLabel',
+    },
+  ],
+};
+
+describe('Semantic validation spec', () => {
+  test('Warns on invalid path segments. Node->Rel', () => {
+    const query = 'MATCH (n:Trainer)-[:WEAK_TO]->() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 30,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 30,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on valid path segments. Node->Rel', () => {
+    const query = 'MATCH (n:Pokemon)-[:WEAK_TO]->() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on invalid path segments. Node<-Rel', () => {
+    const query = 'MATCH (n:Pokemon)<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 30,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 30,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on valid path segments. Node<-Rel', () => {
+    const query = 'MATCH (n:Type)<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on invalid path segments. Rel->Node', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message: 'Path segment does not exist on graph.',
+        offsets: {
+          end: 28,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 28,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+});

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -44,15 +44,6 @@ const dbSchema = {
 };
 
 describe('Schema based linting spec', () => {
-  let flag: boolean;
-  beforeAll(() => {
-    flag = _internalFeatureFlags.lintPatternDirectionalityIssues;
-    _internalFeatureFlags.lintPatternDirectionalityIssues = true;
-  });
-  afterAll(() => {
-    _internalFeatureFlags.lintPatternDirectionalityIssues = flag;
-  });
-
   test('Warns on invalid path segments. Node->Rel', () => {
     const query = 'MATCH (n:Trainer)-[:WEAK_TO]->() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -241,7 +241,7 @@ suite('Syntax validation spec', () => {
             new vscode.Position(0, 8),
             new vscode.Position(0, 32),
           ),
-          'Path segment does not exist on graph.',
+          '"Relationship with label ACTED_IN has no incoming connection to a node with label(s) Person."',
           vscode.DiagnosticSeverity.Warning,
         ),
         new vscode.Diagnostic(
@@ -257,7 +257,7 @@ suite('Syntax validation spec', () => {
             new vscode.Position(0, 18),
             new vscode.Position(0, 65),
           ),
-          'Path segment does not exist on graph.',
+          '"Node with label Movie has no incoming connection to a relationship with label(s) ACTED_IN."',
           vscode.DiagnosticSeverity.Warning,
         ),
         new vscode.Diagnostic(

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -238,6 +238,22 @@ suite('Syntax validation spec', () => {
       expected: [
         new vscode.Diagnostic(
           new vscode.Range(
+            new vscode.Position(0, 8),
+            new vscode.Position(0, 32),
+          ),
+          'Path segment does not exist on graph.',
+          vscode.DiagnosticSeverity.Warning,
+        ),
+        new vscode.Diagnostic(
+          new vscode.Range(
+            new vscode.Position(0, 18),
+            new vscode.Position(0, 65),
+          ),
+          'Path segment does not exist on graph.',
+          vscode.DiagnosticSeverity.Warning,
+        ),
+        new vscode.Diagnostic(
+          new vscode.Range(
             new vscode.Position(0, 11),
             new vscode.Position(0, 17),
           ),

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -246,18 +246,18 @@ suite('Syntax validation spec', () => {
         ),
         new vscode.Diagnostic(
           new vscode.Range(
-            new vscode.Position(0, 18),
-            new vscode.Position(0, 65),
-          ),
-          'Path segment does not exist on graph.',
-          vscode.DiagnosticSeverity.Warning,
-        ),
-        new vscode.Diagnostic(
-          new vscode.Range(
             new vscode.Position(0, 11),
             new vscode.Position(0, 17),
           ),
           "Label Person is not present in the database. Make sure you didn't misspell it or that it is available when you run this statement in your application",
+          vscode.DiagnosticSeverity.Warning,
+        ),
+        new vscode.Diagnostic(
+          new vscode.Range(
+            new vscode.Position(0, 18),
+            new vscode.Position(0, 65),
+          ),
+          'Path segment does not exist on graph.',
           vscode.DiagnosticSeverity.Warning,
         ),
         new vscode.Diagnostic(

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -241,7 +241,7 @@ suite('Syntax validation spec', () => {
             new vscode.Position(0, 8),
             new vscode.Position(0, 32),
           ),
-          '"Relationship with label ACTED_IN has no incoming connection to a node with label(s) Person."',
+          'Relationship with label ACTED_IN has no incoming connection to a node with label(s) Person.',
           vscode.DiagnosticSeverity.Warning,
         ),
         new vscode.Diagnostic(
@@ -257,7 +257,7 @@ suite('Syntax validation spec', () => {
             new vscode.Position(0, 18),
             new vscode.Position(0, 65),
           ),
-          '"Node with label Movie has no incoming connection to a relationship with label(s) ACTED_IN."',
+          'Node with label Movie has no incoming connection to a relationship with label(s) ACTED_IN.',
           vscode.DiagnosticSeverity.Warning,
         ),
         new vscode.Diagnostic(


### PR DESCRIPTION
Adds linting using the symbol table for invalid paths in a query. Warns on each segment that is invalid like
`MATCH (:Trainer)-[:WEAK_TO]->(:Type)` -> "Path segment does not exist on graph." marking the `(:Trainer)-[:WEAK_TO]->` segment

or

`MATCH (:Trainer)-[:WEAK_TO]->(:Gym)` -> "Path segment does not exist on graph." x2, once marking `(:Trainer)-[:WEAK_TO]->` and once marking `-[:WEAK_TO]->(:Gym)`

Limitation: Re-uses a modified version of the completion logic, so it currently only supports a single label on the second variable in a path segment - otherwise ignores the segment.

Warnings are deliberately skipped inside CREATE / INSERT / MERGE clauses.

While making the PR I ran across and fixed some places where the tighter TS checks of TS 6 (now default in vscode) showed some type issues (usually ~"value not checked for null when it could be")

Closes LS-103