### PR TITLE
Filter out "parameter missing" errors when not connected

### DIFF
--- a/.changeset/major-beds-wave.md
+++ b/.changeset/major-beds-wave.md
@@ -1,0 +1,7 @@
+---
+"@neo4j-cypher/language-support": patch
+"@neo4j-cypher/react-codemirror": patch
+"@neo4j-cypher/language-server": patch
+---
+
+Hide parameter errors when disconnected

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -1,6 +1,6 @@
 import {
   clampUnsafePositions,
-  filterParams,
+  isNotParamError,
   SymbolTable,
   SyntaxDiagnostic,
 } from '@neo4j-cypher/language-support';
@@ -96,7 +96,7 @@ function filterLintResult(
   document: TextDocument,
 ) {
   return dontWarnOnParams
-    ? clampUnsafePositions(filterParams(diagnostics), document)
+    ? clampUnsafePositions(diagnostics.filter(isNotParamError), document)
     : clampUnsafePositions(diagnostics, document);
 }
 

--- a/packages/language-server/src/linting.ts
+++ b/packages/language-server/src/linting.ts
@@ -1,6 +1,8 @@
 import {
   clampUnsafePositions,
+  filterParams,
   SymbolTable,
+  SyntaxDiagnostic,
 } from '@neo4j-cypher/language-support';
 import { Neo4jSchemaPoller } from '@neo4j-cypher/query-tools';
 import debounce from 'lodash.debounce';
@@ -63,12 +65,6 @@ async function rawLintDocument(
     });
     const result = await lastSemanticJob;
 
-    //marks the entire text if any position is negative
-    const positionSafeResult = clampUnsafePositions(
-      result.diagnostics,
-      document,
-    );
-
     // Pass the computed symbol tables to the parser
     if (result.symbolTables) {
       languageService.setSymbolsInfo(
@@ -80,12 +76,28 @@ async function rawLintDocument(
       );
     }
 
-    sendDiagnostics(positionSafeResult);
+    sendDiagnostics(
+      filterLintResult(
+        result.diagnostics,
+        dbSchema?.databaseNames?.length ? false : true,
+        document,
+      ),
+    );
   } catch (err) {
     if (!(err instanceof workerpool.Promise.CancellationError)) {
       console.error(err);
     }
   }
+}
+
+function filterLintResult(
+  diagnostics: SyntaxDiagnostic[],
+  dontWarnOnParams: boolean,
+  document: TextDocument,
+) {
+  return dontWarnOnParams
+    ? clampUnsafePositions(filterParams(diagnostics), document)
+    : clampUnsafePositions(diagnostics, document);
 }
 
 export const lintDocument: typeof rawLintDocument = debounce(

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -27,7 +27,7 @@ export type { ParsedCypherToken } from './syntaxHighlighting/syntaxHighlightingH
 export {
   lintCypherQuery,
   clampUnsafePositions,
-  filterParams,
+  isNotParamError,
 } from './syntaxValidation/syntaxValidation.js';
 export type { SyntaxDiagnostic } from './syntaxValidation/syntaxValidation.js';
 export { testData } from './tests/testData.js';

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -27,6 +27,7 @@ export type { ParsedCypherToken } from './syntaxHighlighting/syntaxHighlightingH
 export {
   lintCypherQuery,
   clampUnsafePositions,
+  filterParams,
 } from './syntaxValidation/syntaxValidation.js';
 export type { SyntaxDiagnostic } from './syntaxValidation/syntaxValidation.js';
 export { testData } from './tests/testData.js';

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -89,12 +89,12 @@ function detectNonDeclaredLabel(
 
 type GenericDiagnostic = { message: string };
 
-export function filterParams<T extends GenericDiagnostic>(
-  diagnostics: T[],
-): T[] {
-  const paramRegex = /Parameter .+ is not defined./;
-  return diagnostics.filter(
-    (x) => x.message.length > 1000 || !x.message.match(paramRegex),
+export function isNotParamError<T extends GenericDiagnostic>(
+  diagnostic: T,
+): boolean {
+  return (
+    !diagnostic.message.startsWith('Parameter ') ||
+    !diagnostic.message.endsWith(' is not defined.')
   );
 }
 
@@ -812,6 +812,8 @@ function warningOnDeprecatedFunction(
   }
   return warnings;
 }
+
+export const paramMsgStart = 'Parameter ';
 
 function errorOnUndeclaredParameters(
   parsingResult: ParsedStatement,

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -87,6 +87,15 @@ function detectNonDeclaredLabel(
   return undefined;
 }
 
+type GenericDiagnostic = { message: string };
+
+export function filterParams<T extends GenericDiagnostic>(
+  diagnostics: T[],
+): T[] {
+  const paramRegex = /Parameter .+ is not defined./;
+  return diagnostics.filter((x) => !x.message.match(paramRegex));
+}
+
 export function clampUnsafePositions(
   diagnostics: SyntaxDiagnostic[],
   document: TextDocument,

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -93,7 +93,9 @@ export function filterParams<T extends GenericDiagnostic>(
   diagnostics: T[],
 ): T[] {
   const paramRegex = /Parameter .+ is not defined./;
-  return diagnostics.filter((x) => !x.message.match(paramRegex));
+  return diagnostics.filter(
+    (x) => x.message.length > 1000 || !x.message.match(paramRegex),
+  );
 }
 
 export function clampUnsafePositions(

--- a/packages/language-support/src/tests/misc.test.ts
+++ b/packages/language-support/src/tests/misc.test.ts
@@ -1,9 +1,12 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
   clampUnsafePositions,
+  filterParams,
   SyntaxDiagnostic,
 } from '../syntaxValidation/syntaxValidation.js';
 import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
+import { getDiagnosticsForQuery } from './syntaxValidation/helpers.js';
+import { testData } from './testData.js';
 
 describe('Clean positions', () => {
   test('Cleaning positions should mark the entire document when a position is negative.', () => {
@@ -45,6 +48,26 @@ describe('Clean positions', () => {
     const cleanedError = clampUnsafePositions([error], textDoc)[0];
     expect(cleanedError).toBe(error);
   });
+});
+
+test('Can filter out missing parameter warnings when disconnected using filterParams', () => {
+  const query =
+    'MATCH (n: Person) WHERE n.name = $`missing param` and n.age = $`some param` RETURN n';
+
+  expect(
+    filterParams(
+      getDiagnosticsForQuery({
+        query,
+        dbSchema: {
+          ...testData.mockSchema,
+          parameters: {
+            'some param': 21,
+          },
+          databaseNames: [],
+        },
+      }),
+    ),
+  ).toEqual([]);
 });
 
 function testPositionCoversDoc(

--- a/packages/language-support/src/tests/misc.test.ts
+++ b/packages/language-support/src/tests/misc.test.ts
@@ -1,7 +1,7 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
   clampUnsafePositions,
-  filterParams,
+  isNotParamError,
   SyntaxDiagnostic,
 } from '../syntaxValidation/syntaxValidation.js';
 import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
@@ -50,23 +50,21 @@ describe('Clean positions', () => {
   });
 });
 
-test('Can filter out missing parameter warnings when disconnected using filterParams', () => {
+test('Can filter out missing parameter warnings when disconnected using isNotParamError', () => {
   const query =
     'MATCH (n: Person) WHERE n.name = $`missing param` and n.age = $`some param` RETURN n';
 
   expect(
-    filterParams(
-      getDiagnosticsForQuery({
-        query,
-        dbSchema: {
-          ...testData.mockSchema,
-          parameters: {
-            'some param': 21,
-          },
-          databaseNames: [],
+    getDiagnosticsForQuery({
+      query,
+      dbSchema: {
+        ...testData.mockSchema,
+        parameters: {
+          'some param': 21,
         },
-      }),
-    ),
+        databaseNames: [],
+      },
+    }).filter(isNotParamError),
   ).toEqual([]);
 });
 

--- a/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
+++ b/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
@@ -4,7 +4,7 @@ import { DiagnosticSeverity, DiagnosticTag } from 'vscode-languageserver-types';
 import workerpool from 'workerpool';
 import type { CypherConfig } from './langCypher';
 import type { LintWorker } from '@neo4j-cypher/lint-worker';
-import { filterParams } from '@neo4j-cypher/language-support';
+import { isNotParamError } from '@neo4j-cypher/language-support';
 
 const WorkerURL = new URL('./lintWorker.mjs', import.meta.url).pathname;
 
@@ -60,7 +60,7 @@ export const cypherLinter: (config: CypherConfig) => Extension = (config) =>
         };
       });
       if (!config.schema?.databaseNames?.length) {
-        return filterParams(a);
+        return a.filter(isNotParamError);
       }
       return a;
     } catch (err) {

--- a/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
+++ b/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
@@ -4,6 +4,7 @@ import { DiagnosticSeverity, DiagnosticTag } from 'vscode-languageserver-types';
 import workerpool from 'workerpool';
 import type { CypherConfig } from './langCypher';
 import type { LintWorker } from '@neo4j-cypher/lint-worker';
+import { filterParams } from '@neo4j-cypher/language-support';
 
 const WorkerURL = new URL('./lintWorker.mjs', import.meta.url).pathname;
 
@@ -44,8 +45,9 @@ export const cypherLinter: (config: CypherConfig) => Extension = (config) =>
 
       const a: Diagnostic[] = result.diagnostics.map((diagnostic) => {
         return {
-          from: diagnostic.offsets.start,
-          to: diagnostic.offsets.end,
+          from: diagnostic.offsets.start >= 0 ? diagnostic.offsets.start : 0,
+          to:
+            diagnostic.offsets.end >= 0 ? diagnostic.offsets.end : query.length,
           severity:
             diagnostic.severity === DiagnosticSeverity.Error
               ? 'error'
@@ -57,6 +59,9 @@ export const cypherLinter: (config: CypherConfig) => Extension = (config) =>
             : {}),
         };
       });
+      if (!config.schema?.databaseNames?.length) {
+        return filterParams(a);
+      }
       return a;
     } catch (err) {
       if (!String(err).includes('Worker terminated')) {

--- a/packages/vscode-extension/tests/helpers.ts
+++ b/packages/vscode-extension/tests/helpers.ts
@@ -44,6 +44,12 @@ export async function eventually(
   timeoutMs = 15000,
   backoffMs = 100,
 ) {
+  // Cap the backoff so the retry interval stays small. Without a cap the
+  // exponential growth means we both poll very rarely near the end (a correct
+  // state can appear and not be noticed for tens of seconds) and overshoot
+  // `timeoutMs` in wall-clock time by ~2x, so mocha's own timeout fires first
+  // and hides the real assertion error.
+  const maxBackoffMs = 5000;
   let totalWait = 0;
   let wait = backoffMs;
   let succeeded = false;
@@ -53,16 +59,15 @@ export async function eventually(
       await assertion();
       succeeded = true;
     } catch (e) {
-      totalWait += wait;
       if (totalWait > timeoutMs) {
         throw new Error(
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Timeout of ${timeoutMs} exceeded for test with last error: ${e}`,
         );
-      } else {
-        wait *= 2;
-        await sleep(wait);
       }
+      await sleep(wait);
+      totalWait += wait;
+      wait = Math.min(wait * 2, maxBackoffMs);
     }
   }
 }

--- a/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
@@ -96,11 +96,6 @@ suite('Lint switching spec', () => {
   }
 
   test('Switching the linter to an old one should show different errors', async function () {
-    // Going through the real SWITCH_LINTER_COMMAND downloads the linter from
-    // npm and spawns a fresh lint worker pool that re-lints the document. On
-    // cold CI machines that whole chain can take well over 10s, so we give the
-    // diagnostics polling (and mocha) plenty of headroom to avoid flaky timeouts.
-    this.timeout(60000);
     const linterVersion = '5.26';
     const stub = sandbox.stub(
       window,
@@ -125,7 +120,6 @@ suite('Lint switching spec', () => {
           vscode.DiagnosticSeverity.Error,
         ),
       ],
-      timeoutMs: 40000,
     });
   });
 
@@ -199,9 +193,6 @@ suite('Lint switching spec', () => {
   });
 
   test('Switching the linter back to a new one should show different errors', async function () {
-    // See the comment on the "old one" test above: the real switch + relint can
-    // be slow on cold machines, so we extend the diagnostics/mocha timeouts.
-    this.timeout(90000);
     const linterVersion = '2025.06';
     const stub = sandbox.stub(
       window,
@@ -217,7 +208,6 @@ suite('Lint switching spec', () => {
     await testSyntaxValidation({
       docUri: textDocument.uri,
       expected: [],
-      timeoutMs: 60000,
     });
   });
 

--- a/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
@@ -187,7 +187,7 @@ suite('Lint switching spec', () => {
   test('Switching the linter back to a new one should show different errors', async function () {
     // See the comment on the "old one" test above: the real switch + relint can
     // be slow on cold machines, so we extend the diagnostics/mocha timeouts.
-    this.timeout(60000);
+    this.timeout(90000);
     const linterVersion = '2025.06';
     const stub = sandbox.stub(
       window,
@@ -203,7 +203,7 @@ suite('Lint switching spec', () => {
     await testSyntaxValidation({
       docUri: textDocument.uri,
       expected: [],
-      timeoutMs: 40000,
+      timeoutMs: 60000,
     });
   });
 

--- a/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
@@ -29,6 +29,21 @@ suite('Lint switching spec', () => {
   let showErrorMessageSpy: sinon.SinonSpy;
 
   before(async () => {
+    textDocument = await newUntitledFileWithContent(`MATCH (n) RETURN m`);
+    await saveDefaultConnection();
+    await testSyntaxValidation({
+      docUri: textDocument.uri,
+      expected: [
+        new vscode.Diagnostic(
+          new vscode.Range(
+            new vscode.Position(0, 17),
+            new vscode.Position(0, 18),
+          ),
+          'Variable `m` not defined',
+          vscode.DiagnosticSeverity.Error,
+        ),
+      ],
+    });
     textDocument = await newUntitledFileWithContent(`
       UNWIND range(1, 100) AS i
       CALL (i) {
@@ -50,7 +65,6 @@ suite('Lint switching spec', () => {
       'switchWorkerOnLanguageServer',
     );
     sendNotificationSpy = sandbox.spy(mockLanguageClient, 'sendNotification');
-    await saveDefaultConnection();
     sandbox.resetHistory();
   });
 

--- a/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/lintSwitching.spec.ts
@@ -81,7 +81,12 @@ suite('Lint switching spec', () => {
     }
   }
 
-  test('Switching the linter to an old one should show different errors', async () => {
+  test('Switching the linter to an old one should show different errors', async function () {
+    // Going through the real SWITCH_LINTER_COMMAND downloads the linter from
+    // npm and spawns a fresh lint worker pool that re-lints the document. On
+    // cold CI machines that whole chain can take well over 10s, so we give the
+    // diagnostics polling (and mocha) plenty of headroom to avoid flaky timeouts.
+    this.timeout(60000);
     const linterVersion = '5.26';
     const stub = sandbox.stub(
       window,
@@ -106,6 +111,7 @@ suite('Lint switching spec', () => {
           vscode.DiagnosticSeverity.Error,
         ),
       ],
+      timeoutMs: 40000,
     });
   });
 
@@ -178,7 +184,10 @@ suite('Lint switching spec', () => {
     checkLinterUpdatedInLanguageServer('Default');
   });
 
-  test('Switching the linter back to a new one should show different errors', async () => {
+  test('Switching the linter back to a new one should show different errors', async function () {
+    // See the comment on the "old one" test above: the real switch + relint can
+    // be slow on cold machines, so we extend the diagnostics/mocha timeouts.
+    this.timeout(60000);
     const linterVersion = '2025.06';
     const stub = sandbox.stub(
       window,
@@ -194,6 +203,7 @@ suite('Lint switching spec', () => {
     await testSyntaxValidation({
       docUri: textDocument.uri,
       expected: [],
+      timeoutMs: 40000,
     });
   });
 

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -20,11 +20,13 @@ import {
 type InclusionTestArgs = {
   docUri: vscode.Uri;
   expected: vscode.Diagnostic[];
+  timeoutMs?: number;
 };
 
 export async function testSyntaxValidation({
   docUri,
   expected,
+  timeoutMs,
 }: InclusionTestArgs) {
   await eventually(
     () =>
@@ -66,6 +68,7 @@ export async function testSyntaxValidation({
           reject(e);
         }
       }),
+    timeoutMs,
   );
 }
 

--- a/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/syntaxValidation.spec.ts
@@ -77,7 +77,8 @@ suite('Syntax validation spec', () => {
     await toggleLinting(true);
   });
 
-  test('Suggests replacements for deprecated functions/procedures', async () => {
+  test('Suggests replacements for deprecated functions/procedures', async function () {
+    this.timeout(60000);
     const textFile = 'deprecated-by.cypher';
     const docUri = getDocumentUri(textFile);
 
@@ -103,10 +104,12 @@ suite('Syntax validation spec', () => {
           vscode.DiagnosticSeverity.Warning,
         ),
       ],
+      timeoutMs: 40000,
     });
   });
 
-  test('Relints when database connected / disconnected', async () => {
+  test('Relints when database connected / disconnected', async function () {
+    this.timeout(60000);
     const textFile = 'deprecated-by.cypher';
     const docUri = getDocumentUri(textFile);
 
@@ -128,16 +131,19 @@ suite('Syntax validation spec', () => {
     await testSyntaxValidation({
       docUri,
       expected: deprecationErrors,
+      timeoutMs: 40000,
     });
     await disconnectDefault();
     await testSyntaxValidation({
       docUri,
       expected: [],
+      timeoutMs: 40000,
     });
     await connectDefault();
     await testSyntaxValidation({
       docUri,
       expected: deprecationErrors,
+      timeoutMs: 40000,
     });
   });
 
@@ -345,7 +351,8 @@ suite('Syntax validation spec', () => {
     });
   });
 
-  test('Linting can be disabled with the config option', async () => {
+  test('Linting can be disabled with the config option', async function () {
+    this.timeout(60000);
     const textFile = 'deprecated-by.cypher';
     const docUri = getDocumentUri(textFile);
 
@@ -371,12 +378,14 @@ suite('Syntax validation spec', () => {
           vscode.DiagnosticSeverity.Warning,
         ),
       ],
+      timeoutMs: 40000,
     });
 
     await toggleLinting(false);
     await testSyntaxValidation({
       docUri,
       expected: [],
+      timeoutMs: 40000,
     });
   });
 });

--- a/packages/vscode-extension/tests/specs/api/versionSpecificLinting.spec.ts
+++ b/packages/vscode-extension/tests/specs/api/versionSpecificLinting.spec.ts
@@ -32,7 +32,7 @@ suite('Neo4j version specific linting spec', () => {
     await connectDefault({ version: 'neo4j 2025' });
   });
 
-  async function testNeo4jSpecificLinting() {
+  async function testNeo4jSpecificLinting(timeoutMs?: number) {
     const textFile = 'cypher-versioned.cypher';
     const docUri = getDocumentUri(textFile);
     await openDocument(docUri);
@@ -49,6 +49,7 @@ suite('Neo4j version specific linting spec', () => {
           vscode.DiagnosticSeverity.Error,
         ),
       ],
+      timeoutMs,
     });
 
     await connectDefault({ version: 'neo4j 5' });
@@ -64,15 +65,17 @@ suite('Neo4j version specific linting spec', () => {
           vscode.DiagnosticSeverity.Error,
         ),
       ],
+      timeoutMs,
     });
 
     await connectDefault({ version: 'neo4j 2025' });
   }
 
-  test('Linting depends on the specific neo4j version and works when having to download new linters', async () => {
+  test('Linting depends on the specific neo4j version and works when having to download new linters', async function () {
+    this.timeout(60000);
     const lintersFolder = getExtensionStoragePath();
     rmSync(lintersFolder, { force: true, recursive: true });
-    await testNeo4jSpecificLinting();
+    await testNeo4jSpecificLinting(40000);
   });
 
   test('Linting depends on the specific neo4j version and works when linters are already present', async () => {


### PR DESCRIPTION
When disconnected one can not add new params, since we rely on evaluating their value against the current db. (see browser example)
<img width="502" height="171" alt="image" src="https://github.com/user-attachments/assets/8a186042-8438-48e6-a94a-ff397bfe1a9a" />
It's therefor not very helpful to give this linting to the user - rather we can wait until they connect, and then provide the linting + let them add the param.

In order for the change to be retroactive for old linter files ive added the removal of this error as a filtering on the results from the lint worker in the language-server/in react-codemirror. The check for whether to do this is if we have a schema with dbs or not (no dbs = disconnected from dbms).

Here it is in action:
Connected -> error
<img width="1242" height="285" alt="image" src="https://github.com/user-attachments/assets/18cac2c0-b935-463d-8ee8-a58f769752ec" />
Disconnected -> no error
<img width="1245" height="153" alt="image" src="https://github.com/user-attachments/assets/4ffe6e46-c58a-4456-8478-75f53a695f4d" />

We also had a really flaky test suite that made the CI painful. Added a fix for that too (that suite now passed 7 times in a row after primary fix 🥳, where before it would fail more often than not)

Closes LS-151