### PR TITLE
Relint codemirror on schema update

### DIFF
--- a/.changeset/early-onions-check.md
+++ b/.changeset/early-onions-check.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/react-codemirror": patch
+---
+
+Relint codemirror on schema update

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -38,7 +38,7 @@ import {
   replMode as historyNavigation,
 } from './historyNavigation';
 import { cypher, CypherConfig } from './lang-cypher/langCypher';
-import { cleanupWorkers } from './lang-cypher/syntaxValidation';
+import { cleanupWorkers, schemaUpdated } from './lang-cypher/syntaxValidation';
 import { basicNeo4jSetup } from './neo4jSetup';
 import { getThemeExtension } from './themes';
 import { richClipboardCopier } from './richClipboardCopier';
@@ -134,6 +134,10 @@ export interface CypherEditorProps {
   };
   /**
    * The schema to use for autocompletion and linting.
+   *
+   * Compared by reference to decide when the document needs relinting:
+   * Avoid passing a new object when nothing changed
+   * as that would relint on every poll for no reason.
    *
    * @type {DbSchema}
    */
@@ -850,6 +854,10 @@ export class CypherEditor extends Component<
     this.schemaRef.current.schema = this.props.schema;
     this.schemaRef.current.lint = this.props.lint;
     this.schemaRef.current.featureFlags = this.props.featureFlags;
+
+    if (prevProps.schema !== this.props.schema) {
+      this.editorView.current.dispatch({ effects: schemaUpdated.of() });
+    }
   }
 
   componentWillUnmount(): void {

--- a/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
+++ b/packages/react-codemirror/src/lang-cypher/syntaxValidation.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, linter } from '@codemirror/lint';
-import { Extension } from '@codemirror/state';
+import { Extension, StateEffect } from '@codemirror/state';
 import { DiagnosticSeverity, DiagnosticTag } from 'vscode-languageserver-types';
 import workerpool from 'workerpool';
 import type { CypherConfig } from './langCypher';
@@ -14,62 +14,74 @@ const pool = workerpool.pool(WorkerURL, {
   workerTerminateTimeout: 2000,
 });
 
+export const schemaUpdated = StateEffect.define<void>();
+
 export const cypherLinter: (config: CypherConfig) => Extension = (config) =>
-  linter(async (view) => {
-    if (!config.lint) {
-      return [];
-    }
-    const query = view.state.doc.toString();
-    if (query.length === 0) {
-      return [];
-    }
-
-    try {
-      if (pool.stats().busyWorkers > 0) {
-        await pool.terminate(true);
+  linter(
+    async (view) => {
+      if (!config.lint) {
+        return [];
+      }
+      const query = view.state.doc.toString();
+      if (query.length === 0) {
+        return [];
       }
 
-      const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
-      const result = await proxyWorker.lintCypherQuery(
-        query,
-        config.schema ?? {},
-        config.featureFlags ?? {},
-      );
+      try {
+        if (pool.stats().busyWorkers > 0) {
+          await pool.terminate(true);
+        }
 
-      if (result.symbolTables) {
-        config.languageService.setSymbolsInfo({
+        const proxyWorker = (await pool.proxy()) as unknown as LintWorker;
+        const result = await proxyWorker.lintCypherQuery(
           query,
-          symbolTables: result.symbolTables,
-        });
-      }
+          config.schema ?? {},
+          config.featureFlags ?? {},
+        );
 
-      const a: Diagnostic[] = result.diagnostics.map((diagnostic) => {
-        return {
-          from: diagnostic.offsets.start >= 0 ? diagnostic.offsets.start : 0,
-          to:
-            diagnostic.offsets.end >= 0 ? diagnostic.offsets.end : query.length,
-          severity:
-            diagnostic.severity === DiagnosticSeverity.Error
-              ? 'error'
-              : 'warning',
-          message: diagnostic.message,
-          ...(diagnostic.tags !== undefined &&
-          diagnostic.tags.includes(DiagnosticTag.Deprecated)
-            ? { markClass: 'cm-deprecated-element' }
-            : {}),
-        };
-      });
-      if (!config.schema?.databaseNames?.length) {
-        return a.filter(isNotParamError);
+        if (result.symbolTables) {
+          config.languageService.setSymbolsInfo({
+            query,
+            symbolTables: result.symbolTables,
+          });
+        }
+
+        const a: Diagnostic[] = result.diagnostics.map((diagnostic) => {
+          return {
+            from: diagnostic.offsets.start >= 0 ? diagnostic.offsets.start : 0,
+            to:
+              diagnostic.offsets.end >= 0
+                ? diagnostic.offsets.end
+                : query.length,
+            severity:
+              diagnostic.severity === DiagnosticSeverity.Error
+                ? 'error'
+                : 'warning',
+            message: diagnostic.message,
+            ...(diagnostic.tags !== undefined &&
+            diagnostic.tags.includes(DiagnosticTag.Deprecated)
+              ? { markClass: 'cm-deprecated-element' }
+              : {}),
+          };
+        });
+        if (!config.schema?.databaseNames?.length) {
+          return a.filter(isNotParamError);
+        }
+        return a;
+      } catch (err) {
+        if (!String(err).includes('Worker terminated')) {
+          console.error(String(err) + ' ' + query);
+        }
       }
-      return a;
-    } catch (err) {
-      if (!String(err).includes('Worker terminated')) {
-        console.error(String(err) + ' ' + query);
-      }
-    }
-    return [];
-  });
+      return [];
+    },
+    {
+      needsRefresh: (update) =>
+        update.transactions.some((tr) =>
+          tr.effects.some((effect) => effect.is(schemaUpdated)),
+        ),
+    },
+  );
 
 export const cleanupWorkers = () => {
   void pool.terminate();


### PR DESCRIPTION
Adds a "needsRefresh" check to react-codemirror linter, that gets triggered when schema is updated. (Checks by object equality, not deep equality)

Has a corresponding PR [in upx](https://github.com/neo4j/upx/pull/12023) that will update codemirror to use this change, and prevent the passing of a new schema object when the old schema is identical to the new

Closes LS-203