### PR TITLE
Add ref to GraphAcademy links to see usage

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -562,67 +562,67 @@
           {
             "id": "neo4jFundamentals",
             "title": "Neo4j Fundamentals",
-            "description": "Learn about graph databases and get started with Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/)",
+            "description": "Learn about graph databases and get started with Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/neo4j-fundamentals.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/courses/neo4j-fundamentals/"
+              "onLink:https://graphacademy.neo4j.com/courses/neo4j-fundamentals/?ref=vscode-learn"
             ]
           },
           {
             "id": "cypherFundamentals",
             "title": "Cypher Fundamentals",
-            "description": "Learn Cypher, the query language for Neo4j, in about an hour.\n[Start course](https://graphacademy.neo4j.com/courses/cypher-fundamentals/)",
+            "description": "Learn Cypher, the query language for Neo4j, in about an hour.\n[Start course](https://graphacademy.neo4j.com/courses/cypher-fundamentals/?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/cypher-fundamentals.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/courses/cypher-fundamentals/"
+              "onLink:https://graphacademy.neo4j.com/courses/cypher-fundamentals/?ref=vscode-learn"
             ]
           },
           {
             "id": "modelingFundamentals",
             "title": "Graph Data Modeling Fundamentals",
-            "description": "Learn how to design a Neo4j graph using best practices.\n[Start course](https://graphacademy.neo4j.com/courses/modeling-fundamentals/)",
+            "description": "Learn how to design a Neo4j graph using best practices.\n[Start course](https://graphacademy.neo4j.com/courses/modeling-fundamentals/?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/modeling-fundamentals.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/courses/modeling-fundamentals/"
+              "onLink:https://graphacademy.neo4j.com/courses/modeling-fundamentals/?ref=vscode-learn"
             ]
           },
           {
             "id": "importingFundamentals",
             "title": "Importing Data Fundamentals",
-            "description": "Learn how to import data into Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/importing-fundamentals/)",
+            "description": "Learn how to import data into Neo4j.\n[Start course](https://graphacademy.neo4j.com/courses/importing-fundamentals/?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/importing-fundamentals.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/courses/importing-fundamentals/"
+              "onLink:https://graphacademy.neo4j.com/courses/importing-fundamentals/?ref=vscode-learn"
             ]
           },
           {
             "id": "generativeAiPathway",
             "title": "Generative AI & GraphRAG",
-            "description": "Ready for more? Combine Neo4j with LLMs to build GraphRAG applications.\n[Explore pathway](https://graphacademy.neo4j.com/categories/generative-ai)",
+            "description": "Ready for more? Combine Neo4j with LLMs to build GraphRAG applications.\n[Explore pathway](https://graphacademy.neo4j.com/categories/generative-ai?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/generative-ai.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/categories/generative-ai"
+              "onLink:https://graphacademy.neo4j.com/categories/generative-ai?ref=vscode-learn"
             ]
           },
           {
             "id": "appDevelopmentPathway",
             "title": "Graph Application Development",
-            "description": "Build applications powered by Neo4j using the official drivers.\n[Explore pathway](https://graphacademy.neo4j.com/categories/app-development)",
+            "description": "Build applications powered by Neo4j using the official drivers.\n[Explore pathway](https://graphacademy.neo4j.com/categories/app-development?ref=vscode-learn)",
             "media": {
               "markdown": "resources/walkthroughs/app-development.md"
             },
             "completionEvents": [
-              "onLink:https://graphacademy.neo4j.com/categories/app-development"
+              "onLink:https://graphacademy.neo4j.com/categories/app-development?ref=vscode-learn"
             ]
           }
         ]

--- a/packages/vscode-extension/resources/walkthroughs/app-development.md
+++ b/packages/vscode-extension/resources/walkthroughs/app-development.md
@@ -8,4 +8,4 @@ This GraphAcademy pathway covers:
 - Building full-stack applications backed by a graph
 - Best practices for production Neo4j applications
 
-[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/app-development)
+[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/app-development?ref=vscode-learn)

--- a/packages/vscode-extension/resources/walkthroughs/cypher-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/cypher-fundamentals.md
@@ -12,4 +12,4 @@ Everything you learn here you can try out directly in your `.cypher` files with 
 
 ⏱️ 1 hour · Free
 
-[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/cypher-fundamentals/)
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/cypher-fundamentals/?ref=vscode-learn)

--- a/packages/vscode-extension/resources/walkthroughs/generative-ai.md
+++ b/packages/vscode-extension/resources/walkthroughs/generative-ai.md
@@ -9,4 +9,4 @@ This GraphAcademy pathway covers:
 - Building GraphRAG pipelines
 - Using Neo4j with popular GenAI frameworks
 
-[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/generative-ai)
+[Explore the pathway on GraphAcademy →](https://graphacademy.neo4j.com/categories/generative-ai?ref=vscode-learn)

--- a/packages/vscode-extension/resources/walkthroughs/importing-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/importing-fundamentals.md
@@ -10,4 +10,4 @@ In this free, hands-on GraphAcademy course you will:
 
 ⏱️ 1 hour · Free
 
-[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/importing-fundamentals/)
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/importing-fundamentals/?ref=vscode-learn)

--- a/packages/vscode-extension/resources/walkthroughs/modeling-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/modeling-fundamentals.md
@@ -10,4 +10,4 @@ In this free, hands-on GraphAcademy course you will:
 
 ⏱️ 2 hours · Free
 
-[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/modeling-fundamentals/)
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/modeling-fundamentals/?ref=vscode-learn)

--- a/packages/vscode-extension/resources/walkthroughs/neo4j-fundamentals.md
+++ b/packages/vscode-extension/resources/walkthroughs/neo4j-fundamentals.md
@@ -10,4 +10,4 @@ In this free, hands-on GraphAcademy course you will:
 
 ⏱️ 1 hour · Free
 
-[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/)
+[Start the course on GraphAcademy →](https://graphacademy.neo4j.com/courses/neo4j-fundamentals/?ref=vscode-learn)


### PR DESCRIPTION
# Add `ref` attribution parameter to GraphAcademy links

Adds `?ref=vscode-learn` to all GraphAcademy hyperlinks so traffic from the VS
Code extension can be attributed in GraphAcademy analytics.

## Changes

Appended `?ref=vscode-learn` to every `graphacademy.neo4j.com` course and pathway
link in the "Learn Neo4j" walkthrough:

- The 6 walkthrough media files (`resources/walkthroughs/*.md`)
- The matching step `description` links in `package.json`
- The corresponding `onLink:` completion events in `package.json` (kept in sync
  so step completion still fires)

## Testing

- Verified `package.json` is valid JSON and every `onLink` event still matches
  its step's href.