### PR TITLE
normalize CRLF line endings

### DIFF
--- a/.changeset/rare-clubs-work.md
+++ b/.changeset/rare-clubs-work.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/react-codemirror': minor
+---
+
+normalize CRLF line endings

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -46,6 +46,19 @@ import { LintWorker } from '@neo4j-cypher/lint-worker';
 import workerpool from 'workerpool';
 
 type DomEventHandlers = Parameters<typeof EditorView.domEventHandlers>[0];
+
+/**
+ * Normalize CRLF line endings to LF, which is what CodeMirror expects.
+ * CodeMirror collapses `\r\n` into a single line break, so a raw `value`
+ * string with CRLF endings is longer than the resulting document. Normalizing
+ * up front keeps the document length in sync with the value length used for
+ * cursor placement, and avoids "Selection points outside of document" errors.
+ * https://codemirror.net/docs/ref/#state.EditorState^lineSeparator
+ */
+function normalizeLineEndings<T extends string | undefined>(value: T): T {
+  return value?.replace(/\r\n/g, '\n') as T;
+}
+
 export interface CypherEditorProps {
   /**
    * The prompt to show on single line editors
@@ -438,8 +451,17 @@ export class CypherEditor extends Component<
    * For example, to move the cursor to the end of the editor, use `value.length`
    */
   updateCursorPosition(position: number) {
-    this.editorView.current?.dispatch({
-      selection: { anchor: position, head: position },
+    const view = this.editorView.current;
+    if (!view) {
+      return;
+    }
+
+    // Clamp to the doc length; `position` may come from a raw value longer than
+    // the doc (e.g. CRLF endings), which would throw "Selection points outside
+    // of document".
+    const clamped = Math.max(0, Math.min(position, view.state.doc.length));
+    view.dispatch({
+      selection: { anchor: clamped, head: clamped },
     });
   }
 
@@ -448,10 +470,7 @@ export class CypherEditor extends Component<
    */
   setValueAndFocus(value = '') {
     const currentCmValue = this.editorView.current.state?.doc.toString() ?? '';
-    // Normalize line endings to LF that CM expects.
-    // Prevents issues with inserted values that contain CRLF line endings.
-    // https://codemirror.net/docs/ref/?utm_source=chatgpt.com#state.EditorState^lineSeparator
-    const normalizedValue = value.replace(/\r\n/g, '\n');
+    const normalizedValue = normalizeLineEndings(value);
     this.editorView.current.dispatch({
       changes: {
         from: 0,
@@ -603,7 +622,7 @@ export class CypherEditor extends Component<
         ),
         this.editorActionsController.extension,
       ],
-      doc: this.props.value,
+      doc: normalizeLineEndings(this.props.value),
     });
 
     this.editorView.current = new EditorView({
@@ -701,7 +720,7 @@ export class CypherEditor extends Component<
         changes: {
           from: 0,
           to: currentCmValue.length,
-          insert: this.props.value ?? '',
+          insert: normalizeLineEndings(this.props.value) ?? '',
         },
         annotations: [ExternalEdit.of(true)],
       });

--- a/packages/react-codemirror/src/CypherEditor.tsx
+++ b/packages/react-codemirror/src/CypherEditor.tsx
@@ -55,8 +55,8 @@ type DomEventHandlers = Parameters<typeof EditorView.domEventHandlers>[0];
  * cursor placement, and avoids "Selection points outside of document" errors.
  * https://codemirror.net/docs/ref/#state.EditorState^lineSeparator
  */
-function normalizeLineEndings<T extends string | undefined>(value: T): T {
-  return value?.replace(/\r\n/g, '\n') as T;
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, '\n');
 }
 
 export interface CypherEditorProps {
@@ -622,7 +622,7 @@ export class CypherEditor extends Component<
         ),
         this.editorActionsController.extension,
       ],
-      doc: normalizeLineEndings(this.props.value),
+      doc: normalizeLineEndings(this.props.value ?? ''),
     });
 
     this.editorView.current = new EditorView({
@@ -720,7 +720,7 @@ export class CypherEditor extends Component<
         changes: {
           from: 0,
           to: currentCmValue.length,
-          insert: normalizeLineEndings(this.props.value) ?? '',
+          insert: normalizeLineEndings(this.props.value ?? ''),
         },
         annotations: [ExternalEdit.of(true)],
       });

--- a/packages/react-codemirror/src/e2e_tests/sanityChecks.spec.tsx
+++ b/packages/react-codemirror/src/e2e_tests/sanityChecks.spec.tsx
@@ -42,6 +42,29 @@ test('the editor can report changes to the text ', async ({ mount, page }) => {
   }).toPass({ intervals: [300, 300, 1000] });
 });
 
+test('can mount an autofocused editor with CRLF line endings without crashing', async ({
+  mount,
+}) => {
+  const value = 'MATCH (n)\r\nRETURN n;';
+
+  const component = await mount(<CypherEditor value={value} autofocus />);
+
+  await expect(component).toContainText('MATCH (n)');
+  await expect(component).toContainText('RETURN n;');
+});
+
+test('can externally update to a value with CRLF line endings without crashing', async ({
+  mount,
+}) => {
+  const component = await mount(<CypherEditor value="MATCH (n)" autofocus />);
+
+  await component.update(
+    <CypherEditor value={'MATCH (n)\r\nRETURN n;'} autofocus />,
+  );
+
+  await expect(component).toContainText('RETURN n;');
+});
+
 test('can complete RETURN', async ({ page, mount }) => {
   await mount(<CypherEditor />);
   const textField = page.getByRole('textbox');


### PR DESCRIPTION
### Description

Codemirror expects LF line endings and collapses `\r\n` into a single break, so a value containing CRLF is longer than the resulting document. When the editor was auto-focused, we set the cursor to `value.length`, which points past the end of the  normalised doc(shorter) and threw selection points outside of document.

This PR is to:
- Clamp the cursor position to the doc length
- Apply `normalizeLineEndings` consistently and not just on `setValueAndFocus`

**Similar to:** https://github.com/neo4j/cypher-language-support/pull/539