### PR TITLE
Update changelog and package.json for vscode release 1.18.0

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neo4j-for-vscode
 
+## 1.18.0
+- Add schema based linting for path segments
+- Add a welcome page
+- Remove "parameter missing" warnings when disconnected
+- Fix formatter bugs/improve coverage
+
 ## 1.16.0
 - Add aliases to connections pane
 - Add path segment completions

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neo4j-for-vscode",
   "displayName": "Neo4j for VS Code",
-  "version": "1.17.30",
+  "version": "1.18.0",
   "private": true,
   "description": "Highlighting, completions and more for Neo4j Cypher in VS Code",
   "categories": [


### PR DESCRIPTION
We've already released the schema-based linting to upx last week - about time we do it in vscode too!