### PR TITLE
Add missed changeset for schema-based linting, export resolveCypherVersion

### DIFF
--- a/.changeset/proud-moons-listen.md
+++ b/.changeset/proud-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/language-support": patch
+---
+
+Schema-based linting when connected: warn on labels and relationship types missing from the database and on relationship patterns that contradict the graph schema's direction (#681), with improved warning readability (#685)

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -5,7 +5,7 @@ export { backtickIfNeeded } from './autocompletion/autocompletionHelpers.js';
 export type { DbSchema } from './dbSchema.js';
 export { _internalFeatureFlags } from './featureFlags.js';
 export { formatQuery } from './formatting/formatting.js';
-export { antlrUtils } from './helpers.js';
+export { antlrUtils, resolveCypherVersion } from './helpers.js';
 export { CypherTokenType, lexerSymbols } from './lexerSymbols.js';
 export {
   parse,


### PR DESCRIPTION
I'm experimenting with wiring our linting into the experimental new `neo4j-cli`  (https://neo4j.sh/). Found we were missing a changeset.
 
Claudes PR description below 🤖

## What
- Adds the changeset that #681 (schema-based linting) and #685 (improve readability of schema-based warnings) merged without. `2.0.0-next.33` (published right after #688) contains #681's code but no changelog entry for it, and #685 is not released at all — this changeset triggers the next `@neo4j-cypher/language-support` pre-release and documents both.
- Exports `resolveCypherVersion` from the package root. External `lintCypherQuery` consumers (e.g. neo4j-cli's offline `query :lint`) currently replicate the `prologue ?? dbSchema.defaultLanguage ?? 'CYPHER 5'` precedence on their side; exporting the helper lets them stay in sync if the resolution ever changes. Happy to drop this part if you'd rather keep the surface minimal.
