### PR TITLE
Pin actions to full-length commit SHA

### DIFF
--- a/.github/actions/codemirror-e2e-tests/action.yaml
+++ b/.github/actions/codemirror-e2e-tests/action.yaml
@@ -35,7 +35,7 @@ runs:
       run: pnpm --filter react-codemirror test:e2e --project="$BROWSER"
 
     - name: Upload Playwright Report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: playwright-report-${{ inputs.browser }}

--- a/.github/actions/setup-and-build/action.yaml
+++ b/.github/actions/setup-and-build/action.yaml
@@ -4,10 +4,10 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         # Pinned below 24.16.0: that release hangs `playwright install` (browser
         # archive extraction stalls) and breaks the wdio-vscode webview tests.
@@ -22,7 +22,7 @@ runs:
 
     - name: Check for cached build
       id: restore-cache
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           # Build artifacts only (not node_modules), based on .gitignore
@@ -50,7 +50,7 @@ runs:
 
     - name: Cache build output
       if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         # Same paths as above
         path: |


### PR DESCRIPTION
Closes LS-208

### Description
All of our GitHub actions should now be pinned to a full-length commit SHA so we can turn on the repository option that enforcing this. Also bumped the versions of all newly pinned actions.