### PR TITLE
Brow-341: inline widget panel

### DIFF
--- a/.changeset/five-ghosts-joke.md
+++ b/.changeset/five-ghosts-joke.md
@@ -1,0 +1,6 @@
+---
+"@neo4j-cypher/react-codemirror-playground": patch
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Add `inlinePanel` prop to `CypherEditor` for rendering a host-controlled panel as a block widget inside the editor.

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -1,9 +1,36 @@
 import { DbSchema, testData } from '@neo4j-cypher/language-support';
-import { CypherEditor } from '@neo4j-cypher/react-codemirror';
-import { useMemo, useRef, useState } from 'react';
+import {
+  CypherEditor,
+  type InlinePanelProps,
+} from '@neo4j-cypher/react-codemirror';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Tree } from 'react-d3-tree';
 import { TokenTable } from './TokenTable';
 import { getDebugTree } from './treeUtil';
+
+function InlinePanelDemo({ onClose }: { onClose: () => void }) {
+  const [text, setText] = useState('');
+  return (
+    <div className="border w-fit border-blue-400 bg-blue-50 dark:bg-gray-700 dark:border-blue-300 p-3 m-1 rounded flex flex-col gap-2 text-black dark:text-white">
+      <div className="text-sm">Inline panel demo</div>
+      <div className="flex gap-2 items-center text-sm">
+        <input
+          className="border px-2 py-1 text-black rounded flex-1"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Type something"
+        />
+        <button
+          className="bg-gray-400 hover:bg-gray-500 text-white px-2 py-1 rounded"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
 
 const demos = {
   allTokenTypes: `MATCH (variable :Label)-[:REL_TYPE]->() 
@@ -47,6 +74,12 @@ export function App() {
   );
   const [schemaError, setSchemaError] = useState<string | null>(null);
 
+  const [isInlinePanelOpen, setIsInlinePanelOpen] = useState(false);
+  const [inlinePanelContainer, setInlinePanelContainer] =
+    useState<HTMLElement | null>(null);
+
+  const closeInlinePanel = useCallback(() => setIsInlinePanelOpen(false), []);
+
   const extraKeybindings = [
     {
       key: 'Ctrl-Shift-f',
@@ -60,6 +93,15 @@ export function App() {
   ];
 
   const editorRef = useRef<CypherEditor>(null);
+
+  const inlinePanel: InlinePanelProps | null = isInlinePanelOpen
+    ? {
+        pos:
+          editorRef.current?.editorView.current?.state.selection.main.from ?? 0,
+        onMount: setInlinePanelContainer,
+        onUnmount: () => setInlinePanelContainer(null),
+      }
+    : null;
 
   const treeData = useMemo(() => {
     return getDebugTree(value);
@@ -131,18 +173,32 @@ export function App() {
                 consoleCommands: true,
               }}
               ariaLabel="Cypher Editor"
+              inlinePanel={inlinePanel}
             />
-            <p
-              onClick={() => editorRef.current.format()}
-              className="text-blue-500 cursor-pointer hover:text-blue-700"
-              title={
-                window.navigator.userAgent.includes('Mac')
-                  ? 'Shift-Option-F'
-                  : 'Ctrl-Shift-I'
-              }
-            >
-              Format Query
-            </p>
+            {inlinePanelContainer &&
+              createPortal(
+                <InlinePanelDemo onClose={closeInlinePanel} />,
+                inlinePanelContainer,
+              )}
+            <div className="flex gap-4">
+              <p
+                onClick={() => editorRef.current.format()}
+                className="text-blue-500 cursor-pointer hover:text-blue-700"
+                title={
+                  window.navigator.userAgent.includes('Mac')
+                    ? 'Shift-Option-F'
+                    : 'Ctrl-Shift-I'
+                }
+              >
+                Format Query
+              </p>
+              <p
+                onClick={() => setIsInlinePanelOpen((prevState) => !prevState)}
+                className="text-blue-500 cursor-pointer hover:text-blue-700"
+              >
+                {isInlinePanelOpen ? 'Close inline panel' : 'Open inline panel'}
+              </p>
+            </div>
             {commandRanCount > 0 && (
               <span className="text-gray-400">
                 "commands" ran so far: {commandRanCount}

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -14,6 +14,11 @@ import {
   ViewUpdate,
 } from '@codemirror/view';
 import {
+  createInlinePanelController,
+  type InlinePanelCallbacks,
+  type InlinePanelController,
+} from './inlinePanel';
+import {
   formatQuery,
   CypherLanguageService,
   type DbSchema,
@@ -180,7 +185,24 @@ export interface CypherEditorProps {
    * @default false
    */
   moveFocusOnTab?: boolean;
+  /**
+   * Render a panel as a block widget inside the editor.
+   */
+  inlinePanel?: InlinePanelProps | null;
 }
+
+export type InlinePanelProps = {
+  /**
+   * Position the panel anchors to.
+   */
+  pos: number;
+  /**
+   * Whether to render above or below the line
+   *
+   * @default 'above'
+   */
+  placement?: 'above' | 'below';
+} & InlinePanelCallbacks;
 
 const format = (view: EditorView): void => {
   try {
@@ -360,6 +382,8 @@ export class CypherEditor extends Component<
    */
   editorView: React.MutableRefObject<EditorView> = createRef();
   private schemaRef: React.MutableRefObject<CypherConfig> = createRef();
+  private inlinePanelController: InlinePanelController | null = null;
+  private inlinePanelResizeObserver: ResizeObserver | null = null;
 
   /**
    * Format Cypher query
@@ -471,6 +495,8 @@ export class CypherEditor extends Component<
       overrideThemeBackgroundColor,
     );
 
+    this.inlinePanelController = createInlinePanelController();
+
     const changeListener = this.debouncedOnChange
       ? [
           EditorView.updateListener.of((upt: ViewUpdate) => {
@@ -536,6 +562,7 @@ export class CypherEditor extends Component<
                 'Press Escape to leave the editor and continue tabbing through the page',
             })
           : [],
+        this.inlinePanelController.extension,
       ],
       doc: this.props.value,
     });
@@ -553,6 +580,50 @@ export class CypherEditor extends Component<
     } else if (this.props.offset) {
       this.updateCursorPosition(this.props.offset);
     }
+
+    if (this.props.inlinePanel) {
+      this.openInlinePanel(this.props.inlinePanel);
+    }
+  }
+
+  private openInlinePanel(
+    props: NonNullable<CypherEditorProps['inlinePanel']>,
+  ): void {
+    const view = this.editorView.current;
+    const controller = this.inlinePanelController;
+    if (!view || !controller) {
+      return;
+    }
+
+    view.dispatch({
+      effects: controller.show({
+        pos: view.state.doc.lineAt(props.pos).from,
+        placement: props.placement,
+        onMount: (container) => {
+          this.inlinePanelResizeObserver?.disconnect();
+          const observer = new ResizeObserver(() => {
+            this.editorView.current?.requestMeasure();
+          });
+          observer.observe(container);
+          this.inlinePanelResizeObserver = observer;
+          props.onMount(container);
+        },
+        onUnmount: () => {
+          this.inlinePanelResizeObserver?.disconnect();
+          this.inlinePanelResizeObserver = null;
+          props.onUnmount();
+        },
+      }),
+    });
+  }
+
+  private closeInlinePanel(): void {
+    const view = this.editorView.current;
+    const controller = this.inlinePanelController;
+    if (!view || !controller) {
+      return;
+    }
+    view.dispatch({ effects: controller.hide() });
   }
 
   componentDidUpdate(prevProps: CypherEditorProps): void {
@@ -642,6 +713,18 @@ export class CypherEditor extends Component<
       });
     }
 
+    if (prevProps.inlinePanel !== this.props.inlinePanel) {
+      // Reference equality: any change tears down the existing panel and
+      // opens a new one (or closes if the new value is nullish). Hosts
+      // should memoize the prop while a panel is open.
+      if (prevProps.inlinePanel) {
+        this.closeInlinePanel();
+      }
+      if (this.props.inlinePanel) {
+        this.openInlinePanel(this.props.inlinePanel);
+      }
+    }
+
     if (prevProps.domEventHandlers !== this.props.domEventHandlers) {
       this.editorView.current.dispatch({
         effects: domEventHandlerCompartment.reconfigure(
@@ -675,6 +758,8 @@ export class CypherEditor extends Component<
   }
 
   componentWillUnmount(): void {
+    this.inlinePanelResizeObserver?.disconnect();
+    this.inlinePanelResizeObserver = null;
     this.editorView.current?.destroy();
     this.symbolFetcher?.terminate();
     cleanupWorkers();

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -383,7 +383,6 @@ export class CypherEditor extends Component<
   editorView: React.MutableRefObject<EditorView> = createRef();
   private schemaRef: React.MutableRefObject<CypherConfig> = createRef();
   private inlinePanelController: InlinePanelController | null = null;
-  private inlinePanelResizeObserver: ResizeObserver | null = null;
 
   /**
    * Format Cypher query
@@ -595,24 +594,14 @@ export class CypherEditor extends Component<
       return;
     }
 
+    const pos = Math.max(0, Math.min(props.pos, view.state.doc.length));
+    const line = view.state.doc.lineAt(pos);
     view.dispatch({
       effects: controller.show({
-        pos: view.state.doc.lineAt(props.pos).from,
+        pos: props.placement === 'below' ? line.to : line.from,
         placement: props.placement,
-        onMount: (container) => {
-          this.inlinePanelResizeObserver?.disconnect();
-          const observer = new ResizeObserver(() => {
-            this.editorView.current?.requestMeasure();
-          });
-          observer.observe(container);
-          this.inlinePanelResizeObserver = observer;
-          props.onMount(container);
-        },
-        onUnmount: () => {
-          this.inlinePanelResizeObserver?.disconnect();
-          this.inlinePanelResizeObserver = null;
-          props.onUnmount();
-        },
+        onMount: props.onMount,
+        onUnmount: props.onUnmount,
       }),
     });
   }
@@ -758,8 +747,6 @@ export class CypherEditor extends Component<
   }
 
   componentWillUnmount(): void {
-    this.inlinePanelResizeObserver?.disconnect();
-    this.inlinePanelResizeObserver = null;
     this.editorView.current?.destroy();
     this.symbolFetcher?.terminate();
     cleanupWorkers();

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -187,6 +187,7 @@ export interface CypherEditorProps {
   moveFocusOnTab?: boolean;
   /**
    * Render a panel as a block widget inside the editor.
+   * The widget DOM is only rebuilt when `pos` or `placement` change
    */
   inlinePanel?: InlinePanelProps | null;
 }
@@ -596,6 +597,10 @@ export class CypherEditor extends Component<
 
     const pos = Math.max(0, Math.min(props.pos, view.state.doc.length));
     const line = view.state.doc.lineAt(pos);
+    controller.updateCallbacks({
+      onMount: props.onMount,
+      onUnmount: props.onUnmount,
+    });
     view.dispatch({
       effects: controller.show({
         pos: props.placement === 'below' ? line.to : line.from,
@@ -603,6 +608,15 @@ export class CypherEditor extends Component<
         onMount: props.onMount,
         onUnmount: props.onUnmount,
       }),
+    });
+  }
+
+  private updateInlinePanel(
+    props: NonNullable<CypherEditorProps['inlinePanel']>,
+  ): void {
+    this.inlinePanelController?.updateCallbacks({
+      onMount: props.onMount,
+      onUnmount: props.onUnmount,
     });
   }
 
@@ -702,15 +716,19 @@ export class CypherEditor extends Component<
       });
     }
 
-    if (prevProps.inlinePanel !== this.props.inlinePanel) {
-      // Reference equality: any change tears down the existing panel and
-      // opens a new one (or closes if the new value is nullish). Hosts
-      // should memoize the prop while a panel is open.
-      if (prevProps.inlinePanel) {
+    const prevPanel = prevProps.inlinePanel;
+    const nextPanel = this.props.inlinePanel;
+    if (prevPanel !== nextPanel) {
+      if (!nextPanel) {
         this.closeInlinePanel();
-      }
-      if (this.props.inlinePanel) {
-        this.openInlinePanel(this.props.inlinePanel);
+      } else if (
+        !prevPanel ||
+        prevPanel.pos !== nextPanel.pos ||
+        prevPanel.placement !== nextPanel.placement
+      ) {
+        this.openInlinePanel(nextPanel);
+      } else {
+        this.updateInlinePanel(nextPanel);
       }
     }
 

--- a/packages/react-codemirror/src/index.ts
+++ b/packages/react-codemirror/src/index.ts
@@ -1,4 +1,5 @@
 export * as LanguageSupport from '@neo4j-cypher/language-support';
 export { CypherEditor } from './CypherEditor';
+export type { InlinePanelProps } from './CypherEditor';
 export { cypher } from './lang-cypher/langCypher';
 export { darkThemeConstants, lightThemeConstants } from './themes';

--- a/packages/react-codemirror/src/inlinePanel.ts
+++ b/packages/react-codemirror/src/inlinePanel.ts
@@ -1,0 +1,105 @@
+import { StateEffect, StateField, type Extension } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  WidgetType,
+} from '@codemirror/view';
+
+/**
+ * Lifecycle callbacks for an inline panel. The host renders into the
+ * provided DOM container (e.g. via React `createPortal`) and is expected
+ * to clean up on unmount.
+ */
+export type InlinePanelCallbacks = {
+  onMount: (container: HTMLElement) => void;
+  onUnmount: () => void;
+};
+
+export type InlinePanelShowOptions = {
+  /** Document position the panel anchors to. */
+  pos: number;
+  /**
+   * Where to render the panel relative to the line at `pos`. `'above'`
+   * places it before the line, `'below'` after it.
+   *
+   * @default 'above'
+   */
+  placement?: 'above' | 'below';
+} & InlinePanelCallbacks;
+
+type ShowPayload = InlinePanelShowOptions | null;
+
+export type InlinePanelController = {
+  /** CodeMirror extension to register on the editor. */
+  extension: Extension;
+  /** Build an effect that mounts the panel with the given options. */
+  show: (options: InlinePanelShowOptions) => StateEffect<ShowPayload>;
+  /** Build an effect that unmounts the panel. */
+  hide: () => StateEffect<ShowPayload>;
+};
+
+export function createInlinePanelController(): InlinePanelController {
+  const showEffect = StateEffect.define<ShowPayload>();
+
+  class InlinePanelWidget extends WidgetType {
+    constructor(readonly options: InlinePanelShowOptions) {
+      super();
+    }
+
+    toDOM(): HTMLElement {
+      const container = document.createElement('div');
+      container.className = 'cm-inline-panel';
+      this.options.onMount(container);
+      return container;
+    }
+
+    destroy(): void {
+      this.options.onUnmount();
+    }
+
+    eq(other: InlinePanelWidget): boolean {
+      return other.options === this.options;
+    }
+
+    ignoreEvent(): boolean {
+      return true;
+    }
+  }
+
+  const field = StateField.define<DecorationSet>({
+    create() {
+      return Decoration.none;
+    },
+    update(decorations, transaction) {
+      let next: DecorationSet | null = null;
+      for (const effect of transaction.effects) {
+        if (effect.is(showEffect)) {
+          if (effect.value === null) {
+            next = Decoration.none;
+          } else {
+            const side = effect.value.placement === 'below' ? 1 : -1;
+            next = Decoration.set([
+              Decoration.widget({
+                widget: new InlinePanelWidget(effect.value),
+                block: true,
+                side,
+              }).range(effect.value.pos),
+            ]);
+          }
+        }
+      }
+      if (next !== null) {
+        return next;
+      }
+      return decorations.map(transaction.changes);
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  });
+
+  return {
+    extension: field,
+    show: (options) => showEffect.of(options),
+    hide: () => showEffect.of(null),
+  };
+}

--- a/packages/react-codemirror/src/inlinePanel.ts
+++ b/packages/react-codemirror/src/inlinePanel.ts
@@ -43,18 +43,24 @@ export function createInlinePanelController(): InlinePanelController {
   const showEffect = StateEffect.define<ShowPayload>();
 
   class InlinePanelWidget extends WidgetType {
+    private resizeObserver: ResizeObserver | null = null;
+
     constructor(readonly options: InlinePanelShowOptions) {
       super();
     }
 
-    toDOM(): HTMLElement {
+    toDOM(view: EditorView): HTMLElement {
       const container = document.createElement('div');
       container.className = 'cm-inline-panel';
+      this.resizeObserver = new ResizeObserver(() => view.requestMeasure());
+      this.resizeObserver.observe(container);
       this.options.onMount(container);
       return container;
     }
 
     destroy(): void {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = null;
       this.options.onUnmount();
     }
 

--- a/packages/react-codemirror/src/inlinePanel.ts
+++ b/packages/react-codemirror/src/inlinePanel.ts
@@ -37,10 +37,13 @@ export type InlinePanelController = {
   show: (options: InlinePanelShowOptions) => StateEffect<ShowPayload>;
   /** Build an effect that unmounts the panel. */
   hide: () => StateEffect<ShowPayload>;
+  updateCallbacks: (callbacks: InlinePanelCallbacks) => void;
 };
 
 export function createInlinePanelController(): InlinePanelController {
   const showEffect = StateEffect.define<ShowPayload>();
+
+  let callbacksRef: InlinePanelCallbacks | null = null;
 
   class InlinePanelWidget extends WidgetType {
     private resizeObserver: ResizeObserver | null = null;
@@ -54,18 +57,21 @@ export function createInlinePanelController(): InlinePanelController {
       container.className = 'cm-inline-panel';
       this.resizeObserver = new ResizeObserver(() => view.requestMeasure());
       this.resizeObserver.observe(container);
-      this.options.onMount(container);
+      callbacksRef?.onMount(container);
       return container;
     }
 
     destroy(): void {
       this.resizeObserver?.disconnect();
       this.resizeObserver = null;
-      this.options.onUnmount();
+      callbacksRef?.onUnmount();
     }
 
     eq(other: InlinePanelWidget): boolean {
-      return other.options === this.options;
+      return (
+        other.options.pos === this.options.pos &&
+        other.options.placement === this.options.placement
+      );
     }
 
     ignoreEvent(): boolean {
@@ -107,5 +113,8 @@ export function createInlinePanelController(): InlinePanelController {
     extension: field,
     show: (options) => showEffect.of(options),
     hide: () => showEffect.of(null),
+    updateCallbacks: (callbacks) => {
+      callbacksRef = callbacks;
+    },
   };
 }


### PR DESCRIPTION
This PR adds an inlinePanel prop to CypherEditor for rendering a  panel as a block widget inside the editor controlled by the caller. The prop has pos, optional placement, and onMount, onUnmount callbacks. The caller renders its own content into the provided DOM container, via createPortal for example, so react-codemirror will continue to not have react-dom as a dep.([ref to similar discussions](https://discuss.codemirror.net/t/rendering-react-components-or-similar-in-decoration-todom/3492/6)) While the panel is open, new onMount / onUnmount references are picked up without remounting and caller don't need to memoize callbacks. Changing pos or placement repositions the block widget, which removes the existing DOM and remounts at the new position.
The widget also manages a ResizeObserver so the editor remeasures its layout when host content resizes.