### PR TITLE
Fix CI: pin Node to 24.15.0

### DIFF
--- a/.github/actions/setup-and-build/action.yaml
+++ b/.github/actions/setup-and-build/action.yaml
@@ -17,7 +17,10 @@ runs:
     - name: Setup node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 24
+        # Pinned below 24.16.0: that release hangs `playwright install` (browser
+        # archive extraction stalls) and breaks the wdio-vscode webview tests.
+        # See https://github.com/microsoft/playwright/issues/40724
+        node-version: 24.15.0
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Pins CI Node to **24.15.0**.

`setup-and-build` floats `node-version: 24`. GitHub runners moved that to **24.16.0** (~May 27), which breaks every browser-based CI job:

- **Chromium / Firefox E2E** — `playwright install` hangs extracting the browser archive on Node 24.16+ ([playwright#40724](https://github.com/microsoft/playwright/issues/40724)) → 30‑min timeout.
- **VSCode Webview** — `wdio-vscode-service` connection timeout.

Both regressed exactly at the 24.15.0 → 24.16.0 boundary. The last green `main` run ([#684](https://github.com/neo4j/cypher-language-support/actions/runs/26399510787), May 25) ran on **24.15.0** with the current deps — so pinning back is enough; no dependency bumps needed.
