### PR TITLE
Add a Welcome experience to the VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ benchmarks.txt
 .idea/
 vite.config.ts.timestamp*
 .wdio-vscode-service
+.claude

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,9 @@
       "name": "Debug VSCode Webview Tests",
       "type": "node",
       "request": "launch",
-      "args": ["${workspaceFolder}/packages/vscode-extension/dist/tests/runWebviewTests.js"],
+      "args": [
+        "${workspaceFolder}/packages/vscode-extension/dist/tests/runWebviewTests.js"
+      ],
       "env": {
         "DEBUG_VSCODE_TESTS": "true"
       },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "name": "VSCode Playground",
       "runtimeExecutable": "${execPath}",
       "env": {
-        "watch": "true"
+        "watch": "false"
       },
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension"
@@ -52,13 +52,13 @@
       "name": "Debug VSCode Webview Tests",
       "type": "node",
       "request": "launch",
-      "args": ["./packages/vscode-extension/dist/tests/runWebviewTests.js"],
+      "args": ["${workspaceFolder}/packages/vscode-extension/dist/tests/runWebviewTests.js"],
       "env": {
         "DEBUG_VSCODE_TESTS": "true"
       },
       "cwd": "${workspaceFolder}",
       "autoAttachChildProcesses": true,
-      "program": "${workspaceRoot}/node_modules/@wdio/cli/bin/wdio.js",
+      "program": "${workspaceRoot}/packages/vscode-extension/node_modules/@wdio/cli/bin/wdio.js",
       "console": "integratedTerminal",
       "skipFiles": [
         "${workspaceFolder}/node_modules/**/*.js",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "name": "VSCode Playground",
       "runtimeExecutable": "${execPath}",
       "env": {
-        "watch": "false"
+        "watch": "true"
       },
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -175,6 +175,16 @@
         "title": "Edit parameter",
         "category": "Neo4j",
         "icon": "$(pencil)"
+      },
+      {
+        "command": "neo4j.showWelcome",
+        "title": "Welcome",
+        "category": "Neo4j"
+      },
+      {
+        "command": "neo4j.addGraphAcademyMcpServer",
+        "title": "Add GraphAcademy MCP server",
+        "category": "Neo4j"
       }
     ],
     "keybindings": [
@@ -531,7 +541,93 @@
         "editor.semanticHighlighting.enabled": true,
         "editor.defaultFormatter": "neo4j-extensions.neo4j-for-vscode"
       }
-    }
+    },
+    "walkthroughs": [
+      {
+        "id": "neo4jLearnNeo4j",
+        "title": "Learn Neo4j",
+        "description": "New to Neo4j? Get started for free with these fundamentals courses from Neo4j GraphAcademy.",
+        "steps": [
+          {
+            "id": "graphAcademyMcp",
+            "title": "Add the GraphAcademy MCP server",
+            "description": "Give your AI coding agent tools to learn Neo4j, design graph models, and generate Cypher.\n[Add MCP server](command:neo4j.addGraphAcademyMcpServer)",
+            "media": {
+              "markdown": "resources/walkthroughs/graphacademy-mcp.md"
+            },
+            "completionEvents": [
+              "onCommand:neo4j.addGraphAcademyMcpServer"
+            ]
+          },
+          {
+            "id": "neo4jFundamentals",
+            "title": "Neo4j Fundamentals",
+            "description": "Learn about graph databases and get started with Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/)",
+            "media": {
+              "markdown": "resources/walkthroughs/neo4j-fundamentals.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/courses/neo4j-fundamentals/"
+            ]
+          },
+          {
+            "id": "cypherFundamentals",
+            "title": "Cypher Fundamentals",
+            "description": "Learn Cypher, the query language for Neo4j, in about an hour.\n[Start course](https://graphacademy.neo4j.com/courses/cypher-fundamentals/)",
+            "media": {
+              "markdown": "resources/walkthroughs/cypher-fundamentals.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/courses/cypher-fundamentals/"
+            ]
+          },
+          {
+            "id": "modelingFundamentals",
+            "title": "Graph Data Modeling Fundamentals",
+            "description": "Learn how to design a Neo4j graph using best practices.\n[Start course](https://graphacademy.neo4j.com/courses/modeling-fundamentals/)",
+            "media": {
+              "markdown": "resources/walkthroughs/modeling-fundamentals.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/courses/modeling-fundamentals/"
+            ]
+          },
+          {
+            "id": "importingFundamentals",
+            "title": "Importing Data Fundamentals",
+            "description": "Learn how to import data into Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/importing-fundamentals/)",
+            "media": {
+              "markdown": "resources/walkthroughs/importing-fundamentals.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/courses/importing-fundamentals/"
+            ]
+          },
+          {
+            "id": "generativeAiPathway",
+            "title": "Generative AI & GraphRAG",
+            "description": "Ready for more? Combine Neo4j with LLMs to build GraphRAG applications.\n[Explore pathway](https://graphacademy.neo4j.com/categories/generative-ai)",
+            "media": {
+              "markdown": "resources/walkthroughs/generative-ai.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/categories/generative-ai"
+            ]
+          },
+          {
+            "id": "appDevelopmentPathway",
+            "title": "Graph Application Development",
+            "description": "Build applications powered by Neo4j using the official drivers.\n[Explore pathway](https://graphacademy.neo4j.com/categories/app-development)",
+            "media": {
+              "markdown": "resources/walkthroughs/app-development.md"
+            },
+            "completionEvents": [
+              "onLink:https://graphacademy.neo4j.com/categories/app-development"
+            ]
+          }
+        ]
+      }
+    ]
   },
   "activationEvents": [],
   "icon": "resources/images/logo.png",

--- a/packages/vscode-extension/resources/walkthroughs/app-development.md
+++ b/packages/vscode-extension/resources/walkthroughs/app-development.md
@@ -1,0 +1,11 @@
+# Graph Application Development
+
+Build applications powered by Neo4j.
+
+This GraphAcademy pathway covers:
+
+- Using the Neo4j drivers in your language of choice
+- Building full-stack applications backed by a graph
+- Best practices for production Neo4j applications
+
+[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/app-development)

--- a/packages/vscode-extension/resources/walkthroughs/cypher-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/cypher-fundamentals.md
@@ -1,0 +1,15 @@
+# Cypher Fundamentals
+
+Learn Cypher, the query language for Neo4j, in about an hour.
+
+In this free, hands-on GraphAcademy course you will:
+
+- Read data from the graph with `MATCH` and `RETURN`
+- Filter results with `WHERE`
+- Create and update data with `MERGE` and `SET`
+
+Everything you learn here you can try out directly in your `.cypher` files with this extension.
+
+⏱️ 1 hour · Free
+
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/cypher-fundamentals/)

--- a/packages/vscode-extension/resources/walkthroughs/generative-ai.md
+++ b/packages/vscode-extension/resources/walkthroughs/generative-ai.md
@@ -1,0 +1,12 @@
+# Generative AI & GraphRAG
+
+Once you have the fundamentals, learn how to Neo4j can support your GenAI
+application.
+
+This GraphAcademy pathway covers:
+
+- Retrieval-augmented generation (RAG) backed by a knowledge graph
+- Building GraphRAG pipelines
+- Using Neo4j with popular GenAI frameworks
+
+[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/generative-ai)

--- a/packages/vscode-extension/resources/walkthroughs/graphacademy-mcp.md
+++ b/packages/vscode-extension/resources/walkthroughs/graphacademy-mcp.md
@@ -1,0 +1,15 @@
+# Add the GraphAcademy MCP server
+
+An MCP server (Model Context Protocol server) gives an AI coding agent a set of
+callable tools it can use on your behalf.
+
+The GraphAcademy MCP server (`https://mcp.graphacademy.neo4j.com/mcp`) gives your
+coding agent tools for:
+
+- **Learning** — browse GraphAcademy courses, lessons and enrolments
+- **Modeling** — design graph data models for your use case
+- **Building** — generate Cypher queries, import scripts, mock data and project scaffolding
+
+Click **Add MCP server** to add it to this workspace's `.vscode/mcp.json`. After it
+is added, start the server from that file and authorize it with a one-time
+GraphAcademy login.

--- a/packages/vscode-extension/resources/walkthroughs/graphacademy-mcp.md
+++ b/packages/vscode-extension/resources/walkthroughs/graphacademy-mcp.md
@@ -3,8 +3,7 @@
 An MCP server (Model Context Protocol server) gives an AI coding agent a set of
 callable tools it can use on your behalf.
 
-The GraphAcademy MCP server (`https://mcp.graphacademy.neo4j.com/mcp`) gives your
-coding agent tools for:
+The GraphAcademy MCP server (`https://mcp.graphacademy.neo4j.com/mcp`) gives the VS Code Copilot agent tools for:
 
 - **Learning** — browse GraphAcademy courses, lessons and enrolments
 - **Modeling** — design graph data models for your use case

--- a/packages/vscode-extension/resources/walkthroughs/importing-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/importing-fundamentals.md
@@ -1,0 +1,13 @@
+# Importing Data Fundamentals
+
+Learn how to import data into Neo4j.
+
+In this free, hands-on GraphAcademy course you will:
+
+- Import data from CSV files with `LOAD CSV`
+- Map source data onto your graph model
+- Apply best practices for fast, reliable imports
+
+⏱️ 1 hour · Free
+
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/importing-fundamentals/)

--- a/packages/vscode-extension/resources/walkthroughs/modeling-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/modeling-fundamentals.md
@@ -1,0 +1,13 @@
+# Graph Data Modeling Fundamentals
+
+Learn how to design a Neo4j graph using best practices.
+
+In this free, hands-on GraphAcademy course you will:
+
+- Turn requirements into a graph data model
+- Choose between nodes, relationships and properties
+- Refactor and evolve a model as requirements change
+
+⏱️ 2 hours · Free
+
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/modeling-fundamentals/)

--- a/packages/vscode-extension/resources/walkthroughs/neo4j-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/neo4j-fundamentals.md
@@ -1,0 +1,13 @@
+# Neo4j Fundamentals
+
+Learn about graph databases and get started with Neo4j.
+
+In this free, hands-on GraphAcademy course you will:
+
+- Understand what a graph database is and why it matters
+- Learn the building blocks of the graph: nodes, relationships and properties
+- Get hands-on running your first queries against Neo4j
+
+⏱️ 1 hour · Free
+
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/)

--- a/packages/vscode-extension/src/commandHandlers/mcp.ts
+++ b/packages/vscode-extension/src/commandHandlers/mcp.ts
@@ -1,0 +1,100 @@
+import { commands, env, Uri, window, workspace } from 'vscode';
+import { CONSTANTS } from '../constants';
+
+type McpServerConfig = {
+  type: 'http';
+  url: string;
+};
+
+type McpJson = {
+  servers?: Record<string, McpServerConfig>;
+};
+
+/**
+ * Adds the GraphAcademy MCP server to the workspace `.vscode/mcp.json` file,
+ * creating or merging the file as needed. This matches the configuration
+ * documented for VS Code, where MCP servers live under a top level `servers`
+ * key.
+ *
+ * If there is no open workspace folder, or the existing file cannot be parsed
+ * (e.g. it contains comments), the configuration is copied to the clipboard and
+ * the user is guided to add it manually.
+ */
+export async function addGraphAcademyMcpServer(): Promise<void> {
+  const serverName = CONSTANTS.MCP.GRAPHACADEMY_SERVER_NAME;
+  const serverConfig: McpServerConfig = {
+    type: 'http',
+    url: CONSTANTS.MCP.GRAPHACADEMY_SERVER_URL,
+  };
+
+  const workspaceFolder = workspace.workspaceFolders?.[0];
+  if (!workspaceFolder) {
+    await copyConfigToClipboard(serverName, serverConfig);
+    void window.showInformationMessage(
+      `Open a folder to add the '${serverName}' MCP server to .vscode/mcp.json. The configuration has been copied to your clipboard.`,
+    );
+    return;
+  }
+
+  const mcpUri = Uri.joinPath(workspaceFolder.uri, '.vscode', 'mcp.json');
+
+  let existingText: string | undefined;
+  try {
+    const bytes = await workspace.fs.readFile(mcpUri);
+    existingText = new TextDecoder().decode(bytes).trim();
+  } catch {
+    // File does not exist yet, we will create it.
+    existingText = undefined;
+  }
+
+  let config: McpJson = {};
+  if (existingText) {
+    try {
+      config = JSON.parse(existingText) as McpJson;
+    } catch {
+      // The file exists but isn't plain JSON (e.g. it has comments). Rather
+      // than risk clobbering it, open it and let the user paste the entry.
+      await copyConfigToClipboard(serverName, serverConfig);
+      await commands.executeCommand('vscode.open', mcpUri);
+      void window.showWarningMessage(
+        `Couldn't automatically update mcp.json. Add the '${serverName}' server entry manually — it has been copied to your clipboard.`,
+      );
+      return;
+    }
+  }
+
+  config.servers ??= {};
+  if (config.servers[serverName]) {
+    // Already configured — open the file so the user can start the server.
+    await commands.executeCommand('vscode.open', mcpUri);
+    void window.showInformationMessage(
+      `The '${serverName}' MCP server is already configured in this workspace.`,
+    );
+    return;
+  }
+
+  config.servers[serverName] = serverConfig;
+  await workspace.fs.writeFile(
+    mcpUri,
+    new TextEncoder().encode(JSON.stringify(config, null, 2)),
+  );
+
+  // Open mcp.json so the "Start" action shown above the server entry is one
+  // click away. VS Code does not expose an API to start a server for us.
+  await commands.executeCommand('vscode.open', mcpUri);
+  void window.showInformationMessage(
+    `Added the '${serverName}' MCP server to .vscode/mcp.json. Click "Start" above the server entry to begin using it.`,
+  );
+}
+
+async function copyConfigToClipboard(
+  serverName: string,
+  serverConfig: McpServerConfig,
+): Promise<void> {
+  const snippet = JSON.stringify(
+    { servers: { [serverName]: serverConfig } },
+    null,
+    2,
+  );
+  await env.clipboard.writeText(snippet);
+}

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -16,6 +16,9 @@ export const CONSTANTS = {
     DELETE_PARAMETER: 'neo4j.deleteParameter',
     EDIT_PARAMETER: 'neo4j.editParameter',
     CLEAR_PARAMETERS: 'neo4j.clearParameters',
+    SHOW_WELCOME: 'neo4j.showWelcome',
+    ADD_GRAPHACADEMY_MCP: 'neo4j.addGraphAcademyMcpServer',
+    SHOW_CONNECTIONS_AND_CREATE: 'neo4j.showConnectionsAndCreate',
     INTERNAL: {
       EVAL_PARAMETER: 'neo4j.internal.evalParam',
       FORCE_DELETE_PARAMETER: 'neo4j.internal.forceDeleteParam',
@@ -55,5 +58,15 @@ export const CONSTANTS = {
       'You need to be connected to Neo4j to run queries',
     PARAMETER_SET: (key: string) => `Parameter '${key}' set.`,
     PARAMETER_DELETED: (key: string) => `Parameter \`${key}\` deleted.`,
+  },
+  LINKS: {
+    REPOSITORY: 'https://github.com/neo4j/cypher-language-support',
+  },
+  WALKTHROUGHS: {
+    LEARN_NEO4J: 'neo4jLearnNeo4j',
+  },
+  MCP: {
+    GRAPHACADEMY_SERVER_NAME: 'graphacademy',
+    GRAPHACADEMY_SERVER_URL: 'https://mcp.graphacademy.neo4j.com/mcp',
   },
 };

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -61,6 +61,8 @@ export const CONSTANTS = {
   },
   LINKS: {
     REPOSITORY: 'https://github.com/neo4j/cypher-language-support',
+    README:
+      'https://github.com/neo4j/cypher-language-support/blob/main/packages/vscode-extension/README.md',
   },
   WALKTHROUGHS: {
     LEARN_NEO4J: 'neo4jLearnNeo4j',

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -23,6 +23,9 @@ import { sendParametersToLanguageServer } from './parameterService';
 import { registerDisposables } from './registrationService';
 import { SymbolTable } from '@neo4j-cypher/language-support';
 import { sendNotificationToLanguageClient } from './languageClientService';
+import { CONSTANTS } from './constants';
+
+const WELCOME_SHOWN_KEY = 'neo4j.welcomeShown';
 
 let client: LanguageClient;
 let symbolTableVersion = 0;
@@ -87,6 +90,12 @@ export async function activate(context: ExtensionContext) {
   // Handle any sequence events for activation
   await reconnectDatabaseConnectionOnExtensionActivation();
   await sendParametersToLanguageServer();
+
+  // Show the welcome page the first time the extension is activated
+  if (!context.globalState.get(WELCOME_SHOWN_KEY, false)) {
+    await context.globalState.update(WELCOME_SHOWN_KEY, true);
+    await commands.executeCommand(CONSTANTS.COMMANDS.SHOW_WELCOME);
+  }
 
   // in developement mode, we manually reload the extension.
   if (process.env.watch === 'true') {

--- a/packages/vscode-extension/src/registrationService.ts
+++ b/packages/vscode-extension/src/registrationService.ts
@@ -34,6 +34,8 @@ import { Neo4jQueryDetailsProvider } from './webviews/queryResults/queryDetailsP
 import { Neo4jQueryVisualizationProvider } from './webviews/queryResults/queryVisualizationProvider';
 import { linterStatusBarItem } from './extension';
 import { manuallyAdjustLinter } from './commandHandlers/linters';
+import { addGraphAcademyMcpServer } from './commandHandlers/mcp';
+import { WelcomePanel } from './webviews/welcomePanel';
 
 /**
  * Any disposable resources that need to be cleaned up when the extension is deactivated should be registered here.
@@ -178,6 +180,25 @@ export function registerDisposables(): Disposable[] {
     commands.registerCommand(
       CONSTANTS.COMMANDS.INTERNAL.FORCE_CONNECT,
       forceConnect,
+    ),
+    commands.registerCommand(CONSTANTS.COMMANDS.SHOW_WELCOME, () =>
+      WelcomePanel.createOrShow(),
+    ),
+    commands.registerCommand(
+      CONSTANTS.COMMANDS.ADD_GRAPHACADEMY_MCP,
+      addGraphAcademyMcpServer,
+    ),
+    commands.registerCommand(
+      CONSTANTS.COMMANDS.SHOW_CONNECTIONS_AND_CREATE,
+      async () => {
+        // Reveal the Neo4j activity bar view, then open the add-connection dialog
+        await commands.executeCommand(
+          'workbench.view.extension.neo4j-explorer',
+        );
+        await commands.executeCommand(
+          CONSTANTS.COMMANDS.CREATE_CONNECTION_COMMAND,
+        );
+      },
     ),
   );
 

--- a/packages/vscode-extension/src/webviews/welcomePanel.ts
+++ b/packages/vscode-extension/src/webviews/welcomePanel.ts
@@ -1,0 +1,271 @@
+import {
+  Disposable,
+  Uri,
+  ViewColumn,
+  Webview,
+  WebviewPanel,
+  window,
+} from 'vscode';
+import { CONSTANTS } from '../constants';
+import { getExtensionContext } from '../contextService';
+import { getNonce } from '../getNonce';
+
+export class WelcomePanel {
+  private static _currentPanel: WelcomePanel | undefined;
+
+  private static readonly _viewType = 'neo4jWelcome';
+
+  private readonly _panel: WebviewPanel;
+  private _disposables: Disposable[] = [];
+
+  private constructor(panel: WebviewPanel) {
+    this._panel = panel;
+    this.update();
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+  }
+
+  public static createOrShow() {
+    const column = window.activeTextEditor
+      ? window.activeTextEditor.viewColumn
+      : ViewColumn.One;
+
+    if (WelcomePanel._currentPanel) {
+      WelcomePanel._currentPanel._panel.reveal(column);
+      return;
+    }
+
+    const panel = window.createWebviewPanel(
+      WelcomePanel._viewType,
+      'Welcome to Neo4j for VS Code',
+      column ?? ViewColumn.One,
+      {
+        enableScripts: false,
+        // Allow welcome page links to invoke these specific VS Code commands
+        enableCommandUris: [
+          'workbench.action.openWalkthrough',
+          CONSTANTS.COMMANDS.ADD_GRAPHACADEMY_MCP,
+          CONSTANTS.COMMANDS.SHOW_CONNECTIONS_AND_CREATE,
+        ],
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          Uri.joinPath(getExtensionContext().extensionUri, 'resources'),
+        ],
+      },
+    );
+
+    panel.iconPath = Uri.joinPath(
+      getExtensionContext().extensionUri,
+      'resources',
+      'images',
+      'logo.png',
+    );
+
+    WelcomePanel._currentPanel = new WelcomePanel(panel);
+  }
+
+  private dispose() {
+    WelcomePanel._currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const x = this._disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+
+  private update(): void {
+    this._panel.webview.html = this.getHtmlForWebview(this._panel.webview);
+  }
+
+  private getHtmlForWebview(webview: Webview): string {
+    const context = getExtensionContext();
+    const nonce = getNonce();
+    const logoUri = webview.asWebviewUri(
+      Uri.joinPath(context.extensionUri, 'resources', 'images', 'logo.png'),
+    );
+
+    // Command URI that opens the "Learn Neo4j" walkthrough contributed in package.json
+    const walkthroughCategory = `${context.extension.id}#${CONSTANTS.WALKTHROUGHS.LEARN_NEO4J}`;
+    const openWalkthroughUri = `command:workbench.action.openWalkthrough?${encodeURIComponent(
+      JSON.stringify(walkthroughCategory),
+    )}`;
+
+    return `
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${
+              webview.cspSource
+            }; style-src 'nonce-${nonce}';">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style nonce="${nonce}">
+              /* Neo4j brand palette (Needle design system) */
+              :root {
+                --neo4j-blue: #0a6190;
+                --neo4j-blue-dark: #02507b;
+                --neo4j-cyan: #8fe3e8;
+                /* Brand accent for headings/links, deep blue on light themes */
+                --neo4j-accent: var(--neo4j-blue);
+              }
+              body.vscode-dark,
+              body.vscode-high-contrast {
+                /* Cyan reads better against dark backgrounds */
+                --neo4j-accent: var(--neo4j-cyan);
+              }
+
+              body {
+                font-family: var(--vscode-font-family);
+                line-height: 1.5;
+                margin: 0;
+                padding: 0 0 3rem;
+              }
+              .content {
+                max-width: 980px;
+                padding: 0 2rem;
+                margin: 0 auto;
+              }
+              .columns {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+                gap: 2rem;
+                align-items: start;
+              }
+              .columns h2 {
+                margin-top: 1.5rem;
+              }
+              .footer {
+                margin-top: 2rem;
+                padding-top: 1rem;
+                border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.35));
+              }
+
+              .hero {
+                display: flex;
+                align-items: center;
+                gap: 1.25rem;
+                padding: 2rem;
+                background: linear-gradient(135deg, var(--neo4j-blue), var(--neo4j-blue-dark));
+                color: #ffffff;
+              }
+              .hero img {
+                width: 64px;
+                height: 64px;
+                flex: 0 0 auto;
+              }
+              .hero h1 {
+                font-size: 1.8rem;
+                margin: 0;
+                color: #ffffff;
+              }
+              .hero .lead {
+                margin: 0.25rem 0 0;
+                color: rgba(255, 255, 255, 0.85);
+              }
+
+              h2 {
+                font-size: 1.25rem;
+                margin-top: 2rem;
+                color: var(--neo4j-accent);
+                border-bottom: 2px solid var(--neo4j-accent);
+                padding-bottom: 0.3rem;
+              }
+              ul {
+                padding-left: 1.2rem;
+              }
+              li {
+                margin: 0.3rem 0;
+              }
+              a {
+                color: var(--neo4j-accent);
+                font-weight: 600;
+              }
+              a:hover {
+                text-decoration: underline;
+              }
+
+              .button {
+                display: inline-block;
+                margin-top: 0.5rem;
+                padding: 0.6rem 1.1rem;
+                border-radius: 4px;
+                background: var(--neo4j-blue);
+                color: #ffffff;
+                font-weight: 600;
+                text-decoration: none;
+              }
+              .button:hover {
+                background: var(--neo4j-blue-dark);
+                text-decoration: none;
+              }
+            </style>
+          </head>
+          <body>
+            <header class="hero">
+              <img src="${logoUri.toString()}" alt="Neo4j logo" />
+              <div>
+                <h1>Welcome to Neo4j for VS Code</h1>
+                <p class="lead">
+                  Write, lint, and run Cypher against your Neo4j databases,
+                  right inside your editor.
+                </p>
+              </div>
+            </header>
+
+            <div class="content">
+              <div class="columns">
+                <section>
+                  <h2>What you can do</h2>
+                  <ul>
+                    <li><strong>Syntax highlighting</strong> for Cypher, including Cypher embedded in Markdown, Java, Python, JavaScript, .NET and Go.</li>
+                    <li><strong>Linting</strong> for both syntax and semantic errors (type errors, unknown labels, and more), tailored to your database version.</li>
+                    <li><strong>Autocompletion</strong> for keywords, functions, labels, properties, database names and more.</li>
+                    <li><strong>Signature help</strong> that shows function signatures as you type.</li>
+                    <li><strong>Formatting</strong> to tidy up your queries according to the Cypher style guide.</li>
+                    <li><strong>Connection management</strong> for one or more Neo4j instances.</li>
+                    <li><strong>Query parameters</strong> you can define, edit and reuse.</li>
+                    <li><strong>Query execution</strong> with results and graph visualization.</li>
+                  </ul>
+                  <p>
+                    <a class="button" href="command:${CONSTANTS.COMMANDS.SHOW_CONNECTIONS_AND_CREATE}">Add connection</a>
+                  </p>
+                </section>
+
+                <section>
+                  <h2>Get Started with Neo4j</h2>
+                  <p>
+                    New to Neo4j? Get started for free with the fundamentals
+                    courses from Neo4j GraphAcademy, covering graph databases,
+                    Cypher, data modeling and importing data.
+                  </p>
+                  <p>
+                    <a class="button" href="${openWalkthroughUri}">Open the Learn Neo4j walkthrough</a>
+                  </p>
+                </section>
+              </div>
+
+              <section>
+                <h2>Supercharge your AI coding agent</h2>
+                <p>
+                  Add the GraphAcademy MCP server to give your AI coding agent
+                  tools to learn Neo4j, design graph data models, generate
+                  Cypher, and scaffold projects.
+                </p>
+                <p>
+                  <a class="button" href="command:${CONSTANTS.COMMANDS.ADD_GRAPHACADEMY_MCP}">Add the GraphAcademy MCP server</a>
+                </p>
+              </section>
+
+              <p class="footer">
+                Visit the
+                <a href="${CONSTANTS.LINKS.REPOSITORY}">project on GitHub</a>
+                to learn more, report issues, or contribute.
+              </p>
+            </div>
+          </body>
+        </html>`;
+  }
+}

--- a/packages/vscode-extension/src/webviews/welcomePanel.ts
+++ b/packages/vscode-extension/src/webviews/welcomePanel.ts
@@ -230,6 +230,10 @@ export class WelcomePanel {
                     <li><strong>Query execution</strong> with results and graph visualization.</li>
                   </ul>
                   <p>
+                    <a href="${CONSTANTS.LINKS.README}">Find more information</a>
+                    about these features.
+                  </p>
+                  <p>
                     <a class="button" href="command:${CONSTANTS.COMMANDS.SHOW_CONNECTIONS_AND_CREATE}">Add connection</a>
                   </p>
                 </section>

--- a/packages/vscode-extension/tests/specs/webviews/connection.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/connection.spec.ts
@@ -6,11 +6,13 @@ import { CONSTANTS } from '../../../src/constants';
 import {
   clickOnContextMenuItem,
   closeActiveTab,
+  findWebview,
   getConnectionSection,
   openFixtureFile,
   selectConnectionItem,
   setText,
   waitUntilNotification,
+  WEBVIEW_SELECTORS,
 } from '../../webviewUtils';
 
 suite('Connection testing', () => {
@@ -74,9 +76,12 @@ suite('Connection testing', () => {
     await waitUntilNotification(browser, 'Connected to Neo4j.');
   });
 
-  test('should not lose connection form details when going into another tab', async function () {
+  test('should not lose connection from details when going into another tab', async function () {
     await workbench.executeCommand(CONSTANTS.COMMANDS.EDIT_CONNECTION_COMMAND);
-    const connectionWebview = (await workbench.getAllWebviews()).at(0);
+    const connectionWebview = await findWebview(
+      workbench,
+      WEBVIEW_SELECTORS.connection,
+    );
     await setText(connectionWebview, '#host', 'Badabadum');
 
     // Opens a new tab, then closes it

--- a/packages/vscode-extension/tests/specs/webviews/params.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/params.spec.ts
@@ -3,7 +3,8 @@ import { before } from 'mocha';
 import { Workbench } from 'wdio-vscode-service';
 import { Key } from 'webdriverio';
 import {
-  checkResultsContent,
+  checkResult,
+  checkSummary,
   clickOnContextMenuItem,
   ensureNotificationsAreDismissed,
   executeFile,
@@ -137,7 +138,7 @@ suite('Params panel testing', () => {
 
     await executeFile(workbench, 'params.cypher');
 
-    await checkResultsContent(workbench, false, async () => {
+    await checkResult(workbench, async () => {
       await expectTableContent([
         'charmander',
         'caterpie',
@@ -153,7 +154,7 @@ suite('Params panel testing', () => {
 
     await escapeModal(4);
 
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain([
         'Expected parameter(s): a, b, some param, some-param',
       ]);
@@ -195,7 +196,7 @@ suite('Params panel testing', () => {
     await forceAddParam('some-param', '"bulbasaur"');
 
     await executeFile(workbench, 'params.cypher');
-    await checkResultsContent(workbench, false, async () => {
+    await checkResult(workbench, async () => {
       await expectTableContent([
         'charmander',
         'caterpie',
@@ -208,7 +209,7 @@ suite('Params panel testing', () => {
     await forceModifyParam('a', '"abra"');
 
     await executeFile(workbench, 'params.cypher');
-    await checkResultsContent(workbench, false, async () => {
+    await checkResult(workbench, async () => {
       await expectTableContent([
         'abra',
         'caterpie',
@@ -227,7 +228,7 @@ suite('Params panel testing', () => {
 
     await executeFile(workbench, 'params.cypher');
 
-    await checkResultsContent(workbench, false, async () => {
+    await checkResult(workbench, async () => {
       await expectTableContent([
         'charmander',
         'caterpie',
@@ -244,7 +245,7 @@ suite('Params panel testing', () => {
 
     await escapeModal(2);
 
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain(['Expected parameter(s): a, b']);
     });
   });
@@ -266,7 +267,7 @@ suite('Params panel testing', () => {
     await browser.pause(1000);
     await browser.keys(['5', Key.Enter]);
 
-    await checkResultsContent(workbench, false, async () => {
+    await checkResult(workbench, async () => {
       await expectTableContent(['1998', '12', 'false', '5', '2010']);
     });
   });

--- a/packages/vscode-extension/tests/specs/webviews/queryExecution.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/queryExecution.spec.ts
@@ -3,7 +3,7 @@ import { before } from 'mocha';
 import * as os from 'os';
 import { ViewSection, Workbench } from 'wdio-vscode-service';
 import {
-  checkResultsContent,
+  checkSummary,
   clickOnContextMenuItem,
   executeFile,
   getConnectionSection,
@@ -49,7 +49,7 @@ suite('Query results testing', () => {
 
   test('should manage queries that need implicit transactions', async function () {
     await executeFile(workbench, 'call-in-transactions.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain([
         '6 nodes created, 12 properties set, 6 labels added.',
       ]);
@@ -58,14 +58,14 @@ suite('Query results testing', () => {
 
   test('should correctly execute valid Cypher', async function () {
     await executeFile(workbench, 'valid.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain(['1 nodes created, 1 labels added.']);
     });
   });
 
   test('should correctly execute valid Cypher when highlighting several statements', async function () {
     await executeFile(workbench, 'multiline.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain([
         '1 nodes created, 1 labels added.',
         '2 nodes created, 2 labels added.',
@@ -76,7 +76,7 @@ suite('Query results testing', () => {
 
   test('should error on invalid cypher', async function () {
     await executeFile(workbench, 'invalid.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain(['Variable `n` not defined']);
     });
   });
@@ -90,11 +90,11 @@ suite('Query results testing', () => {
     await clickOnContextMenuItem(connectionSection, 'Connect', 1);
 
     await executeFile(workbench, 'create-for-match.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain(['1 nodes created, 1 labels added.']);
     });
     await executeFile(workbench, 'match-for-create.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain(['Started streaming 1 record']);
     });
 
@@ -104,7 +104,7 @@ suite('Query results testing', () => {
     await waitUntilNotification(browser, 'Connected to Neo4j.');
 
     await executeFile(workbench, 'match-for-create.cypher');
-    await checkResultsContent(workbench, true, async () => {
+    await checkSummary(workbench, async () => {
       await expectSummariesContain([undefined]);
     });
     await clickOnContextMenuItem(connectionSection, 'Disconnect', 0);

--- a/packages/vscode-extension/tests/specs/webviews/setup.spec.ts
+++ b/packages/vscode-extension/tests/specs/webviews/setup.spec.ts
@@ -1,7 +1,9 @@
 import { before } from 'mocha';
-import { createNewConnection } from '../../webviewUtils';
+import { closeActiveTab, createNewConnection } from '../../webviewUtils';
+import { browser } from '@wdio/globals';
 
 before(async () => {
   await createNewConnection('vscode-webview-tests-1');
   await createNewConnection('vscode-webview-tests-2');
+  await closeActiveTab(browser);
 });

--- a/packages/vscode-extension/tests/webviewUtils.ts
+++ b/packages/vscode-extension/tests/webviewUtils.ts
@@ -70,6 +70,59 @@ export async function openFixtureFile(
   );
 }
 
+/**
+ * Identifying elements for each of our webviews. We look these selectors up
+ * inside a webview's DOM instead of relying on the (unstable) ordering of
+ * workbench.getAllWebviews() — that order shifts whenever another webview
+ * (e.g. the welcome page) is open.
+ */
+export const WEBVIEW_SELECTORS = {
+  connection: '#save-connection',
+  querySummary: '#queryDetails',
+  queryResults: '#queryVisualization',
+} as const;
+
+/**
+ * Finds the webview whose content contains `selector`. Opening a webview
+ * switches the WebDriver context into its iframe, so we probe each one in turn
+ * and always switch back out before moving on. Retries until a match appears,
+ * since a webview's content may not be rendered the instant it's created.
+ */
+export async function findWebview(
+  workbench: Workbench,
+  selector: string,
+): Promise<WebView> {
+  let match: WebView | undefined;
+
+  await browser.waitUntil(
+    async () => {
+      const webviews = await workbench.getAllWebviews();
+      for (const webview of webviews) {
+        try {
+          await webview.open();
+          const found = await $(selector).isExisting();
+          await webview.close();
+          if (found) {
+            match = webview;
+            return true;
+          }
+        } catch {
+          // The webview wasn't ready to be opened (e.g. a hidden editor tab);
+          // make sure we're back in the main context before trying the next.
+          await webview.close();
+        }
+      }
+      return false;
+    },
+    {
+      timeout: 15000,
+      timeoutMsg: `No webview found containing "${selector}"`,
+    },
+  );
+  // waitUntil throws on timeout, so match is guaranteed to be set here.
+  return match as WebView;
+}
+
 export async function createNewConnection(containerName: string) {
   const container = await createAndStartTestContainer({
     containerName: containerName,
@@ -79,8 +132,8 @@ export async function createNewConnection(containerName: string) {
   const workbench = await browser.getWorkbench();
   const activityBar = workbench.getActivityBar();
   const neo4jTile = await activityBar.getViewControl('Neo4j');
-  const connectionPannel = await neo4jTile.openView();
-  const content = connectionPannel.getContent();
+  const connectionPanel = await neo4jTile.openView();
+  const content = connectionPanel.getContent();
   const sections = await content.getSections();
 
   try {
@@ -88,30 +141,32 @@ export async function createNewConnection(containerName: string) {
     const newConnectionButton = await section.button$;
     await newConnectionButton.click();
   } catch {
-    await workbench.executeCommand('neo4j.createConnection');
+    await browser.executeWorkbench(async (vscode) => {
+      await vscode.commands.executeCommand('neo4j.createConnection');
+    });
   }
+  const connectionWebview = await findWebview(
+    workbench,
+    WEBVIEW_SELECTORS.connection,
+  );
 
-  const connectionWebview = (await workbench.getAllWebviews()).at(0);
+  await connectionWebview.open();
 
-  if (connectionWebview) {
-    await connectionWebview.open();
+  const schemeInput = await $('#scheme');
+  const hostInput = await $('#host');
+  const portInput = await $('#port');
+  const userInput = await $('#user');
+  const passwordInput = await $('#password');
+  await schemeInput.selectByVisibleText('neo4j://');
+  await hostInput.setValue('localhost');
+  await portInput.setValue(port);
+  await userInput.setValue('neo4j');
+  await passwordInput.setValue('password');
 
-    const schemeInput = await $('#scheme');
-    const hostInput = await $('#host');
-    const portInput = await $('#port');
-    const userInput = await $('#user');
-    const passwordInput = await $('#password');
-    await schemeInput.selectByVisibleText('neo4j://');
-    await hostInput.setValue('localhost');
-    await portInput.setValue(port);
-    await userInput.setValue('neo4j');
-    await passwordInput.setValue('password');
+  const saveConnectionButton = await $('#save-connection');
+  await saveConnectionButton.click();
 
-    const saveConnectionButton = await $('#save-connection');
-    await saveConnectionButton.click();
-
-    await connectionWebview.close();
-  }
+  await connectionWebview.close();
 
   await waitUntilNotification(browser, 'Connected to Neo4j.');
 }
@@ -196,16 +251,32 @@ export async function closeActiveTab(browser: WebdriverIO.Browser) {
   });
 }
 
-export async function checkResultsContent(
+export async function checkSummary(
   workbench: Workbench,
-  summaryWebView: boolean,
   check: () => Promise<void>,
 ) {
   await browser.pause(1000);
-  const webviews = await workbench.getAllWebviews();
-  await expect(webviews.length).toBe(2);
-  const webviewNbr = summaryWebView ? 0 : 1;
-  const resultsWebview = (await workbench.getAllWebviews()).at(webviewNbr);
+  await browser.executeWorkbench(async (vscode) => {
+    await vscode.commands.executeCommand('neo4jQueryDetails.focus');
+  });
+  const selector = WEBVIEW_SELECTORS.querySummary;
+  const resultsWebview = await findWebview(workbench, selector);
+  await resultsWebview.open();
+  await check();
+  await resultsWebview.close();
+  await workbench.getEditorView().closeAllEditors();
+}
+
+export async function checkResult(
+  workbench: Workbench,
+  check: () => Promise<void>,
+) {
+  await browser.pause(1000);
+  await browser.executeWorkbench(async (vscode) => {
+    await vscode.commands.executeCommand('neo4jQueryVisualization.focus');
+  });
+  const selector = WEBVIEW_SELECTORS.queryResults;
+  const resultsWebview = await findWebview(workbench, selector);
   await resultsWebview.open();
   await check();
   await resultsWebview.close();


### PR DESCRIPTION
# Add a Welcome experience to the VS Code extension

https://github.com/user-attachments/assets/815d5e41-6cab-41a9-a106-ece9a0506514

## Summary

Adds a branded **welcome page**, a **"Learn Neo4j" walkthrough**, and one-click<br>**"Add GraphAcademy MCP server"** functionality to the Neo4j for VS Code<br>extension. The goal is to help new users understand what the extension does,<br>connect to a database, and start learning Neo4j — all from the moment they<br>install it.

## What's included

### Welcome page (`src/webviews/welcomePanel.ts`)

A new webview panel, shown automatically on first install and re-openable via<br>the **Neo4j: Welcome** command.

* Branded with the Neo4j logo, a hero header, and the Needle (NDL) brand colours<br>(deep blue `#0A6190` / cyan `#8FE3E8`), with theme-aware accents for light and<br>dark themes.
* Two-column responsive layout:
  * **What you can do** — a summary of the extension's features, plus an<br>**Add connection** button that reveals the Neo4j sidebar and opens the<br>add-connection dialog.
  * **Get Started with Neo4j** — intro and a button that opens the walkthrough.
* A **Supercharge your AI coding agent** section with a button to add the<br>GraphAcademy MCP server.
* Opens automatically only once, gated on a `globalState` flag.

### "Learn Neo4j" walkthrough (`contributes.walkthroughs`)

A native VS Code walkthrough that links to free Neo4j GraphAcademy content:

* Add the GraphAcademy MCP server
* Neo4j Fundamentals
* Cypher Fundamentals
* Graph Data Modeling Fundamentals
* Importing Data Fundamentals
* Generative AI & GraphRAG (pathway)
* Graph Application Development (pathway)

Each step has a markdown media file under `resources/walkthroughs/` and a<br>completion event.

### Add GraphAcademy MCP server (`src/commandHandlers/mcp.ts`)

A command (`neo4j.addGraphAcademyMcpServer`, **Neo4j: Add GraphAcademy MCP****<br>****server**) that adds the GraphAcademy MCP server to the workspace<br>`.vscode/mcp.json`:

* Creates or merges the `graphacademy` entry (type `http`,<br>`https://mcp.graphacademy.neo4j.com/mcp`) under the top-level `servers` key.
* Opens `mcp.json` automatically so VS Code's **Start** action is one click away.
* Graceful fallbacks: copies the config to the clipboard when there is no open<br>workspace folder, or when an existing `mcp.json` can't be parsed safely.

The command is surfaced in three places: the welcome page, the walkthrough, and<br>the Command Palette.

## New commands

<!-- linear:table-colwidths:266,266,266 -->
| Command | Title | Purpose |
| -- | -- | -- |
| `neo4j.showWelcome` | Neo4j: Welcome | Open the welcome page |
| `neo4j.addGraphAcademyMcpServer` | Neo4j: Add GraphAcademy MCP server | Add the GraphAcademy MCP server to `.vscode/mcp.json` |
| `neo4j.showConnectionsAndCreate` | *(internal)* | Reveal the Neo4j sidebar and open the add-connection dialog |

## Testing

* Launch the extension (F5 / "VSCode Playground").
* On first activation the welcome page opens; reopen with **Neo4j: Welcome**.
* **Add connection** opens the Neo4j sidebar and the add-connection dialog.
* **Open the Learn Neo4j walkthrough** / **Welcome: Open Walkthrough… → Learn****<br>****Neo4j** shows the steps; widen the editor so the media pane renders.
* **Add the GraphAcademy MCP server** writes `.vscode/mcp.json` and opens it with<br>the Start action visible.

## Notes

* MCP configuration is **workspace-scoped** (`.vscode/mcp.json`), matching the<br>documented VS Code setup. VS Code does not expose an API to start an MCP<br>server programmatically, so starting remains a one-click user action (the<br>GraphAcademy server also requires a one-time browser login).