### PR TITLE
Symmetric schema based linting

### DIFF
--- a/.changeset/true-moose-arrive.md
+++ b/.changeset/true-moose-arrive.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/language-support": patch
+---
+
+Add schema based linting

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -15,7 +15,7 @@ import {
 } from '../generated-parser/CypherCmdParser.js';
 import { backtickIfNeeded } from './autocompletionHelpers.js';
 import {
-  convertToCNF,
+  convertToSimplifiedCNF,
   isAnyNode,
   isNotAnyNode,
   removeInnerAnys,
@@ -55,7 +55,7 @@ export function getShortPathCompletions(
     ) {
       return [];
     }
-    cnfTree = convertToCNF(treeWithRewrittenAnys);
+    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
   } catch {
     return [];
   }
@@ -117,7 +117,7 @@ export function getPathCompletions(
     ) {
       return [];
     }
-    cnfTree = convertToCNF(treeWithRewrittenAnys);
+    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
   } catch {
     return [];
   }
@@ -278,7 +278,7 @@ export function completeNodeLabel(
         } else if (isNotAnyNode(treeWithRewrittenAnys)) {
           return [];
         }
-        cnfTree = convertToCNF(treeWithRewrittenAnys);
+        cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
       } catch {
         return allLabelCompletions(dbSchema);
       }
@@ -371,7 +371,7 @@ export function completeRelationshipType(
         } else if (isNotAnyNode(treeWithRewrittenAnys)) {
           return [];
         }
-        cnfTree = convertToCNF(treeWithRewrittenAnys);
+        cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
       } catch {
         return [];
       }

--- a/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
+++ b/packages/language-support/src/autocompletion/schemaBasedCompletions.ts
@@ -5,7 +5,7 @@ import {
 } from 'vscode-languageserver-types';
 import { DbSchema } from '../dbSchema.js';
 import { ParsedStatement } from '../cypherLanguageService.js';
-import { isLabelLeaf, LabelOrCondition, SymbolsInfo } from '../types.js';
+import { isLabelLeaf, SymbolsInfo } from '../types.js';
 import { findParent } from '../helpers.js';
 import {
   NodePatternContext,
@@ -14,12 +14,7 @@ import {
   RelationshipPatternContext,
 } from '../generated-parser/CypherCmdParser.js';
 import { backtickIfNeeded } from './autocompletionHelpers.js';
-import {
-  convertToSimplifiedCNF,
-  isAnyNode,
-  isNotAnyNode,
-  removeInnerAnys,
-} from '../labelTreeRewriting.js';
+import { normalizeLabelTreeForSchemaCheck } from '../labelTreeRewriting.js';
 import {
   getNodesFromRelsSet,
   getRelsFromNodesSets,
@@ -46,23 +41,18 @@ export function getShortPathCompletions(
     getNodesFromRelsSet(dbSchema);
   const assumedDirection = lastNode.leftArrow() ? 'outgoing' : 'incoming';
 
-  let cnfTree: LabelOrCondition;
-  try {
-    const treeWithRewrittenAnys = removeInnerAnys(lastVariable.labels);
-    if (
-      isAnyNode(treeWithRewrittenAnys) ||
-      isNotAnyNode(treeWithRewrittenAnys)
-    ) {
-      return [];
-    }
-    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
-  } catch {
+  // ANY (%) / NOT-ANY (!%) and unconvertible trees give no usable completions.
+  const normalized = normalizeLabelTreeForSchemaCheck(
+    lastVariable.labels,
+    'cnf',
+  );
+  if (normalized.kind !== 'converted') {
     return [];
   }
   const { inLabels, outLabels } = walkCNFTree(
     nodesToRelsSet,
     nodesFromRelsSet,
-    cnfTree,
+    normalized.tree,
   );
 
   if (assumedDirection === 'outgoing') {
@@ -108,23 +98,18 @@ export function getPathCompletions(
   }
   const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
     getRelsFromNodesSets(dbSchema);
-  let cnfTree: LabelOrCondition;
-  try {
-    const treeWithRewrittenAnys = removeInnerAnys(lastVariable.labels);
-    if (
-      isAnyNode(treeWithRewrittenAnys) ||
-      isNotAnyNode(treeWithRewrittenAnys)
-    ) {
-      return [];
-    }
-    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
-  } catch {
+  // ANY (%) / NOT-ANY (!%) and unconvertible trees give no usable completions.
+  const normalized = normalizeLabelTreeForSchemaCheck(
+    lastVariable.labels,
+    'cnf',
+  );
+  if (normalized.kind !== 'converted') {
     return [];
   }
   const { inLabels: inRelTypes, outLabels: outRelTypes } = walkCNFTree(
     relsToNodesSet,
     relsFromNodesSet,
-    cnfTree,
+    normalized.tree,
   );
   const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
     getNodesFromRelsSet(dbSchema);
@@ -270,22 +255,22 @@ export function completeNodeLabel(
       // limitation: not checking node label repetition
       const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
         getNodesFromRelsSet(dbSchema);
-      let cnfTree: LabelOrCondition;
-      try {
-        const treeWithRewrittenAnys = removeInnerAnys(foundVariable.labels);
-        if (isAnyNode(treeWithRewrittenAnys)) {
-          return allLabelCompletions(dbSchema);
-        } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-          return [];
-        }
-        cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
-      } catch {
+      const normalized = normalizeLabelTreeForSchemaCheck(
+        foundVariable.labels,
+        'cnf',
+      );
+      // !% matches only label-less nodes, so the schema yields no labels; for %
+      // or an unconvertible tree we can't narrow, so suggest all labels.
+      if (normalized.kind === 'notAny') {
+        return [];
+      }
+      if (normalized.kind !== 'converted') {
         return allLabelCompletions(dbSchema);
       }
       const { inLabels, outLabels } = walkCNFTree(
         nodesToRelsSet,
         nodesFromRelsSet,
-        cnfTree,
+        normalized.tree,
       );
       const allNodes =
         direction === 'outgoing'
@@ -363,22 +348,21 @@ export function completeRelationshipType(
       const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
         getRelsFromNodesSets(dbSchema);
 
-      let cnfTree: LabelOrCondition;
-      try {
-        const treeWithRewrittenAnys = removeInnerAnys(foundVariable.labels);
-        if (isAnyNode(treeWithRewrittenAnys)) {
-          return allReltypeCompletions(dbSchema);
-        } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-          return [];
-        }
-        cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
-      } catch {
+      const normalized = normalizeLabelTreeForSchemaCheck(
+        foundVariable.labels,
+        'cnf',
+      );
+      // % -> suggest all rel types; !% or an unconvertible tree -> nothing.
+      if (normalized.kind === 'any') {
+        return allReltypeCompletions(dbSchema);
+      }
+      if (normalized.kind !== 'converted') {
         return [];
       }
       const { inLabels, outLabels } = walkCNFTree(
         relsToNodesSet,
         relsFromNodesSet,
-        cnfTree,
+        normalized.tree,
       );
       const allRels =
         direction === 'outgoing'

--- a/packages/language-support/src/labelTreeRewriting.ts
+++ b/packages/language-support/src/labelTreeRewriting.ts
@@ -17,9 +17,55 @@ function copyLabelTree(labelTree: LabelOrCondition): LabelOrCondition {
 }
 
 /**
- * Takes a label tree with an AND-root and converts it to Conjunctive Normal Form
+ * Takes a label tree with an AND-root and converts it to Distjunctive Normal Form
+ * also simplifies away redundant conditions
  * @param root - the original label tree
- * @returns a an equivalent CNF tree
+ * @returns a an equivalent DNF tree
+ */
+export function convertToSimplifiedDNF(
+  root: LabelOrCondition,
+): LabelOrCondition {
+  const dnfRoot: LabelOrCondition = convertToDNF(root);
+  return simplifyAndRemoveDNFContradictions(dnfRoot);
+}
+
+/**
+ * Takes a label tree with an AND-root and converts it to Distjunctive Normal Form
+ * Uses a trick with De Morgan's law (ex. !AND(X,Y) = OR(!X, !Y)) to turn CNF to DNF
+ * Like this: !CNF(!Φ) = DNF(Φ). CNF(!Φ) is equiv to !Φ and !CNF(!Φ) is thus equiv to !!Φ = Φ
+ * @param root - the original label tree
+ * @returns a an equivalent DNF tree
+ */
+export function convertToDNF(root: LabelOrCondition): LabelOrCondition {
+  //Because we need an AND-root in my CNF functions, I add AND(NOT(Φ)) - AND with a single child can be simplified away
+  const negatedRoot: ConditionNode = {
+    condition: 'and',
+    children: [{ condition: 'not', children: [root] }],
+  };
+  const negatedRootCNF = convertToCNF(negatedRoot);
+  //Negated CNF -> DNF via De Morgan's law. Double negation (initial + this) -> equivalent to original tree
+  return pushInNots({ condition: 'not', children: [negatedRootCNF] });
+}
+
+/**
+ * Takes a label tree with an AND-root and converts it to Conjunctive Normal Form
+ * also simplifies away redundant conditions
+ * @param root - the original label tree
+ * @returns an equivalent CNF tree, simplified to remove duplication and tautologies
+ */
+export function convertToSimplifiedCNF(
+  root: LabelOrCondition,
+): LabelOrCondition {
+  const cnfRoot: LabelOrCondition = convertToCNF(root);
+  const cleanedCnfTree: LabelOrCondition =
+    simplifyAndRemoveTautologies(cnfRoot);
+  return cleanedCnfTree;
+}
+
+/**
+ * Takes a label tree with an AND-root and converts it to Conjunctive Normal Form, without simplification
+ * @param root - the original label tree
+ * @returns an equivalent CNF tree
  */
 export function convertToCNF(root: LabelOrCondition): LabelOrCondition {
   if (isLabelLeaf(root) || !(root.condition === 'and')) {
@@ -37,9 +83,7 @@ export function convertToCNF(root: LabelOrCondition): LabelOrCondition {
       addChild(newChildren, newChild, 'and');
     });
     const cnfRoot: ConditionNode = { condition: 'and', children: newChildren };
-    const cleanedCnfTree: LabelOrCondition =
-      simplifyAndRemoveTautologies(cnfRoot);
-    return cleanedCnfTree;
+    return cnfRoot;
   }
 }
 
@@ -253,7 +297,7 @@ function pushInOr(orCondition: LabelOrCondition): LabelOrCondition {
 }
 
 /**
- * Takes a CNF-tree and simplifies away redudant conditions and tautologies
+ * Takes a CNF tree and simplifies away redudant conditions and tautologies
  *
  * Tautologies are the conditions that are true for any label, like OR(!A, !B) or OR(!A, A)
  *
@@ -269,68 +313,221 @@ function pushInOr(orCondition: LabelOrCondition): LabelOrCondition {
 export function simplifyAndRemoveTautologies(
   root: LabelOrCondition,
 ): LabelOrCondition {
+  if (isLabelLeaf(root) || !(root.condition === 'and')) {
+    throw new Error('Misshapen label tree: Root is not an AND-node');
+  }
   const newRoot: LabelOrCondition = copyLabelTree(root);
-  if (isLabelLeaf(newRoot) || newRoot.condition !== 'and') {
+  if (isLabelLeaf(newRoot)) {
     return newRoot;
   } else {
-    for (let i = 0; i < newRoot.children.length; i++) {
-      if (!newRoot.children[i]) {
+    const simplifiedChildren: (LabelOrCondition | undefined)[] = [
+      ...newRoot.children,
+    ];
+    for (let i = 0; i < simplifiedChildren.length; i++) {
+      const currentNode = simplifiedChildren[i];
+      if (!currentNode) {
         continue;
       }
       //Rewriting to CNF we can get nodes like OR(Person,Person)
       //We can also have tautologies like OR(!A, A) or OR(!A, !B) which are always true
       //within the AND, we can also remove ORs fully covered by other ORs or literals
       //Ex. AND(A, OR(A,B), OR(B,C), OR(B,C,D)) = AND(A,OR(B,C))
-      if (isTautology(newRoot.children[i])) {
-        newRoot.children[i] = undefined;
+      if (isTautology(currentNode)) {
+        simplifiedChildren[i] = undefined;
         continue;
       }
       //After removing tautologies we can only have 0 or 1 Not-node inside an OR-condition, without any matching not-NOT node with the same label.
       //These can then be simplified to just the not-condition since ex. OR(!A, B, C)=!A (!A covers B and C too)
-      const currentNode = newRoot.children[i];
       if (!isLabelLeaf(currentNode) && currentNode.condition === 'or') {
         for (const c of currentNode.children) {
           if (!isLabelLeaf(c) && c.condition === 'not') {
-            newRoot.children[i] = c;
+            simplifiedChildren[i] = c;
           }
         }
       }
-      for (let j = i + 1; j < newRoot.children.length; j++) {
-        if (!newRoot.children[j]) {
+
+      //We can also remove conditions where one covers the other
+      //Ex. AND(OR(A,B), OR(A,B,C)) -> if OR(A,B) is true, OR(A,B,C) will always be true too, so since we need both (ANDed) we can check just for OR(A,B)
+      for (let j = i + 1; j < simplifiedChildren.length; j++) {
+        const comparedNode = simplifiedChildren[j];
+        if (!comparedNode) {
           continue;
-        } else if (!newRoot.children[i]) {
-          break;
         }
 
         const stricterCondition = findStricterCondition(
-          newRoot.children[i],
-          newRoot.children[j],
+          currentNode,
+          comparedNode,
         );
-        if (stricterCondition === newRoot.children[i]) {
-          newRoot.children[j] = undefined;
+        if (stricterCondition === simplifiedChildren[i]) {
+          simplifiedChildren[j] = undefined;
           continue;
         }
-        if (stricterCondition === newRoot.children[j]) {
-          newRoot.children[i] = undefined;
+        if (stricterCondition === simplifiedChildren[j]) {
+          simplifiedChildren[i] = undefined;
           break;
         }
 
-        const isDuplicate = checkEquality(
-          newRoot.children[i],
-          newRoot.children[j],
-        );
-        if (isDuplicate) {
-          newRoot.children[i] = undefined;
+        if (
+          simplifiedChildren[i] !== undefined &&
+          simplifiedChildren[j] !== undefined
+        ) {
+          const isDuplicate = checkEquality(currentNode, comparedNode);
+          if (isDuplicate) {
+            simplifiedChildren[i] = undefined;
+            break;
+          }
         }
       }
     }
-    newRoot.children = newRoot.children.filter((x) => x !== undefined);
+
+    //At this stage we have simplified to 3 types of children - A: free label, B: free NOT label, C: OR of labels (not NOTed)
+    //Finally we can also remove NOTs covered by the other conditions
+    //Since we would have removed other conditions covered by NOTs previously, we can remove all free NOTs if we have some non-not child
+    // Ex. AND(A, OR(B,C), !D, !E) = AND(A, OR(B,C))
+    //AND(!A, !B) = AND(!A, !B)
+    const hasNonNegatedLabel = simplifiedChildren.some(
+      (c) => c && (isLabelLeaf(c) || c.condition !== 'not'),
+    );
+    if (hasNonNegatedLabel) {
+      for (let i = 0; i < simplifiedChildren.length; i++) {
+        const c = simplifiedChildren[i];
+        if (c && !isLabelLeaf(c) && c.condition === 'not') {
+          simplifiedChildren[i] = undefined;
+        }
+      }
+    }
+    newRoot.children = simplifiedChildren.filter((x) => x !== undefined);
+
+    return newRoot;
+  }
+}
+//DNF is OR(AND(x,!y), AND(!z,!w), AND(v, u), s, r, !t)
+//if we have OR(AND(x,...), x, ...) we can remove the AND. For the outer OR, we can remove any inner ANDs that are more strict than
+
+//OR -> true IF ANY CONDITION is true -> can simplify away more strict conditions that are true if any of the less strict are true
+//We can obviously also remove duplicate identical conditions
+//Simplifying away NOT conditions:
+// OR(AND(!A, A), ...) <- OR(never, ...) => OR(...)
+// OR(!A, A) <- ANY => ANY
+/**
+ * Takes a DNF tree and simplifies away redudant conditions and tautologies
+ *
+ * Tautologies are the conditions that are true for any label, like OR(!A, !B) or OR(!A, A)
+ *
+ * We can also simplify away conditions covered by another like AND(A, OR(A,B) = AND(A)
+ *
+ * Finally we can also simplify OR(!A, B, C, D) to !A, since this case includes the specific cases B,C,D
+ *
+ * Does some simplifications of the tree to remove redudant conditions. Some of these simplifications
+ * ignore positions, rather than taking the first instance of a rule
+ * @param root
+ * @returns
+ */
+export function simplifyAndRemoveDNFContradictions(
+  root: LabelOrCondition,
+): LabelOrCondition {
+  const newRoot: LabelOrCondition = copyLabelTree(root);
+  if (
+    isLabelLeaf(newRoot) ||
+    newRoot.condition === 'any' ||
+    newRoot.condition === 'not'
+  ) {
+    return newRoot;
+  } else {
+    const simplifiedChildren: (LabelOrCondition | undefined)[] = [
+      ...newRoot.children,
+    ];
+    for (let i = 0; i < simplifiedChildren.length; i++) {
+      let currentNode = simplifiedChildren[i];
+      if (!currentNode) {
+        continue;
+      }
+      //The child-conditions of the DNF tree can be contradictions like AND(!A, A) which is never true
+      //Since it's within an OR we can simplify by removing this condition, we can also remove ANDs that are a subcondition of an existing condition in the OR
+      //Ex. OR(A, AND(A,B), AND(B,C), AND(B,C,D)) = OR(A, AND(B,C))
+      if (isContradiction(currentNode)) {
+        simplifiedChildren[i] = undefined;
+        continue;
+      } else if (!isLabelLeaf(currentNode) && currentNode.condition === 'and') {
+        //for ANDs like AND(A, !B) where we dont have a contradiction, we can remove the !B which becomes true automatically if we must have other labels than B, keeping only non-negated labels
+        //Could not remove it if we have both !B and B, but this would be caught above
+        const newChildren = currentNode.children.filter((c) => isLabelLeaf(c));
+        currentNode =
+          newChildren.length === 1
+            ? newChildren[0]
+            : {
+                condition: 'and',
+                children: currentNode.children.filter((c) => isLabelLeaf(c)),
+              };
+        simplifiedChildren[i] = currentNode;
+      }
+      //After removing contradictions we can only have !A or A, not both for any label A inside an AND-condition.
+      for (let j = i + 1; j < simplifiedChildren.length; j++) {
+        const comparedNode = simplifiedChildren[j];
+        if (!comparedNode) {
+          continue;
+        }
+
+        const stricterCondition = findStricterCondition(
+          currentNode,
+          comparedNode,
+        );
+        //Remove the stricter condition here, since we are inside an OR
+        if (stricterCondition === simplifiedChildren[i]) {
+          simplifiedChildren[i] = undefined;
+          break;
+        }
+        if (stricterCondition === simplifiedChildren[j]) {
+          simplifiedChildren[j] = undefined;
+          continue;
+        }
+
+        const isDuplicate = checkEquality(currentNode, comparedNode);
+        if (isDuplicate) {
+          simplifiedChildren[i] = undefined;
+          break;
+        }
+      }
+    }
+
+    //At this stage we must have no negations inside ANDs, for example
+    //OR(A, !B, AND(C,B))
+    //But if we have an outer !B, this would also pass for all cases that A and AND(C,B) cover, so we can remove those
+    //OR(A, !B, AND(C,B)) = OR(!B)
+
+    //TODO add this simplification too
+
+    // const freeNots = simplifiedChildren.filter(c => c && !isLabelLeaf(c) && c.condition === "not");
+    // //If we have OR(!A, A, ...) - simplify to OR(ANY)
+    // if (freeNots.some(c => {
+    //   if (c && !isLabelLeaf(c) && c.condition === "not") {
+    //     const innerLabel = c.children[0];
+    //     if (isLabelLeaf(innerLabel)) {
+    //       return simplifiedChildren.some(c2 => c2 && isLabelLeaf(c2) && c2.value === innerLabel.value)
+    //     }
+    //   }
+    // }))
+
+    // if (freeNots) {
+    //   simplifiedChildren.map(c => {
+    //     if (c && !isLabelLeaf(c) && c.condition === "and") {
+    //       return undefined;
+    //     } else if (c && isLabelLeaf(c)) {
+    //       return undefined;
+    //     } else {
+    //       return c;
+    //     }
+    //   });
+    // }
+
+    newRoot.children = simplifiedChildren.filter((x) => x !== undefined);
     return newRoot;
   }
 }
 
 /**
- * Takes in two labels/conditions from a CNF-tree and returns the stricter of the two if one covers the other. Otherwise returns undefined to signal that neither rule is redundant
+ * Takes in two labels/conditions and returns the stricter of the two if one covers the other. Otherwise returns undefined to signal that neither rule is redundant
+ * For OR-conditions a smaller condition is stricter (Ex. OR(A,B) over OR(A,B,C)) and the opposite is true for ANDs, (ex. AND(A,B,C) over AND(A,B))
  * @param A
  * @param B
  * @returns A if A is a stricter version of B, in the sense that if A is true, B will always be true as well. Vice versa if B is stricter than A. If neither covers the other, returns undefined
@@ -343,15 +540,15 @@ function findStricterCondition(
   const bIsLabel = isLabelLeaf(B);
   if (aIsLabel && bIsLabel) {
     return undefined;
-  } else if (aIsLabel && !bIsLabel) {
+  } else if (aIsLabel && !bIsLabel && !(B.condition === 'not')) {
     if (B.children.find((x) => isLabelLeaf(x) && x.value === A.value)) {
-      return A;
+      return B.condition === 'or' ? A : B;
     } else {
       return undefined;
     }
-  } else if (bIsLabel && !aIsLabel) {
+  } else if (bIsLabel && !aIsLabel && !(A.condition === 'not')) {
     if (A.children.find((x) => isLabelLeaf(x) && x.value === B.value)) {
-      return B;
+      return A.condition === 'or' ? B : A;
     } else {
       return undefined;
     }
@@ -371,7 +568,7 @@ function findStricterCondition(
             x.children[0].value === A.children[0].value,
         )
       ) {
-        return A;
+        return B.condition === 'or' ? A : B;
       } else {
         return undefined;
       }
@@ -386,7 +583,7 @@ function findStricterCondition(
             x.children[0].value === B.children[0].value,
         )
       ) {
-        return B;
+        return A.condition === 'or' ? B : A;
       } else {
         return undefined;
       }
@@ -409,7 +606,7 @@ function findStricterCondition(
         return undefined;
       }
     }
-    return A;
+    return B.condition === 'or' ? A : B;
   } else {
     for (const cB of B.children) {
       if (
@@ -423,7 +620,49 @@ function findStricterCondition(
         return undefined;
       }
     }
-    return B;
+    return A.condition === 'or' ? B : A;
+  }
+}
+
+//Contradictions we could have...
+//AND(A,B)... no
+//AND(!A,A).. yes
+//AND(!A,B)...no
+//AND(!A,!B)...no
+
+/**
+ * Takes a child-node from a DNF-tree (an AND-node, a NOT-node or a literal) and returns whether it is a contradiction or not
+ * @param node
+ * @returns
+ */
+function isContradiction(node: LabelOrCondition) {
+  if (!node || isLabelLeaf(node) || node.condition === 'not') {
+    return false;
+  }
+  //getting here node must be an AND-condition
+  for (let i = 0; i < node.children.length; i++) {
+    for (let j = i + 1; j < node.children.length; j++) {
+      const nodeI = node.children[i];
+      const nodeJ = node.children[j];
+      //If we have AND(A, !A)
+      if (
+        isLabelLeaf(nodeI) &&
+        !isLabelLeaf(nodeJ) &&
+        nodeJ.condition === 'not' &&
+        isLabelLeaf(nodeJ.children[0]) &&
+        nodeJ.children[0].value === nodeI.value
+      ) {
+        return true;
+      } else if (
+        isLabelLeaf(nodeJ) &&
+        !isLabelLeaf(nodeI) &&
+        nodeI.condition === 'not' &&
+        isLabelLeaf(nodeI.children[0]) &&
+        nodeI.children[0].value === nodeJ.value
+      ) {
+        return true;
+      }
+    }
   }
 }
 
@@ -485,25 +724,23 @@ export function removeDuplicates(
   for (let i = 0; i < newLabelTree.children.length; i++) {
     newLabelTree.children[i] = removeDuplicates(newLabelTree.children[i]);
   }
+  const deduplicatedChildren = [];
   for (let i = 0; i < newLabelTree.children.length; i++) {
+    let foundDuplicate = false;
     for (let j = i + 1; j < newLabelTree.children.length; j++) {
-      if (
-        newLabelTree.children[i] === undefined ||
-        newLabelTree.children[j] === undefined
-      ) {
-        continue;
-      }
-      const foundDuplicate: boolean = checkEquality(
+      foundDuplicate = checkEquality(
         newLabelTree.children[i],
         newLabelTree.children[j],
       );
       if (foundDuplicate) {
-        newLabelTree.children[i] = undefined;
         break;
       }
     }
+    if (!foundDuplicate) {
+      deduplicatedChildren.push(newLabelTree.children[i]);
+    }
   }
-  newLabelTree.children = newLabelTree.children.filter((x) => x !== undefined);
+  newLabelTree.children = deduplicatedChildren;
   return newLabelTree;
 }
 
@@ -529,6 +766,10 @@ function checkEquality(
     isLabelLeaf(labelTree2) ||
     labelTree1.condition !== labelTree2.condition
   ) {
+    return false;
+  }
+
+  if (labelTree1.children.length !== labelTree2.children.length) {
     return false;
   }
 

--- a/packages/language-support/src/labelTreeRewriting.ts
+++ b/packages/language-support/src/labelTreeRewriting.ts
@@ -22,9 +22,9 @@ function copyLabelTree(labelTree: LabelOrCondition): LabelOrCondition {
  * @param root - the original label tree
  * @returns a an equivalent DNF tree
  */
-export function convertToSimplifiedDNF(
-  root: LabelOrCondition,
-): LabelOrCondition {
+// Not exported: callers must go through normalizeLabelTreeForSchemaCheck so the
+// ANY / !% / throw cases are always handled.
+function convertToSimplifiedDNF(root: LabelOrCondition): LabelOrCondition {
   const dnfRoot: LabelOrCondition = convertToDNF(root);
   return simplifyAndRemoveDNFContradictions(dnfRoot);
 }
@@ -53,9 +53,9 @@ export function convertToDNF(root: LabelOrCondition): LabelOrCondition {
  * @param root - the original label tree
  * @returns an equivalent CNF tree, simplified to remove duplication and tautologies
  */
-export function convertToSimplifiedCNF(
-  root: LabelOrCondition,
-): LabelOrCondition {
+// Not exported: callers must go through normalizeLabelTreeForSchemaCheck so the
+// ANY / !% / throw cases are always handled.
+function convertToSimplifiedCNF(root: LabelOrCondition): LabelOrCondition {
   const cnfRoot: LabelOrCondition = convertToCNF(root);
   const cleanedCnfTree: LabelOrCondition =
     simplifyAndRemoveTautologies(cnfRoot);
@@ -897,4 +897,47 @@ export function removeInnerAnys(labelTree: LabelOrCondition): LabelOrCondition {
     }
   }
   return newLabelTree;
+}
+
+export type NormalizedLabelTree =
+  | { kind: 'any' } // % : matches any labelled element
+  | { kind: 'notAny' } // !% : matches only label-less nodes
+  | { kind: 'converted'; tree: LabelOrCondition }
+  | { kind: 'unconvertible' }; // conversion threw on a malformed tree
+
+/**
+ * Shared entry point for reasoning about a label expression against a graph
+ * schema. Strips ANY (%) / NOT-ANY (!%) nodes and converts the remainder to the
+ * requested normal form, catching conversion failures.
+ *
+ * Every consumer (schema-based linting and schema-based completions) MUST funnel
+ * label trees through this before walking them, so the ANY / !% / throw cases
+ * can't be forgotten — past crashes and false positives came from a call site
+ * that open-coded (and skipped part of) this dance.
+ *
+ * `any` (%) and `notAny` (!%) can't be validated against the label-keyed schema
+ * (a label-less node may have connections the schema does not enumerate), and
+ * `unconvertible` means the tree was malformed. Callers decide what each of
+ * those means for them and only walk the tree on `converted`.
+ */
+export function normalizeLabelTreeForSchemaCheck(
+  labels: LabelOrCondition,
+  form: 'dnf' | 'cnf',
+): NormalizedLabelTree {
+  try {
+    const treeWithRewrittenAnys = removeInnerAnys(labels);
+    if (isAnyNode(treeWithRewrittenAnys)) {
+      return { kind: 'any' };
+    }
+    if (isNotAnyNode(treeWithRewrittenAnys)) {
+      return { kind: 'notAny' };
+    }
+    const tree =
+      form === 'dnf'
+        ? convertToSimplifiedDNF(treeWithRewrittenAnys)
+        : convertToSimplifiedCNF(treeWithRewrittenAnys);
+    return { kind: 'converted', tree };
+  } catch {
+    return { kind: 'unconvertible' };
+  }
 }

--- a/packages/language-support/src/labelTreeRewriting.ts
+++ b/packages/language-support/src/labelTreeRewriting.ts
@@ -459,7 +459,7 @@ export function simplifyAndRemoveDNFContradictions(
               ? newChildren[0]
               : {
                   condition: 'and',
-                  children: currentNode.children.filter((c) => isLabelLeaf(c)),
+                  children: newChildren,
                 };
           simplifiedChildren[i] = currentNode;
         }
@@ -500,8 +500,10 @@ export function simplifyAndRemoveDNFContradictions(
 
     //TODO add this simplification too
 
-    // const freeNots = simplifiedChildren.filter(c => c && !isLabelLeaf(c) && c.condition === "not");
-    // //If we have OR(!A, A, ...) - simplify to OR(ANY)
+    const freeNots = simplifiedChildren.filter(
+      (c) => c && !isLabelLeaf(c) && c.condition === 'not',
+    );
+    //If we have OR(!A, A, ...) - simplify to OR(ANY)
     // if (freeNots.some(c => {
     //   if (c && !isLabelLeaf(c) && c.condition === "not") {
     //     const innerLabel = c.children[0];
@@ -511,17 +513,17 @@ export function simplifyAndRemoveDNFContradictions(
     //   }
     // }))
 
-    // if (freeNots) {
-    //   simplifiedChildren.map(c => {
-    //     if (c && !isLabelLeaf(c) && c.condition === "and") {
-    //       return undefined;
-    //     } else if (c && isLabelLeaf(c)) {
-    //       return undefined;
-    //     } else {
-    //       return c;
-    //     }
-    //   });
-    // }
+    if (freeNots) {
+      simplifiedChildren.map((c) => {
+        if (c && !isLabelLeaf(c) && c.condition === 'and') {
+          return undefined;
+        } else if (c && isLabelLeaf(c)) {
+          return undefined;
+        } else {
+          return c;
+        }
+      });
+    }
 
     newRoot.children = simplifiedChildren.filter((x) => x !== undefined);
     return newRoot;
@@ -667,6 +669,7 @@ function isContradiction(node: LabelOrCondition) {
       }
     }
   }
+  return false;
 }
 
 /**

--- a/packages/language-support/src/labelTreeRewriting.ts
+++ b/packages/language-support/src/labelTreeRewriting.ts
@@ -451,15 +451,18 @@ export function simplifyAndRemoveDNFContradictions(
       } else if (!isLabelLeaf(currentNode) && currentNode.condition === 'and') {
         //for ANDs like AND(A, !B) where we dont have a contradiction, we can remove the !B which becomes true automatically if we must have other labels than B, keeping only non-negated labels
         //Could not remove it if we have both !B and B, but this would be caught above
+        //Can also not remove them if we dont have non-NOTed labels
         const newChildren = currentNode.children.filter((c) => isLabelLeaf(c));
-        currentNode =
-          newChildren.length === 1
-            ? newChildren[0]
-            : {
-                condition: 'and',
-                children: currentNode.children.filter((c) => isLabelLeaf(c)),
-              };
-        simplifiedChildren[i] = currentNode;
+        if (newChildren.length !== 0) {
+          currentNode =
+            newChildren.length === 1
+              ? newChildren[0]
+              : {
+                  condition: 'and',
+                  children: currentNode.children.filter((c) => isLabelLeaf(c)),
+                };
+          simplifiedChildren[i] = currentNode;
+        }
       }
       //After removing contradictions we can only have !A or A, not both for any label A inside an AND-condition.
       for (let j = i + 1; j < simplifiedChildren.length; j++) {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -404,20 +404,10 @@ function findPathIssues(
           let dnfLabels: LabelOrCondition;
           try {
             const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
-            if (isAnyNode(treeWithRewrittenAnys)) {
-              continue;
-            } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-              const firstVarType = 'node';
-              diagnostics.push({
-                message: labelsToMessage(
-                  symbol.labels,
-                  nextSymbolLabels,
-                  direction,
-                  firstVarType,
-                ),
-                severity: DiagnosticSeverity.Warning,
-                ...translateTokensToRange(child.start, nextChild.stop),
-              });
+            if (
+              isAnyNode(treeWithRewrittenAnys) ||
+              isNotAnyNode(treeWithRewrittenAnys)
+            ) {
               continue;
             }
             dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
@@ -499,20 +489,10 @@ function findPathIssues(
           let dnfLabels: LabelOrCondition;
           try {
             const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
-            if (isAnyNode(treeWithRewrittenAnys)) {
-              continue;
-            } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-              const firstVarType = 'relationship';
-              diagnostics.push({
-                message: labelsToMessage(
-                  symbol.labels,
-                  nextSymbolLabels,
-                  direction,
-                  firstVarType,
-                ),
-                severity: DiagnosticSeverity.Warning,
-                ...translateTokensToRange(child.start, nextChild.stop),
-              });
+            if (
+              isAnyNode(treeWithRewrittenAnys) ||
+              isNotAnyNode(treeWithRewrittenAnys)
+            ) {
               continue;
             }
             dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
@@ -569,10 +549,11 @@ function isViableSegment(
   let dnfTree: LabelOrCondition;
   try {
     const treeWithRewrittenAnys = removeInnerAnys(endLabels);
-    if (isAnyNode(treeWithRewrittenAnys)) {
+    if (
+      isAnyNode(treeWithRewrittenAnys) ||
+      isNotAnyNode(treeWithRewrittenAnys)
+    ) {
       return true;
-    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-      return false;
     }
     dnfTree = convertToSimplifiedDNF(treeWithRewrittenAnys);
     if (!isLabelLeaf(dnfTree) && dnfTree.condition === 'or') {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -585,7 +585,7 @@ function isViableSegment(
           const negated = c.children[0];
           if (
             isLabelLeaf(negated) &&
-            completedLabels.difference(new Set(negated.value)).size > 0
+            completedLabels.difference(new Set([negated.value])).size > 0
           ) {
             return true;
           }

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -308,7 +308,7 @@ function labelTreeToString(node: LabelOrCondition): string {
   if (isLabelLeaf(node)) {
     return node.value;
   } else if (node.condition === 'any') {
-    return 'ANY';
+    return '%';
   } else if (node.condition === 'not') {
     return '!' + labelTreeToString(node.children[0]);
   } else if (node.children.length === 1) {
@@ -401,7 +401,29 @@ function findPathIssues(
                 ? 'incoming'
                 : 'bidirectional';
 
-          const dnfLabels = convertToSimplifiedDNF(symbol.labels);
+          let dnfLabels: LabelOrCondition;
+          try {
+            const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
+            if (isAnyNode(treeWithRewrittenAnys)) {
+              continue;
+            } else if (isNotAnyNode(treeWithRewrittenAnys)) {
+              const firstVarType = 'node';
+              diagnostics.push({
+                message: labelsToMessage(
+                  symbol.labels,
+                  nextSymbolLabels,
+                  direction,
+                  firstVarType,
+                ),
+                severity: DiagnosticSeverity.Warning,
+                ...translateTokensToRange(child.start, nextChild.stop),
+              });
+              continue;
+            }
+            dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
+          } catch {
+            continue;
+          }
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {
@@ -474,7 +496,29 @@ function findPathIssues(
                 ? 'incoming'
                 : 'bidirectional';
 
-          const dnfLabels = convertToSimplifiedDNF(symbol.labels);
+          let dnfLabels: LabelOrCondition;
+          try {
+            const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
+            if (isAnyNode(treeWithRewrittenAnys)) {
+              continue;
+            } else if (isNotAnyNode(treeWithRewrittenAnys)) {
+              const firstVarType = 'relationship';
+              diagnostics.push({
+                message: labelsToMessage(
+                  symbol.labels,
+                  nextSymbolLabels,
+                  direction,
+                  firstVarType,
+                ),
+                severity: DiagnosticSeverity.Warning,
+                ...translateTokensToRange(child.start, nextChild.stop),
+              });
+              continue;
+            }
+            dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
+          } catch {
+            continue;
+          }
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -39,7 +39,10 @@ import {
   StatementContext,
 } from '../generated-parser/CypherCmdParser.js';
 import { ParserRuleContext } from 'antlr4';
-import { normalizeLabelTreeForSchemaCheck } from '../labelTreeRewriting.js';
+import {
+  NormalizedLabelTree,
+  normalizeLabelTreeForSchemaCheck,
+} from '../labelTreeRewriting.js';
 import {
   getNodesFromRelsSet,
   getRelsFromNodesSets,
@@ -288,12 +291,21 @@ function warnOnPathDirectionalityIssues(
   symbolTable: SymbolTable,
 ): SyntaxDiagnostic[] {
   const statements = parsingResult.ctx.statementOrCommand_list();
+  // The schema-derived maps only depend on dbSchema, so build them once here
+  // rather than rebuilding them for every path segment / disjunct.
+  const relsFromNodes = getRelsFromNodesSets(dbSchema);
+  const nodesFromRels = getNodesFromRelsSet(dbSchema);
   return statements.reduce<SyntaxDiagnostic[]>((acc, stmtOrCommand) => {
     const stmt = stmtOrCommand.preparsedStatement()?.statement();
     if (!stmt) {
       return acc;
     }
-    const pathIssues = findPathIssues(stmt, dbSchema, symbolTable);
+    const pathIssues = findPathIssues(
+      stmt,
+      symbolTable,
+      relsFromNodes,
+      nodesFromRels,
+    );
     return acc.concat(pathIssues);
   }, []);
 }
@@ -345,8 +357,9 @@ function labelsToMessage(
 
 function findPathIssues(
   stmt: StatementContext,
-  dbSchema: DbSchema,
   symbolTable: SymbolTable,
+  relsFromNodes: ReturnType<typeof getRelsFromNodesSets>,
+  nodesFromRels: ReturnType<typeof getNodesFromRelsSet>,
 ): SyntaxDiagnostic[] {
   const patternElements: PatternElementContext[] =
     findNonCreatingPatternElements(stmt, []);
@@ -406,17 +419,22 @@ function findPathIssues(
           }
           const dnfLabels = normalizedLabels.tree;
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
+            // The second variable's normal form is loop-invariant — compute once.
+            const endNormalized = normalizeLabelTreeForSchemaCheck(
+              nextSymbolLabels,
+              'dnf',
+            );
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {
               const possibleRels = possibleFollowingRelType(
                 direction,
-                dbSchema,
+                relsFromNodes,
                 { condition: 'and', children: [c] },
               );
               if (possibleRels) {
                 const segmentIsPossible = isViableSegment(
                   possibleRels,
-                  nextSymbolLabels,
+                  endNormalized,
                 );
                 if (segmentIsPossible) {
                   hasViableLabel = true;
@@ -488,17 +506,22 @@ function findPathIssues(
           }
           const dnfLabels = normalizedLabels.tree;
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
+            // The second variable's normal form is loop-invariant — compute once.
+            const endNormalized = normalizeLabelTreeForSchemaCheck(
+              nextSymbolLabels,
+              'dnf',
+            );
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {
               const possibleNodes = possibleFollowingLabels(
                 direction,
-                dbSchema,
+                nodesFromRels,
                 { condition: 'and', children: [c] },
               );
               if (possibleNodes) {
                 const segmentIsPossible = isViableSegment(
                   possibleNodes,
-                  nextSymbolLabels,
+                  endNormalized,
                 );
                 if (segmentIsPossible) {
                   hasViableLabel = true;
@@ -532,15 +555,14 @@ function findPathIssues(
 //Ex. if RHS is OR(A, !B, AND(C,!D)) and completions contain A, the OR could have real matches
 function isViableSegment(
   completedLabels: Set<string>,
-  endLabels: LabelOrCondition,
+  endNormalized: NormalizedLabelTree,
 ) {
   // ANY (%) / NOT-ANY (!%) endpoints can't be disproven by the schema, and an
   // unconvertible tree is treated as viable to avoid a spurious warning.
-  const normalized = normalizeLabelTreeForSchemaCheck(endLabels, 'dnf');
-  if (normalized.kind !== 'converted') {
+  if (endNormalized.kind !== 'converted') {
     return true;
   }
-  const dnfTree = normalized.tree;
+  const dnfTree = endNormalized.tree;
   if (!isLabelLeaf(dnfTree) && dnfTree.condition === 'or') {
     for (const c of dnfTree.children) {
       if (isLabelLeaf(c)) {
@@ -777,28 +799,24 @@ export function lintCypherQuery(
 //Returns possible following rel types, or undefined in cases where we should quit
 function possibleFollowingRelType(
   direction: 'incoming' | 'outgoing' | 'bidirectional',
-  dbSchema: DbSchema,
+  relsFromNodes: ReturnType<typeof getRelsFromNodesSets>,
   labels: LabelOrCondition,
 ): Set<string> | undefined {
-  const { toNodes: relsToNodesSet, fromNodes: relsFromNodesSet } =
-    getRelsFromNodesSets(dbSchema);
   return getFollowingLabels(direction, labels, {
-    incomingLabels: relsToNodesSet,
-    outGoingLabels: relsFromNodesSet,
+    incomingLabels: relsFromNodes.toNodes,
+    outGoingLabels: relsFromNodes.fromNodes,
   });
 }
 
 //Returns possible following labels, or undefined in cases where we should quit
 function possibleFollowingLabels(
   direction: 'incoming' | 'outgoing' | 'bidirectional',
-  dbSchema: DbSchema,
+  nodesFromRels: ReturnType<typeof getNodesFromRelsSet>,
   labels: LabelOrCondition,
 ): Set<string> | undefined {
-  const { toRels: nodesToRelsSet, fromRels: nodesFromRelsSet } =
-    getNodesFromRelsSet(dbSchema);
   return getFollowingLabels(direction, labels, {
-    incomingLabels: nodesToRelsSet,
-    outGoingLabels: nodesFromRelsSet,
+    incomingLabels: nodesFromRels.toRels,
+    outGoingLabels: nodesFromRels.fromRels,
   });
 }
 

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -309,6 +309,8 @@ function labelTreeToString(node: LabelOrCondition): string {
     return node.value;
   } else if (node.condition === 'any') {
     return 'ANY';
+  } else if (node.condition === 'not') {
+    return '!' + labelTreeToString(node.children[0]);
   } else if (node.children.length === 1) {
     return labelTreeToString(node.children[0]);
   } else {
@@ -319,9 +321,6 @@ function labelTreeToString(node: LabelOrCondition): string {
         break;
       case 'or':
         separator = ' | ';
-        break;
-      case 'not':
-        separator = '!';
         break;
     }
     const childStrings: string[] = node.children.map((c) =>
@@ -548,20 +547,27 @@ function isViableSegment(
           }
         } else if (c.condition === 'and') {
           let isViable = true;
-          for (const c2 of c.children) {
-            if (isLabelLeaf(c2)) {
-              if (!completedLabels.has(c2.value)) {
-                isViable = false;
-                break;
-              }
-            } else if (c2.condition === 'not') {
-              const negated = c2.children[0];
-              if (
-                isLabelLeaf(negated) &&
-                completedLabels.difference(new Set(negated.value)).size === 0
-              ) {
-                isViable = false;
-                break;
+          const negatedLabels = c.children
+            .filter((c2) => !isLabelLeaf(c2) && c2.condition === 'not')
+            .map((x) =>
+              !isLabelLeaf(x) && isLabelLeaf(x.children[0])
+                ? x.children[0]
+                : undefined,
+            )
+            .filter((x) => x !== undefined)
+            .map((x) => x.value);
+          const remainingLabels = completedLabels.difference(
+            new Set(negatedLabels),
+          );
+          if (!remainingLabels.size) {
+            continue;
+          } else {
+            for (const c2 of c.children) {
+              if (isLabelLeaf(c2)) {
+                if (!remainingLabels.has(c2.value)) {
+                  isViable = false;
+                  break;
+                }
               }
             }
           }
@@ -571,7 +577,7 @@ function isViableSegment(
         }
       }
     } else {
-      //If we have a bug in DNF creation
+      //If we have a bug - return true here and avoid creating the "invalid segment" warning
       return true;
     }
     return false;

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -39,13 +39,7 @@ import {
   StatementContext,
 } from '../generated-parser/CypherCmdParser.js';
 import { ParserRuleContext } from 'antlr4';
-import {
-  convertToSimplifiedCNF,
-  convertToSimplifiedDNF,
-  isAnyNode,
-  isNotAnyNode,
-  removeInnerAnys,
-} from '../labelTreeRewriting.js';
+import { normalizeLabelTreeForSchemaCheck } from '../labelTreeRewriting.js';
 import {
   getNodesFromRelsSet,
   getRelsFromNodesSets,
@@ -401,19 +395,16 @@ function findPathIssues(
                 ? 'incoming'
                 : 'bidirectional';
 
-          let dnfLabels: LabelOrCondition;
-          try {
-            const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
-            if (
-              isAnyNode(treeWithRewrittenAnys) ||
-              isNotAnyNode(treeWithRewrittenAnys)
-            ) {
-              continue;
-            }
-            dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
-          } catch {
+          // ANY (%) / NOT-ANY (!%) and unconvertible trees can't be validated
+          // against the label-keyed schema, so skip the segment without warning.
+          const normalizedLabels = normalizeLabelTreeForSchemaCheck(
+            symbol.labels,
+            'dnf',
+          );
+          if (normalizedLabels.kind !== 'converted') {
             continue;
           }
+          const dnfLabels = normalizedLabels.tree;
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {
@@ -486,19 +477,16 @@ function findPathIssues(
                 ? 'incoming'
                 : 'bidirectional';
 
-          let dnfLabels: LabelOrCondition;
-          try {
-            const treeWithRewrittenAnys = removeInnerAnys(symbol.labels);
-            if (
-              isAnyNode(treeWithRewrittenAnys) ||
-              isNotAnyNode(treeWithRewrittenAnys)
-            ) {
-              continue;
-            }
-            dnfLabels = convertToSimplifiedDNF(treeWithRewrittenAnys);
-          } catch {
+          // ANY (%) / NOT-ANY (!%) and unconvertible trees can't be validated
+          // against the label-keyed schema, so skip the segment without warning.
+          const normalizedLabels = normalizeLabelTreeForSchemaCheck(
+            symbol.labels,
+            'dnf',
+          );
+          if (normalizedLabels.kind !== 'converted') {
             continue;
           }
+          const dnfLabels = normalizedLabels.tree;
           if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
             let hasViableLabel = false;
             for (const c of dnfLabels.children) {
@@ -546,70 +534,63 @@ function isViableSegment(
   completedLabels: Set<string>,
   endLabels: LabelOrCondition,
 ) {
-  let dnfTree: LabelOrCondition;
-  try {
-    const treeWithRewrittenAnys = removeInnerAnys(endLabels);
-    if (
-      isAnyNode(treeWithRewrittenAnys) ||
-      isNotAnyNode(treeWithRewrittenAnys)
-    ) {
-      return true;
-    }
-    dnfTree = convertToSimplifiedDNF(treeWithRewrittenAnys);
-    if (!isLabelLeaf(dnfTree) && dnfTree.condition === 'or') {
-      for (const c of dnfTree.children) {
-        if (isLabelLeaf(c)) {
-          if (completedLabels.has(c.value)) {
-            return true;
-          }
-        } else if (c.condition === 'not') {
-          const negated = c.children[0];
-          if (
-            isLabelLeaf(negated) &&
-            completedLabels.difference(new Set([negated.value])).size > 0
-          ) {
-            return true;
-          }
-        } else if (c.condition === 'and') {
-          let isViable = true;
-          const negatedLabels = c.children
-            .filter((c2) => !isLabelLeaf(c2) && c2.condition === 'not')
-            .map((x) =>
-              !isLabelLeaf(x) && isLabelLeaf(x.children[0])
-                ? x.children[0]
-                : undefined,
-            )
-            .filter((x) => x !== undefined)
-            .map((x) => x.value);
-          const remainingLabels = completedLabels.difference(
-            new Set(negatedLabels),
-          );
-          if (!remainingLabels.size) {
-            continue;
-          } else {
-            for (const c2 of c.children) {
-              if (isLabelLeaf(c2)) {
-                if (!remainingLabels.has(c2.value)) {
-                  isViable = false;
-                  break;
-                }
+  // ANY (%) / NOT-ANY (!%) endpoints can't be disproven by the schema, and an
+  // unconvertible tree is treated as viable to avoid a spurious warning.
+  const normalized = normalizeLabelTreeForSchemaCheck(endLabels, 'dnf');
+  if (normalized.kind !== 'converted') {
+    return true;
+  }
+  const dnfTree = normalized.tree;
+  if (!isLabelLeaf(dnfTree) && dnfTree.condition === 'or') {
+    for (const c of dnfTree.children) {
+      if (isLabelLeaf(c)) {
+        if (completedLabels.has(c.value)) {
+          return true;
+        }
+      } else if (c.condition === 'not') {
+        const negated = c.children[0];
+        if (
+          isLabelLeaf(negated) &&
+          completedLabels.difference(new Set([negated.value])).size > 0
+        ) {
+          return true;
+        }
+      } else if (c.condition === 'and') {
+        let isViable = true;
+        const negatedLabels = c.children
+          .filter((c2) => !isLabelLeaf(c2) && c2.condition === 'not')
+          .map((x) =>
+            !isLabelLeaf(x) && isLabelLeaf(x.children[0])
+              ? x.children[0]
+              : undefined,
+          )
+          .filter((x) => x !== undefined)
+          .map((x) => x.value);
+        const remainingLabels = completedLabels.difference(
+          new Set(negatedLabels),
+        );
+        if (!remainingLabels.size) {
+          continue;
+        } else {
+          for (const c2 of c.children) {
+            if (isLabelLeaf(c2)) {
+              if (!remainingLabels.has(c2.value)) {
+                isViable = false;
+                break;
               }
             }
           }
-          if (isViable) {
-            return true;
-          }
+        }
+        if (isViable) {
+          return true;
         }
       }
-    } else {
-      //If we have a bug - return true here and avoid creating the "invalid segment" warning
-      return true;
     }
-    return false;
-  } catch {
-    //bail
+  } else {
+    //If we have a bug - return true here and avoid creating the "invalid segment" warning
     return true;
   }
+  return false;
 }
 
 function findNonCreatingPatternElements(
@@ -832,22 +813,16 @@ function getFollowingLabels(
     outGoingLabels: Map<string, Set<string>>;
   },
 ): Set<string> | undefined {
-  let cnfTree: LabelOrCondition;
-  try {
-    const treeWithRewrittenAnys = removeInnerAnys(labels);
-    if (isAnyNode(treeWithRewrittenAnys)) {
-      return undefined;
-    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
-      return undefined;
-    }
-    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
-  } catch {
+  // ANY (%) / NOT-ANY (!%) and unconvertible trees give no usable set of
+  // following labels, so signal "can't determine" with undefined.
+  const normalized = normalizeLabelTreeForSchemaCheck(labels, 'cnf');
+  if (normalized.kind !== 'converted') {
     return undefined;
   }
   const { inLabels, outLabels } = walkCNFTree(
     incomingLabels,
     outGoingLabels,
-    cnfTree,
+    normalized.tree,
   );
   const allNodes =
     direction === 'outgoing'

--- a/packages/language-support/src/syntaxValidation/syntaxValidation.ts
+++ b/packages/language-support/src/syntaxValidation/syntaxValidation.ts
@@ -40,7 +40,8 @@ import {
 } from '../generated-parser/CypherCmdParser.js';
 import { ParserRuleContext } from 'antlr4';
 import {
-  convertToCNF,
+  convertToSimplifiedCNF,
+  convertToSimplifiedDNF,
   isAnyNode,
   isNotAnyNode,
   removeInnerAnys,
@@ -332,7 +333,7 @@ function labelTreeToString(node: LabelOrCondition): string {
 
 function labelsToMessage(
   firstLabelTree: LabelOrCondition,
-  connectedLabel: string,
+  secondLabelTree: LabelOrCondition,
   direction: 'outgoing' | 'incoming' | 'bidirectional',
   firstVarType: 'node' | 'relationship' | 'variable',
 ) {
@@ -346,7 +347,7 @@ function labelsToMessage(
         : 'variable';
   const capitalizedSecondVar =
     secondVarType.at(0)?.toUpperCase() + secondVarType.slice(1);
-  return `${capitalizedSecondVar} with label ${connectedLabel} has no ${directionSubString}connection to a ${firstVarType} with label(s) ${labelTreeToString(firstLabelTree)}.`;
+  return `${capitalizedSecondVar} with label(s) ${labelTreeToString(secondLabelTree)} has no ${directionSubString}connection to a ${firstVarType} with label(s) ${labelTreeToString(firstLabelTree)}.`;
 }
 
 function findPathIssues(
@@ -384,7 +385,14 @@ function findPathIssues(
               ref <= (nextChild.stop?.stop ?? -1),
           ),
         )?.labels;
-        if (symbol && nextSymbolLabels) {
+        if (
+          symbol &&
+          nextSymbolLabels &&
+          !isLabelLeaf(symbol.labels) &&
+          symbol.labels.children.length &&
+          !isLabelLeaf(nextSymbolLabels) &&
+          nextSymbolLabels.children.length
+        ) {
           const direction =
             nextChild.leftArrow() &&
             !nextChild.rightArrow() &&
@@ -393,34 +401,33 @@ function findPathIssues(
               : !nextChild.leftArrow() && nextChild.rightArrow()
                 ? 'incoming'
                 : 'bidirectional';
-          const possibleRels = possibleFollowingRelType(
-            direction,
-            dbSchema,
-            symbol.labels,
-          );
-          if (
-            possibleRels &&
-            'children' in nextSymbolLabels &&
-            nextSymbolLabels.children.length === 1 &&
-            isLabelLeaf(nextSymbolLabels.children[0])
-          ) {
-            if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
-              let firstVarType: 'variable' | 'node' | 'relationship' =
-                'variable';
-              if (symbol.types.length === 1) {
-                switch (symbol.types[0]) {
-                  case 'Node':
-                    firstVarType = 'node';
-                    break;
-                  case 'Relationship':
-                    firstVarType = 'relationship';
-                    break;
+
+          const dnfLabels = convertToSimplifiedDNF(symbol.labels);
+          if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
+            let hasViableLabel = false;
+            for (const c of dnfLabels.children) {
+              const possibleRels = possibleFollowingRelType(
+                direction,
+                dbSchema,
+                { condition: 'and', children: [c] },
+              );
+              if (possibleRels) {
+                const segmentIsPossible = isViableSegment(
+                  possibleRels,
+                  nextSymbolLabels,
+                );
+                if (segmentIsPossible) {
+                  hasViableLabel = true;
+                  break;
                 }
               }
+            }
+            if (!hasViableLabel) {
+              const firstVarType = 'node';
               diagnostics.push({
                 message: labelsToMessage(
                   symbol.labels,
-                  nextSymbolLabels.children[0].value,
+                  nextSymbolLabels,
                   direction,
                   firstVarType,
                 ),
@@ -451,7 +458,14 @@ function findPathIssues(
               ref <= (nextChild.stop?.stop ?? -1),
           ),
         )?.labels;
-        if (symbol && nextSymbolLabels) {
+        if (
+          symbol &&
+          nextSymbolLabels &&
+          !isLabelLeaf(symbol.labels) &&
+          symbol.labels.children.length &&
+          !isLabelLeaf(nextSymbolLabels) &&
+          nextSymbolLabels.children.length
+        ) {
           const direction =
             child.leftArrow() &&
             !child.rightArrow() &&
@@ -460,35 +474,33 @@ function findPathIssues(
               : !child.leftArrow() && child.rightArrow()
                 ? 'incoming'
                 : 'bidirectional';
-          const possibleRels = possibleFollowingLabels(
-            direction,
-            dbSchema,
-            symbol.labels,
-          );
-          if (
-            possibleRels &&
-            nextSymbolLabels &&
-            'children' in nextSymbolLabels &&
-            nextSymbolLabels.children.length === 1 &&
-            isLabelLeaf(nextSymbolLabels.children[0])
-          ) {
-            if (!possibleRels.has(nextSymbolLabels.children[0].value)) {
-              let firstVarType: 'variable' | 'node' | 'relationship' =
-                'variable';
-              if (symbol.types.length === 1) {
-                switch (symbol.types[0]) {
-                  case 'Node':
-                    firstVarType = 'node';
-                    break;
-                  case 'Relationship':
-                    firstVarType = 'relationship';
-                    break;
+
+          const dnfLabels = convertToSimplifiedDNF(symbol.labels);
+          if (!isLabelLeaf(dnfLabels) && dnfLabels.condition === 'or') {
+            let hasViableLabel = false;
+            for (const c of dnfLabels.children) {
+              const possibleNodes = possibleFollowingLabels(
+                direction,
+                dbSchema,
+                { condition: 'and', children: [c] },
+              );
+              if (possibleNodes) {
+                const segmentIsPossible = isViableSegment(
+                  possibleNodes,
+                  nextSymbolLabels,
+                );
+                if (segmentIsPossible) {
+                  hasViableLabel = true;
+                  break;
                 }
               }
+            }
+            if (!hasViableLabel) {
+              const firstVarType = 'relationship';
               diagnostics.push({
                 message: labelsToMessage(
                   symbol.labels,
-                  nextSymbolLabels.children[0].value,
+                  nextSymbolLabels,
                   direction,
                   firstVarType,
                 ),
@@ -502,6 +514,71 @@ function findPathIssues(
     }
   }
   return diagnostics;
+}
+
+//Convert right hand side to Disjunctive normal form (like OR(A, !B, AND(C,!D), ...))
+//If any of the possibilities are viable based off the completions, the path segment is viable
+//Ex. if RHS is OR(A, !B, AND(C,!D)) and completions contain A, the OR could have real matches
+function isViableSegment(
+  completedLabels: Set<string>,
+  endLabels: LabelOrCondition,
+) {
+  let dnfTree: LabelOrCondition;
+  try {
+    const treeWithRewrittenAnys = removeInnerAnys(endLabels);
+    if (isAnyNode(treeWithRewrittenAnys)) {
+      return true;
+    } else if (isNotAnyNode(treeWithRewrittenAnys)) {
+      return false;
+    }
+    dnfTree = convertToSimplifiedDNF(treeWithRewrittenAnys);
+    if (!isLabelLeaf(dnfTree) && dnfTree.condition === 'or') {
+      for (const c of dnfTree.children) {
+        if (isLabelLeaf(c)) {
+          if (completedLabels.has(c.value)) {
+            return true;
+          }
+        } else if (c.condition === 'not') {
+          const negated = c.children[0];
+          if (
+            isLabelLeaf(negated) &&
+            completedLabels.difference(new Set(negated.value)).size > 0
+          ) {
+            return true;
+          }
+        } else if (c.condition === 'and') {
+          let isViable = true;
+          for (const c2 of c.children) {
+            if (isLabelLeaf(c2)) {
+              if (!completedLabels.has(c2.value)) {
+                isViable = false;
+                break;
+              }
+            } else if (c2.condition === 'not') {
+              const negated = c2.children[0];
+              if (
+                isLabelLeaf(negated) &&
+                completedLabels.difference(new Set(negated.value)).size === 0
+              ) {
+                isViable = false;
+                break;
+              }
+            }
+          }
+          if (isViable) {
+            return true;
+          }
+        }
+      }
+    } else {
+      //If we have a bug in DNF creation
+      return true;
+    }
+    return false;
+  } catch {
+    //bail
+    return true;
+  }
 }
 
 function findNonCreatingPatternElements(
@@ -732,7 +809,7 @@ function getFollowingLabels(
     } else if (isNotAnyNode(treeWithRewrittenAnys)) {
       return undefined;
     }
-    cnfTree = convertToCNF(treeWithRewrittenAnys);
+    cnfTree = convertToSimplifiedCNF(treeWithRewrittenAnys);
   } catch {
     return undefined;
   }

--- a/packages/language-support/src/tests/autocompletion/schemaBasedPatternCompletion.test.ts
+++ b/packages/language-support/src/tests/autocompletion/schemaBasedPatternCompletion.test.ts
@@ -598,9 +598,33 @@ RETURN [(p)-[:`;
         { label: 'BATTLES', kind: CompletionItemKind.TypeParameter },
         { label: 'KNOWS', kind: CompletionItemKind.TypeParameter },
         { label: 'WEAK_TO', kind: CompletionItemKind.TypeParameter },
-        { label: 'UNRELATED_RELTYPE', kind: CompletionItemKind.TypeParameter },
+        { label: 'STRONG_AGAINST', kind: CompletionItemKind.TypeParameter },
         { label: 'UNRELATED_RELTYPE', kind: CompletionItemKind.TypeParameter },
       ],
+    });
+  });
+
+  //Equivalent to !Pokemon | !Trainer, which is true for any label
+  test('Handles &-tautology', () => {
+    const query = 'MATCH (x:!(Pokemon&Trainer))-[r:';
+
+    testCompletions({
+      query,
+      dbSchema,
+      computeSymbolsInfo: true,
+      expected: [
+        { label: 'CHALLENGES', kind: CompletionItemKind.TypeParameter },
+        { label: 'CATCHES', kind: CompletionItemKind.TypeParameter },
+        { label: 'TRAINS', kind: CompletionItemKind.TypeParameter },
+        { label: 'BATTLES', kind: CompletionItemKind.TypeParameter },
+        { label: 'IS_IN', kind: CompletionItemKind.TypeParameter },
+        { label: 'CHALLENGES', kind: CompletionItemKind.TypeParameter },
+        { label: 'KNOWS', kind: CompletionItemKind.TypeParameter },
+        { label: 'WEAK_TO', kind: CompletionItemKind.TypeParameter },
+        { label: 'STRONG_AGAINST', kind: CompletionItemKind.TypeParameter },
+        { label: 'UNRELATED_RELTYPE', kind: CompletionItemKind.TypeParameter },
+      ],
+      excluded: [],
     });
   });
 

--- a/packages/language-support/src/tests/autocompletion/treeRewriting.test.ts
+++ b/packages/language-support/src/tests/autocompletion/treeRewriting.test.ts
@@ -1,10 +1,11 @@
 import { isLabelLeaf, LabelOrCondition } from '../../types.js';
 import {
   childAlreadyExists,
-  convertToCNF,
+  convertToSimplifiedCNF,
   pushInNots,
   removeInnerAnys,
   removeDuplicates,
+  convertToSimplifiedDNF,
 } from '../../labelTreeRewriting.js';
 import { lintCypherQuery } from '../../syntaxValidation/syntaxValidation.js';
 
@@ -36,7 +37,7 @@ describe('rewrite tree', () => {
     const parsing = lintCypherQuery(exampleQueries.singleLabel, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     expect(isLabelLeaf(firstSymbolLabels)).toEqual(false);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual({
       children: [
         {
@@ -68,7 +69,7 @@ describe('rewrite tree', () => {
   test('CNF calculation should not break label tree already on CNF', () => {
     const parsing = lintCypherQuery(exampleQueries.twoDifferentLabels, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual({
       children: [
         {
@@ -87,7 +88,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -96,7 +97,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -105,7 +106,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -117,7 +118,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -156,7 +157,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -214,7 +215,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -259,7 +260,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -287,7 +288,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -315,7 +316,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -337,10 +338,35 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [],
+      condition: 'and',
+    });
+  });
+
+  test('CNF handles ! with |', () => {
+    const parsing = lintCypherQuery('MATCH (n:!A&(B|C)&!D)', {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
+    const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    expect(deduplicatedTree).not.toEqual(cnfTree);
+    expect(cnfTree).toEqual({
+      children: [
+        {
+          children: [
+            {
+              value: 'B',
+            },
+            {
+              value: 'C',
+            },
+          ],
+          condition: 'or',
+        },
+      ],
       condition: 'and',
     });
   });
@@ -353,18 +379,10 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
-        {
-          children: [
-            {
-              value: 'A',
-            },
-          ],
-          condition: 'not',
-        },
         {
           children: [
             {
@@ -397,7 +415,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -436,7 +454,7 @@ describe('rewrite tree', () => {
     // AND(OR(A,C,E), OR(A,C,F), OR(A,D,E), OR(A,D,F), OR(B,C,E), OR(B,C,F), OR(B,D,E), OR(B,D,F))
     const parsing = lintCypherQuery(exampleQueries.threeInnerAnds, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    const cnfTree = convertToCNF(firstSymbolLabels);
+    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
     expect(cnfTree).toEqual({
       children: [
         {
@@ -855,7 +873,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:A | % & B))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToCNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(convertToSimplifiedCNF(removeInnerAnys(firstSymbolLabels))).toEqual({
       condition: 'and',
       children: [
         { condition: 'or', children: [{ value: 'A' }, { value: 'B' }] },
@@ -904,6 +922,334 @@ describe('rewrite tree', () => {
       children: [
         { value: 'A' },
         { condition: 'or', children: [{ value: 'B' }, { value: 'C' }] },
+      ],
+    });
+  });
+
+  test('Converting DNF to DNF should remain DNF', () => {
+    const query = 'MATCH (n:A | B)';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [{ value: 'A' }, { value: 'B' }],
+    });
+  });
+
+  test('Converting CNF to DNF should work', () => {
+    const query = 'MATCH (n:A & B)';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
+      ],
+    });
+  });
+
+  test('Converting more complex CNF to DNF should work', () => {
+    const query = 'MATCH (n:A & (B | C))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
+        { condition: 'and', children: [{ value: 'A' }, { value: 'C' }] },
+      ],
+    });
+  });
+
+  test('Simplifying complex DNF should work in DNF conversion', () => {
+    const query = 'MATCH (n:(A & B)|(B & C)|(B & C & D))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
+        { condition: 'and', children: [{ value: 'B' }, { value: 'C' }] },
+      ],
+    });
+  });
+
+  test('Can convert big CNF to DNF', () => {
+    const query = 'MATCH (n:(A | B) & (B | C) & (B | C | D))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { condition: 'and', children: [{ value: 'A' }, { value: 'C' }] },
+        { value: 'B' },
+      ],
+    });
+  });
+
+  test('Can convert deep tree to DNF, v1', () => {
+    const query = 'MATCH (n:(A & (B | (C & D))))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
+        {
+          condition: 'and',
+          children: [{ value: 'A' }, { value: 'C' }, { value: 'D' }],
+        },
+      ],
+    });
+  });
+
+  test('Can convert deep tree to DNF, v2', () => {
+    const query = 'MATCH (n:(A | B | C) & (D | (E & (F | G | H)))))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      children: [
+        {
+          children: [
+            {
+              value: 'A',
+            },
+            {
+              value: 'D',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'A',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'F',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'A',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'G',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'A',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'H',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'B',
+            },
+            {
+              value: 'D',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'B',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'F',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'B',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'G',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'B',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'H',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'C',
+            },
+            {
+              value: 'D',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'C',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'F',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'C',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'G',
+            },
+          ],
+          condition: 'and',
+        },
+        {
+          children: [
+            {
+              value: 'C',
+            },
+            {
+              value: 'E',
+            },
+            {
+              value: 'H',
+            },
+          ],
+          condition: 'and',
+        },
+      ],
+      condition: 'or',
+    });
+  });
+
+  //AND(A, OR(!B, C)) =
+  //OR(AND(A, !B), AND(A, C)) =
+  // OR(AND(A), AND(A,C)) = OR(A) //Extra simplification we can do since !B = A | C | D | ... so AND(!B, A) = A
+  test('Can handle NOTs in DNF conversion, v1', () => {
+    const query = 'MATCH (n:(A & (!B | C)))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { value: 'A' }, //, { condition: 'not', children: [ { value: 'B' }] }] },
+        //{ condition: 'and', children: [{ value: 'A' }, { value: 'C' }] }
+      ],
+    });
+  });
+
+  test('Can handle NOTs in DNF conversion, v2', () => {
+    const query = 'MATCH (n:(A & !B))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { value: 'A' },
+        //{ condition: 'and', children: [{ value: 'A' }, { condition: 'not', children: [ { value: 'B' }] }] }
+      ],
+    });
+  });
+
+  //A | !B = !B
+  test('Can simplify away using NOTs in DNF conversion, v1', () => {
+    const query = 'MATCH (n:(A | !B))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { value: 'A' },
+        { condition: 'not', children: [{ value: 'B' }] },
+      ],
+    });
+  });
+
+  test('Can simplify away using NOTs in DNF conversion, v2', () => {
+    const query = 'MATCH (n:(A | !B | (C | !D)))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { value: 'A' },
+        { condition: 'not', children: [{ value: 'B' }] },
+        { value: 'C' },
+        { condition: 'not', children: [{ value: 'D' }] },
+      ],
+    });
+  }); //!B | (!A & !C)
+
+  test('DNF conversion can handle contradictions', () => {
+    const query = 'MATCH (n:(A & !A))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [],
+    });
+  });
+
+  test('DNF conversion can handle tautologies', () => {
+    const query = 'MATCH (n:(A | !A))';
+    const parsing = lintCypherQuery(query, {});
+    const firstSymbolLabels = parsing.symbolTables[0][0].labels;
+    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+      condition: 'or',
+      children: [
+        { value: 'A' },
+        { condition: 'not', children: [{ value: 'A' }] },
       ],
     });
   });

--- a/packages/language-support/src/tests/autocompletion/treeRewriting.test.ts
+++ b/packages/language-support/src/tests/autocompletion/treeRewriting.test.ts
@@ -1,13 +1,23 @@
 import { isLabelLeaf, LabelOrCondition } from '../../types.js';
 import {
   childAlreadyExists,
-  convertToSimplifiedCNF,
+  normalizeLabelTreeForSchemaCheck,
   pushInNots,
   removeInnerAnys,
   removeDuplicates,
-  convertToSimplifiedDNF,
 } from '../../labelTreeRewriting.js';
 import { lintCypherQuery } from '../../syntaxValidation/syntaxValidation.js';
+
+function toNormalForm(
+  labels: LabelOrCondition,
+  form: 'dnf' | 'cnf',
+): LabelOrCondition {
+  const result = normalizeLabelTreeForSchemaCheck(labels, form);
+  if (result.kind !== 'converted') {
+    throw new Error(`Expected a converted label tree, got '${result.kind}'`);
+  }
+  return result.tree;
+}
 
 const exampleQueries = {
   singleLabel: 'MATCH (n:Move)-[:]',
@@ -37,7 +47,7 @@ describe('rewrite tree', () => {
     const parsing = lintCypherQuery(exampleQueries.singleLabel, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     expect(isLabelLeaf(firstSymbolLabels)).toEqual(false);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual({
       children: [
         {
@@ -69,7 +79,7 @@ describe('rewrite tree', () => {
   test('CNF calculation should not break label tree already on CNF', () => {
     const parsing = lintCypherQuery(exampleQueries.twoDifferentLabels, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual({
       children: [
         {
@@ -88,7 +98,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -97,7 +107,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -106,7 +116,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual(deduplicatedTree);
   });
 
@@ -118,7 +128,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -157,7 +167,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -215,7 +225,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -260,7 +270,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -288,7 +298,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -316,7 +326,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -338,7 +348,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [],
@@ -351,7 +361,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(deduplicatedTree).not.toEqual(cnfTree);
     expect(cnfTree).toEqual({
       children: [
@@ -379,7 +389,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -415,7 +425,7 @@ describe('rewrite tree', () => {
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
     const labelsWithAdjustedNot = pushInNots(firstSymbolLabels);
     const deduplicatedTree = removeDuplicates(labelsWithAdjustedNot);
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).not.toEqual(deduplicatedTree);
     expect(cnfTree).toEqual({
       children: [
@@ -454,7 +464,7 @@ describe('rewrite tree', () => {
     // AND(OR(A,C,E), OR(A,C,F), OR(A,D,E), OR(A,D,F), OR(B,C,E), OR(B,C,F), OR(B,D,E), OR(B,D,F))
     const parsing = lintCypherQuery(exampleQueries.threeInnerAnds, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    const cnfTree = convertToSimplifiedCNF(firstSymbolLabels);
+    const cnfTree = toNormalForm(firstSymbolLabels, 'cnf');
     expect(cnfTree).toEqual({
       children: [
         {
@@ -873,7 +883,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:A | % & B))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedCNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'cnf')).toEqual({
       condition: 'and',
       children: [
         { condition: 'or', children: [{ value: 'A' }, { value: 'B' }] },
@@ -930,7 +940,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:A | B)';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [{ value: 'A' }, { value: 'B' }],
     });
@@ -940,7 +950,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:A & B)';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
@@ -952,7 +962,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:A & (B | C))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
@@ -965,7 +975,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A & B)|(B & C)|(B & C & D))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
@@ -978,7 +988,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A | B) & (B | C) & (B | C | D))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { condition: 'and', children: [{ value: 'A' }, { value: 'C' }] },
@@ -991,7 +1001,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A & (B | (C & D))))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { condition: 'and', children: [{ value: 'A' }, { value: 'B' }] },
@@ -1007,7 +1017,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A | B | C) & (D | (E & (F | G | H)))))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       children: [
         {
           children: [
@@ -1180,7 +1190,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A & (!B | C)))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { value: 'A' }, //, { condition: 'not', children: [ { value: 'B' }] }] },
@@ -1193,7 +1203,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A & !B))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { value: 'A' },
@@ -1207,7 +1217,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A | !B))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { value: 'A' },
@@ -1220,7 +1230,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A | !B | (C | !D)))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { value: 'A' },
@@ -1235,7 +1245,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A & !A))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [],
     });
@@ -1245,7 +1255,7 @@ describe('rewrite tree', () => {
     const query = 'MATCH (n:(A | !A))';
     const parsing = lintCypherQuery(query, {});
     const firstSymbolLabels = parsing.symbolTables[0][0].labels;
-    expect(convertToSimplifiedDNF(removeInnerAnys(firstSymbolLabels))).toEqual({
+    expect(toNormalForm(firstSymbolLabels, 'dnf')).toEqual({
       condition: 'or',
       children: [
         { value: 'A' },

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -50,7 +50,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label WEAK_TO has no incoming connection to a node with label(s) Trainer.',
+          'Relationship with label(s) WEAK_TO has no incoming connection to a node with label(s) Trainer.',
         offsets: {
           end: 30,
           start: 6,
@@ -82,7 +82,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) Pokemon.',
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) Pokemon.',
         offsets: {
           end: 30,
           start: 6,
@@ -114,7 +114,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Node with label Gym has no incoming connection to a relationship with label(s) WEAK_TO.',
+          'Node with label(s) Gym has no incoming connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 27,
           start: 8,
@@ -146,7 +146,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Node with label Gym has no outgoing connection to a relationship with label(s) WEAK_TO.',
+          'Node with label(s) Gym has no outgoing connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 27,
           start: 8,
@@ -178,7 +178,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label WEAK_TO has no connection to a node with label(s) Trainer.',
+          'Relationship with label(s) WEAK_TO has no connection to a node with label(s) Trainer.',
         offsets: {
           end: 30,
           start: 6,
@@ -197,7 +197,7 @@ describe('Schema based linting spec', () => {
       },
       {
         message:
-          'Node with label Gym has no connection to a relationship with label(s) WEAK_TO.',
+          'Node with label(s) Gym has no connection to a relationship with label(s) WEAK_TO.',
         offsets: {
           end: 36,
           start: 16,
@@ -229,7 +229,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) (Trainer | Gym).',
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) (Trainer | Gym).',
         offsets: {
           end: 33,
           start: 6,
@@ -249,13 +249,32 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
-  test('Handles multiple labels on first variable in path segment (rel)', () => {
+  test('Handles multiple labels on both variables in path segment', () => {
     const query = 'MATCH (:Trainer)<-[:WEAK_TO|IS_IN]-(:Move) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
         message:
-          'Node with label Move has no outgoing connection to a relationship with label(s) (WEAK_TO | IS_IN).',
+          'Relationship with label(s) (WEAK_TO | IS_IN) has no outgoing connection to a node with label(s) Trainer.',
+        offsets: {
+          end: 35,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 35,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          'Node with label(s) Move has no outgoing connection to a relationship with label(s) (WEAK_TO | IS_IN).',
         offsets: {
           end: 42,
           start: 16,
@@ -282,7 +301,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label WEAK_TO has no outgoing connection to a node with label(s) ((Trainer | Gym) & (Gym | (Trainer & Pokemon))).',
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) ((Trainer | Gym) & (Gym | (Trainer & Pokemon))).',
         offsets: {
           end: 65,
           start: 6,
@@ -302,14 +321,124 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
-  test('Limitation: Bails on multiple labels on second variable in path segment (node)', () => {
+  test('Handles multiple labels on second variable in path segment (node)', () => {
     const query = 'MATCH (:Type)<-[:WEAK_TO]-(:Trainer|Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) (Trainer | Gym) has no outgoing connection to a relationship with label(s) WEAK_TO.',
+        offsets: {
+          end: 40,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 40,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles multiple labels on second variable in path segment (rel)', () => {
+    const query = 'MATCH (:Gym)<-[:WEAK_TO|IS_IN]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) (WEAK_TO | IS_IN) has no outgoing connection to a node with label(s) Gym.',
+        offsets: {
+          end: 31,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 31,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  //This should be invalid even though Type and Trainer are both individually possible, this syntax means the node will have both, but there is no single
+  //rel type of the CHALLENGES|STRONG_AGAINST rel that would give both
+  test('Handles more complex labels on both variables in path segment, v1', () => {
+    const query =
+      'MATCH (:Type)<-[:CHALLENGES|STRONG_AGAINST]-(:(Type & Trainer)) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) (Type & Trainer) has no outgoing connection to a relationship with label(s) (CHALLENGES | STRONG_AGAINST).',
+        offsets: {
+          end: 63,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 63,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles more complex labels on both variables in path segment, v2', () => {
+    const query =
+      'MATCH (:Type & (Pokemon|Trainer))<-[:BATTLES|(!STRONG_AGAINST & !KNOWS & BATTLES)]-(:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) (BATTLES | (STRONG_AGAINST & KNOWS & BATTLES)) has no outgoing connection to a node with label(s) (Type & (Pokemon | Trainer)).',
+        offsets: {
+          end: 83,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 83,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles more complex labels on both variables in path segment, no false negatives v1', () => {
+    const query =
+      'MATCH (:Type)<-[:CHALLENGES|STRONG_AGAINST]-(:(Pokemon & Trainer)|Type) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([]);
   });
 
-  test('Limitation: Bails on multiple labels on second variable in path segment (rel)', () => {
-    const query = 'MATCH (:Gym)<-[:WEAK_TO|IS_IN]-(:Pokemon) RETURN ""';
+  test('Handles more complex labels on both variables in path segment, no false negatives v2', () => {
+    const query =
+      'MATCH (:Type & (Pokemon|Trainer))<-[:BATTLES|(!STRONG_AGAINST & !KNOWS)]-(:Trainer) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([]);
   });
@@ -339,7 +468,7 @@ describe('Schema based linting spec', () => {
       },
       {
         message:
-          'Relationship with label WEAK_TO has no connection to a node with label(s) Gym.',
+          'Relationship with label(s) WEAK_TO has no connection to a node with label(s) Gym.',
         offsets: {
           end: 22,
           start: 6,
@@ -493,7 +622,7 @@ describe('Schema based linting spec', () => {
       },
       {
         message:
-          'Node with label Pokemon has no incoming connection to a relationship with label(s) IS_IN.',
+          'Node with label(s) Pokemon has no incoming connection to a relationship with label(s) IS_IN.',
         offsets: {
           end: 32,
           start: 12,
@@ -712,13 +841,20 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
+  test('Should not warn on unlabeled nodes/rels', () => {
+    const query =
+      'MATCH (n)-[]->()-[R]-(m:Trainer)-[]-(q)-[:IS_IN]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
   test('Warns both on missing label and path segment at once', () => {
     const query = 'MATCH (n)<-[:MISSED]-(:Archer) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
         message:
-          'Node with label Archer has no outgoing connection to a relationship with label(s) MISSED.',
+          'Node with label(s) Archer has no outgoing connection to a relationship with label(s) MISSED.',
         offsets: {
           end: 30,
           start: 9,

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -409,7 +409,7 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label(s) (BATTLES | (STRONG_AGAINST & KNOWS & BATTLES)) has no outgoing connection to a node with label(s) (Type & (Pokemon | Trainer)).',
+          'Relationship with label(s) (BATTLES | (!STRONG_AGAINST & !KNOWS & BATTLES)) has no outgoing connection to a node with label(s) (Type & (Pokemon | Trainer)).',
         offsets: {
           end: 83,
           start: 6,
@@ -429,16 +429,145 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
-  test('Handles more complex labels on both variables in path segment, no false negatives v1', () => {
+  test('Handles more complex labels on both variables in path segment, no false positives v1', () => {
     const query =
       'MATCH (:Type)<-[:CHALLENGES|STRONG_AGAINST]-(:(Pokemon & Trainer)|Type) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([]);
   });
 
-  test('Handles more complex labels on both variables in path segment, no false negatives v2', () => {
+  test('Handles more complex labels on both variables in path segment, no false positives v2', () => {
     const query =
-      'MATCH (:Type & (Pokemon|Trainer))<-[:BATTLES|(!STRONG_AGAINST & !KNOWS)]-(:Trainer) RETURN ""';
+      'MATCH (:Type|(Pokemon & Trainer))<-[:BATTLES|(!STRONG_AGAINST & !KNOWS)]-(:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Handles ANDed negations on relationship', () => {
+    const query =
+      'MATCH (:Type)<-[:!CATCHES & !TRAINS & !CHALLENGES & !BATTLES & !IS_IN]-(:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) Trainer has no outgoing connection to a relationship with label(s) (!CATCHES & !TRAINS & !CHALLENGES & !BATTLES & !IS_IN).',
+        offsets: {
+          end: 81,
+          start: 13,
+        },
+        range: {
+          end: {
+            character: 81,
+            line: 0,
+          },
+          start: {
+            character: 13,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles ANDed negations on relationship v2', () => {
+    const query =
+      'MATCH (:Trainer)<-[:!CATCHES & !TRAINS & !CHALLENGES & !BATTLES & !IS_IN]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) (!CATCHES & !TRAINS & !CHALLENGES & !BATTLES & !IS_IN) has no outgoing connection to a node with label(s) Trainer.',
+        offsets: {
+          end: 74,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 74,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles ANDed negations on node, v1', () => {
+    const query =
+      'MATCH (:!Type & !Pokemon & !Gym & !Move)<-[:CATCHES|TRAINS]-(x:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) (CATCHES | TRAINS) has no outgoing connection to a node with label(s) (!Type & !Pokemon & !Gym & !Move).',
+        offsets: {
+          end: 60,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 60,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Handles ANDed negations on node, v2', () => {
+    const query =
+      'MATCH (:Pokemon)<-[:CATCHES|TRAINS|IS_IN]-(x:!Type & !Trainer & !Gym & !Move) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) (!Type & !Trainer & !Gym & !Move) has no outgoing connection to a relationship with label(s) (CATCHES | TRAINS | IS_IN).',
+        offsets: {
+          end: 77,
+          start: 16,
+        },
+        range: {
+          end: {
+            character: 77,
+            line: 0,
+          },
+          start: {
+            character: 16,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('No false positives with ANDed negations on relationship', () => {
+    const query =
+      'MATCH (:Type)<-[:!CATCHES & !TRAINS & !CHALLENGES & !BATTLES & !IS_IN]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('No false positives with ANDed negations on node v1', () => {
+    const query =
+      'MATCH (:!Type & !Trainer & !Gym & !Move)<-[:CATCHES|TRAINS]-(:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('No false positives with ANDed negations on node v2', () => {
+    const query =
+      'MATCH (:Pokemon)<-[:CATCHES|TRAINS]-(:!Type & !Pokemon & !Gym & !Move) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([]);
   });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1317,46 +1317,35 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
-  test('Warns on NOT-ANY (!%) first variable. Node->Rel', () => {
+  // A NOT-ANY (!%) node matches only label-less nodes. The label-keyed schema
+  // does not enumerate connections of label-less nodes, so we cannot prove the
+  // segment invalid and must not warn.
+  test('Does not warn on a NOT-ANY (!%) first variable. Node->Rel', () => {
     const query = 'MATCH (:!%)-[:WEAK_TO]->() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
-    expect(diagnostics).toEqual([
-      {
-        message:
-          'Relationship with label(s) WEAK_TO has no incoming connection to a node with label(s) !%.',
-        offsets: {
-          end: 24,
-          start: 6,
-        },
-        range: {
-          end: {
-            character: 24,
-            line: 0,
-          },
-          start: {
-            character: 6,
-            line: 0,
-          },
-        },
-        severity: 2,
-      },
-    ]);
+    expect(diagnostics).toEqual([]);
   });
 
-  test('Warns on NOT-ANY (!%) first variable. Node<-Rel', () => {
+  test('Does not warn on a NOT-ANY (!%) first variable. Node<-Rel', () => {
     const query = 'MATCH (:!%)<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Handles case where we have legitimate label and a contradiction, v1', () => {
+    const query = 'MATCH (:Pokemon | (!% & Trainer))<-[:WEAK_TO]-() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
       {
         message:
-          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) !%.',
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) (Pokemon | (!% & Trainer)).',
         offsets: {
-          end: 24,
+          end: 46,
           start: 6,
         },
         range: {
           end: {
-            character: 24,
+            character: 46,
             line: 0,
           },
           start: {
@@ -1369,29 +1358,53 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
-  test('Warns on NOT-ANY (!%) on rel ', () => {
+  test('Handles case where we have legitimate label and a contradiction, v2', () => {
+    const query =
+      'MATCH (:Pokemon | (!Trainer & Trainer))<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) (Pokemon | (!Trainer & Trainer)).',
+        offsets: {
+          end: 52,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 52,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Limitation: Does warn on contradictions like (!% & X)', () => {
+    const query = 'MATCH (:!% & Trainer)<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Limitation: Does not warn on (contradiction | contradiction)', () => {
+    const query =
+      'MATCH (:(!% & Pokemon) | (!% & Trainer))<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  // A NOT-ANY (!%) relationship is impossible (relationships always have exactly
+  // one type), so Neo4j emits its own semantic error. The schema path linter
+  // should not pile on a separate connection warning.
+  test('Does not add a path warning for a NOT-ANY (!%) rel (only the semantic error)', () => {
     const query = 'MATCH (n:Trainer)<-[:!%]-() RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
     expect(diagnostics).toEqual([
-      {
-        message:
-          'Relationship with label(s) !% has no outgoing connection to a node with label(s) Trainer.',
-        offsets: {
-          end: 25,
-          start: 6,
-        },
-        range: {
-          end: {
-            character: 25,
-            line: 0,
-          },
-          start: {
-            character: 6,
-            line: 0,
-          },
-        },
-        severity: 2,
-      },
       {
         message:
           'Relationship type expression cannot possibly be satisfied. (`!%` can never be satisfied by any relationship. Relationships must have exactly one relationship type.)',

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1427,6 +1427,14 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
+  // (:Trainer)-[:CATCHES] exists, and [:WEAK_TO]->(:Type) exists, but neither of
+  // (:Trainer)-[:CATCHES]->(:Type) nor (:Trainer)-[:WEAK_TO]->(:Type) exist. We could see this from schema and warn
+  test('Limitation: Does not check entire tripples for viability', () => {
+    const query = 'MATCH (n:Trainer)-[:CATCHES | WEAK_TO]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
   test('Should not warn on CREATE', () => {
     const query = 'CREATE (n:Person)<-[:WEAK_TO]-()';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1041,6 +1041,347 @@ describe('Schema based linting spec', () => {
     ]);
   });
 
+  test('Warns on a single (non-ANDed) negated label on the end node. Rel->Node', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:!Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) !Type has no incoming connection to a relationship with label(s) WEAK_TO.',
+        offsets: {
+          end: 29,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Warns on a single negated label on the end node when it is the only target. Rel->Node', () => {
+    const query = 'MATCH ()-[:KNOWS]->(:!Move) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) !Move has no incoming connection to a relationship with label(s) KNOWS.',
+        offsets: {
+          end: 27,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 27,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on a single negated label when another target is viable. Rel->Node', () => {
+    const query = 'MATCH ()-[:CHALLENGES]->(:!Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on a single negated relationship type that removes the only valid type', () => {
+    const query = 'MATCH (:Pokemon)-[:!KNOWS]->(:Move) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) Move has no incoming connection to a relationship with label(s) !KNOWS.',
+        offsets: {
+          end: 35,
+          start: 16,
+        },
+        range: {
+          end: {
+            character: 35,
+            line: 0,
+          },
+          start: {
+            character: 16,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on a negated relationship type when another type is viable', () => {
+    const query = 'MATCH (:Pokemon)-[:!CATCHES]->(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Does not warn on bidirectional rel when one direction is viable', () => {
+    const query = 'MATCH (:Region)-[:IS_IN]-(:Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Warns on bidirectional rel when neither direction is viable', () => {
+    const query = 'MATCH (:Region)-[:IS_IN]-(:Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) Pokemon has no connection to a relationship with label(s) IS_IN.',
+        offsets: {
+          end: 35,
+          start: 15,
+        },
+        range: {
+          end: {
+            character: 35,
+            line: 0,
+          },
+          start: {
+            character: 15,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Warns only on the invalid segment of a multi-hop path', () => {
+    const query =
+      'MATCH (:Trainer)-[:CATCHES]->(:Pokemon)-[:WEAK_TO]->(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) Gym has no incoming connection to a relationship with label(s) WEAK_TO.',
+        offsets: {
+          end: 58,
+          start: 39,
+        },
+        range: {
+          end: {
+            character: 58,
+            line: 0,
+          },
+          start: {
+            character: 39,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on a fully valid multi-hop path', () => {
+    const query =
+      'MATCH (:Trainer)-[:CATCHES]->(:Pokemon)-[:WEAK_TO]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Resolves labels accumulated across clauses on a repeated variable', () => {
+    const query = 'MATCH (n:Trainer) MATCH (n)-[:WEAK_TO]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) WEAK_TO has no incoming connection to a node with label(s) Trainer.',
+        offsets: {
+          end: 40,
+          start: 24,
+        },
+        range: {
+          end: {
+            character: 40,
+            line: 0,
+          },
+          start: {
+            character: 24,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on a self-loop with a viable reltype', () => {
+    const query = 'MATCH (n:Pokemon)-[:CHALLENGES]->(n) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Does not warn when the end node label expression is a tautology (any)', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:Pokemon|!Pokemon) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Does not warn on an OR of negations when a viable label remains', () => {
+    const query = 'MATCH (:Type)<-[:WEAK_TO]-(:!Pokemon|!Trainer) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Limitation: Does not lint variable-length relationships', () => {
+    const query = 'MATCH (:Trainer)-[:WEAK_TO*1..3]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Does not produce a false positive for an ANY (%) first variable', () => {
+    const query = 'MATCH (:%)-[:WEAK_TO]->() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Does not produce a false positive for an ANY (%) ANDed with a label on the first variable', () => {
+    const query = 'MATCH (:Pokemon&%)-[:WEAK_TO]->(:Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('Only warns on the genuinely invalid segment when the first variable is ANY (%)', () => {
+    const query = 'MATCH (:%)-[:WEAK_TO]->(:Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) Gym has no incoming connection to a relationship with label(s) WEAK_TO.',
+        offsets: {
+          end: 29,
+          start: 10,
+        },
+        range: {
+          end: {
+            character: 29,
+            line: 0,
+          },
+          start: {
+            character: 10,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Warns on NOT-ANY (!%) first variable. Node->Rel', () => {
+    const query = 'MATCH (:!%)-[:WEAK_TO]->() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) WEAK_TO has no incoming connection to a node with label(s) !%.',
+        offsets: {
+          end: 24,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Warns on NOT-ANY (!%) first variable. Node<-Rel', () => {
+    const query = 'MATCH (:!%)<-[:WEAK_TO]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) WEAK_TO has no outgoing connection to a node with label(s) !%.',
+        offsets: {
+          end: 24,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 24,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Warns on NOT-ANY (!%) on rel ', () => {
+    const query = 'MATCH (n:Trainer)<-[:!%]-() RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Relationship with label(s) !% has no outgoing connection to a node with label(s) Trainer.',
+        offsets: {
+          end: 25,
+          start: 6,
+        },
+        range: {
+          end: {
+            character: 25,
+            line: 0,
+          },
+          start: {
+            character: 6,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+      {
+        message:
+          'Relationship type expression cannot possibly be satisfied. (`!%` can never be satisfied by any relationship. Relationships must have exactly one relationship type.)',
+        offsets: {
+          end: 23,
+          start: 21,
+        },
+        range: {
+          end: {
+            character: 23,
+            line: 0,
+          },
+          start: {
+            character: 21,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
   test('Should not warn on CREATE', () => {
     const query = 'CREATE (n:Person)<-[:WEAK_TO]-()';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });

--- a/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
+++ b/packages/language-support/src/tests/syntaxValidation/symbolValidation.test.ts
@@ -1241,6 +1241,38 @@ describe('Schema based linting spec', () => {
     expect(diagnostics).toEqual([]);
   });
 
+  test('Warns on a label-OR-negation end node when negated label is the only viable one', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:Gym|!Type) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([
+      {
+        message:
+          'Node with label(s) (Gym | !Type) has no incoming connection to a relationship with label(s) WEAK_TO.',
+        offsets: {
+          end: 33,
+          start: 8,
+        },
+        range: {
+          end: {
+            character: 33,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+        severity: 2,
+      },
+    ]);
+  });
+
+  test('Does not warn on a label-OR-negation end node when there is viability via negation condition', () => {
+    const query = 'MATCH ()-[:WEAK_TO]->(:Type|!Gym) RETURN ""';
+    const diagnostics = getDiagnosticsForQuery({ query, dbSchema });
+    expect(diagnostics).toEqual([]);
+  });
+
   test('Limitation: Does not lint variable-length relationships', () => {
     const query = 'MATCH (:Trainer)-[:WEAK_TO*1..3]->(:Type) RETURN ""';
     const diagnostics = getDiagnosticsForQuery({ query, dbSchema });


### PR DESCRIPTION
Previously the the schema based linting was basically the completions logic, and checking if the RHS label was in completions. To make this work, we limited the RHS to a single label, so we could only handle segments like `(:Person&Friend)-[:KNOWS]` or `[:KNOWS|IS]->(:President)` but not `[:KNOWS|IS]->(:President|(Senator&Presidential_Candidate)` This PR expands the logic (still reusing completions) to handle generic labels

The new logic works like:
Split incoming tree to Disjunctive Normal Form (similar to existing Conjunctive Normal Form). The tree is then guaranteed to be on shape:
OR(A, !B, AND(C,D), AND(E,!F)...)
Also write the second tree to DNF
Ex. OR(X, AND(Y,Z))
if any of the OR-ed labels/ANDs of the LHS (left hand side) tree have a matching label in the OR of the RHS tree, there is a possible match. 

How do we deal with the ANDs then? My implementation takes "what labels come out of AND(C,D)?" from the existing completion logic. If the RHS is also AND, we can say - given that the label can't be any of the NOT-ed labels - can find all the required labels in the labels coming out of the LHS? If so, we've found a viable candidate, and the segment should not have a warning. For the single labels, the logic is like before - if a single completion of what could come after one of the possible LHS labels matches a RHS label we have a viable segment

I also found some bugs in the old logic that I fixed along the way