### PR TITLE
wrap placeholder around editor actions

### DIFF
--- a/.changeset/calm-ads-cut.md
+++ b/.changeset/calm-ads-cut.md
@@ -1,0 +1,6 @@
+---
+'@neo4j-cypher/react-codemirror': minor
+'@neo4j-cypher/react-codemirror-playground': patch
+---
+
+wrap placeholder around editor actions

--- a/packages/react-codemirror-playground/src/App.tsx
+++ b/packages/react-codemirror-playground/src/App.tsx
@@ -251,6 +251,7 @@ export function App() {
               value={value}
               ref={editorRef}
               onChange={setValue}
+              placeholder="Type your Cypher query here"
               prompt="neo4j$"
               onExecute={() => {
                 setCommandRanCount((c) => c + 1);

--- a/packages/react-codemirror/src/editorActions.ts
+++ b/packages/react-codemirror/src/editorActions.ts
@@ -82,7 +82,7 @@ export function createEditorActionsController(): EditorActionsController {
   const spacer = EditorView.decorations.compute(
     ['doc', activeField],
     (state) => {
-      if (!state.field(activeField) || state.doc.length === 0) {
+      if (!state.field(activeField)) {
         return Decoration.none;
       }
       return Decoration.set([
@@ -229,6 +229,9 @@ export function createEditorActionsController(): EditorActionsController {
       userSelect: 'none',
       WebkitUserSelect: 'none',
       pointerEvents: 'none',
+    },
+    '.cm-placeholder': {
+      display: 'inline',
     },
     '.cm-editor-actions': {
       position: 'absolute',


### PR DESCRIPTION
### Description

This PR is to wrap the placeholder around the editor actions to prevent it displayed behind the actions.

**A look from my local:**
<img width="486" height="101" alt="Screenshot 2026-07-29 at 15 08 41" src="https://github.com/user-attachments/assets/cb4e47c1-06ea-452b-be25-6c318d1c7898" />

**Related issue:** https://linear.app/neo4j/issue/BROW-420

**Related previous PR:** https://github.com/neo4j/cypher-language-support/pull/697