### PR TITLE
Update imported workflows to latest + pin version

### DIFF
--- a/.github/workflows/archive-vscode-artifacts.yaml
+++ b/.github/workflows/archive-vscode-artifacts.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Archives VSCode artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup project
         uses: ./.github/actions/setup-and-build
@@ -22,7 +22,7 @@ jobs:
           cd packages/vscode-extension
           pnpm package
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: vscode-extension

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup and build project
         uses: ./.github/actions/setup-and-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Setup and build project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
       - name: Check the TextMate grammar is up to date
         run: |
@@ -32,7 +32,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
 
       - name: Check there are no linting errors
@@ -56,7 +56,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
 
       - name: Run tests
@@ -67,7 +67,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
 
       - name: Run tests
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
       - uses: ./.github/actions/codemirror-e2e-tests
         with:
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
       - uses: ./.github/actions/codemirror-e2e-tests
         with:
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
 
       - name: Run e2e test
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-and-build
 
       - name: Run tests

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -30,19 +30,19 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup and build project
         uses: ./.github/actions/setup-and-build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: './packages/react-codemirror-playground/dist/'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/fetch-dev-artifacts.yaml
+++ b/.github/workflows/fetch-dev-artifacts.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: check-day-of-month
     if: ${{ needs.check-day-of-month.outputs.skip == 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Up Git User
         run: |
@@ -41,7 +41,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_USERNAME }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_PASSWORD }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.git-check.outputs.modified == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BROWSER_BOT_PAT }}
           branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/formatting-integrity-check.yaml
+++ b/.github/workflows/formatting-integrity-check.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Formatter integrity check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup and build project
         uses: ./.github/actions/setup-and-build

--- a/.github/workflows/pre-release-vscode-extension.yaml
+++ b/.github/workflows/pre-release-vscode-extension.yaml
@@ -15,7 +15,7 @@ jobs:
     environment: publish-vscode-extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.BROWSER_BOT_PAT }}
 

--- a/.github/workflows/publish-npm-packages.yaml
+++ b/.github/workflows/publish-npm-packages.yaml
@@ -22,7 +22,7 @@ jobs:
     environment: publish-npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup and build project
         uses: ./.github/actions/setup-and-build
@@ -35,7 +35,7 @@ jobs:
     environment: publish-npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup and build project
         uses: ./.github/actions/setup-and-build

--- a/.github/workflows/publish-vscode-extension.yaml
+++ b/.github/workflows/publish-vscode-extension.yaml
@@ -15,7 +15,7 @@ jobs:
     environment: publish-vscode-extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # todo verify caching works well here too
       - name: Setup and build project


### PR DESCRIPTION
We used some quite old workflows that were even deprecated for node24 (used for all github runs now). We also had a lot of `uses: <...>` imports that did not use a static SHA but rather a version like `@v5` - this is a security issue since the commit this points to could change, opening a vulnerability where there was none before, while static SHAs like it sounds will point to a static commit state. This PR is also to pin all of these.

Most changed commits were quite old so I doubt any well known vulnerabilities lie unpatched there, but just to be safe I asked Claude to google for vulnerabilities or changes to functionality, it found nothing of note.

Closes LS-142