### PR TITLE
Surface gql error message

### DIFF
--- a/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
+++ b/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
@@ -123,7 +123,21 @@ export class Neo4jQueryDetailsProvider implements WebviewViewProvider {
       },
     };
 
-    if (result instanceof Error) {
+    function findDeepestCauseMessage(error: Neo4jError): string {
+      let current: Error | Neo4jError = error;
+      while (current instanceof Neo4jError && current.cause) {
+        current = current.cause;
+      }
+      return current.message;
+    }
+
+    if (result instanceof Neo4jError) {
+      message.result = {
+        ...message.result,
+        type: 'error',
+        errorMessage: findDeepestCauseMessage(result),
+      };
+    } else if (result instanceof Error) {
       message.result = {
         ...message.result,
         type: 'error',

--- a/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
+++ b/packages/vscode-extension/src/webviews/queryResults/queryDetailsProvider.ts
@@ -123,7 +123,7 @@ export class Neo4jQueryDetailsProvider implements WebviewViewProvider {
       },
     };
 
-    function findDeepestCauseMessage(error: Neo4jError): string {
+    function findDeepestCauseMessage(error: Error): string {
       let current: Error | Neo4jError = error;
       while (current instanceof Neo4jError && current.cause) {
         current = current.cause;
@@ -131,17 +131,11 @@ export class Neo4jQueryDetailsProvider implements WebviewViewProvider {
       return current.message;
     }
 
-    if (result instanceof Neo4jError) {
+    if (result instanceof Error) {
       message.result = {
         ...message.result,
         type: 'error',
         errorMessage: findDeepestCauseMessage(result),
-      };
-    } else if (result instanceof Error) {
-      message.result = {
-        ...message.result,
-        type: 'error',
-        errorMessage: result.message,
       };
     } else {
       const resultRecords = result.records.map((record) =>


### PR DESCRIPTION
Currently we surface the legacy messages on the errors, while for example Query are surfacing the gql errors. We should do the same. 

TODO:
- [ ] compare to query implementation
- [ ] test against old db that doesnt provide gql errors

