### PR TITLE
Brow 380 editor action layout

### DIFF
--- a/.changeset/nervous-poems-argue.md
+++ b/.changeset/nervous-poems-argue.md
@@ -1,0 +1,5 @@
+---
+'@neo4j-cypher/react-codemirror': patch
+---
+
+Keep the editor action in the editor's top-right corner when an inline panel or the deleted lines of a diff render above the first line

--- a/packages/react-codemirror/src/editorActions.ts
+++ b/packages/react-codemirror/src/editorActions.ts
@@ -40,6 +40,12 @@ export type EditorActionsController = {
  *    `absolute` on the editor element (which does not scroll). It never moves
  *    when the document grows, when an inline panel opens above the first line,
  *    or when the content scrolls — content simply scrolls behind it.
+ *
+ * The overlay is measured against the scroller's visible box rather than
+ * against the spacer or the content: the spacer moves down the document
+ * whenever something renders above the first line (an inline panel, the
+ * deleted lines of a diff), and the content reaches past the right edge as
+ * soon as it overflows.
  */
 
 const SPACER_BOTTOM_GAP = 2;
@@ -143,6 +149,10 @@ export function createEditorActionsController(): EditorActionsController {
             '--cm-editor-actions-content-min-height',
             `${container.offsetHeight + SPACER_BOTTOM_GAP}px`,
           );
+          view.dom.style.setProperty(
+            '--cm-editor-actions-reserved-width',
+            `${container.offsetWidth + SPACER_LEFT_GAP}px`,
+          );
           this.align(view);
         });
         this.resizeObserver.observe(container);
@@ -159,22 +169,18 @@ export function createEditorActionsController(): EditorActionsController {
               return null;
             }
             const editorRect = view.dom.getBoundingClientRect();
-            const spacer = view.dom.querySelector('.cm-editor-actions-spacer');
-            let topClient: number;
-            let rightClient: number;
-            if (spacer) {
-              const rect = spacer.getBoundingClientRect();
-              topClient = rect.top;
-              rightClient = rect.right;
-            } else {
-              const rect = view.contentDOM.getBoundingClientRect();
-              const style = window.getComputedStyle(view.contentDOM);
-              topClient = rect.top + (parseFloat(style.paddingTop) || 0);
-              rightClient = rect.right - (parseFloat(style.paddingRight) || 0);
-            }
+            const scrollerRect = view.scrollDOM.getBoundingClientRect();
+            const style = window.getComputedStyle(view.contentDOM);
+            const visibleRight = scrollerRect.left + view.scrollDOM.clientWidth;
             return {
-              top: topClient - editorRect.top + view.scrollDOM.scrollTop,
-              right: editorRect.right - rightClient - view.scrollDOM.scrollLeft,
+              top:
+                scrollerRect.top -
+                editorRect.top +
+                (parseFloat(style.paddingTop) || 0),
+              right:
+                editorRect.right -
+                visibleRight +
+                (parseFloat(style.paddingRight) || 0),
             };
           },
           write: (pos) => {
@@ -206,6 +212,7 @@ export function createEditorActionsController(): EditorActionsController {
           root.style.removeProperty('--cm-editor-actions-width');
           root.style.removeProperty('--cm-editor-actions-height');
           root.style.removeProperty('--cm-editor-actions-content-min-height');
+          root.style.removeProperty('--cm-editor-actions-reserved-width');
           root.style.removeProperty('--cm-editor-actions-top');
           root.style.removeProperty('--cm-editor-actions-right');
         }
@@ -229,6 +236,10 @@ export function createEditorActionsController(): EditorActionsController {
       userSelect: 'none',
       WebkitUserSelect: 'none',
       pointerEvents: 'none',
+    },
+    // The spacer only clears the first line, so a panel above it makes its own room.
+    '.cm-inline-panel': {
+      paddingRight: 'var(--cm-editor-actions-reserved-width, 0px)',
     },
     '.cm-placeholder': {
       display: 'inline',


### PR DESCRIPTION
The action buttons were positioned by measuring from the spacer widget inside the first line, so anything rendered above it , such as an inline panel or deleted lines, pushed them down the page, and horizontal overflow pushed them outside the editor's right edge. They're now measured against the scroller's visible box, so they stay in the corner. 
This issue was reported here:

https://github.com/neo4j/upx/pull/12530#issuecomment-5618029363